### PR TITLE
Allow defining packages manually

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ nixpkgs_git_repository(
     revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
 )
 
-RULES_HASKELL_SHA = "e1eba61f145b5203c748fc53e77e0862e2fc2554"
+RULES_HASKELL_SHA = "d5326fadfee5958fa24a7f922c651acf85edea20"
 http_archive(
     name = "io_tweag_rules_haskell",
     urls = ["https://github.com/tweag/rules_haskell/archive/"
@@ -34,9 +34,27 @@ nixpkgs_package(
 
 register_toolchains("@ghc//:ghc")
 
-load("//:hazel.bzl", "hazel_repositories")
+load("//:hazel.bzl", "hazel_repositories",
+     "hazel_custom_package_hackage",
+     "hazel_custom_package_github",
+)
+
+hazel_custom_package_hackage(
+  package_name = "zlib",
+  version = "0.6.2",
+)
+
+hazel_custom_package_github(
+  package_name = "text-metrics",
+  github_user = "mrkkrp",
+  github_repo = "text-metrics",
+  repo_sha = "5d10b6f6ec4ff4b014e5e512f82d23e7606cc260",
+)
+
 load("//:packages.bzl", "packages", "prebuilt_dependencies")
 
 hazel_repositories(
     packages=packages,
-    prebuilt_dependencies=prebuilt_dependencies)
+    prebuilt_dependencies=prebuilt_dependencies,
+    exclude_packages = ["zlib", "text-metrics"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ nixpkgs_git_repository(
     revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
 )
 
-RULES_HASKELL_SHA = "d5326fadfee5958fa24a7f922c651acf85edea20"
+RULES_HASKELL_SHA = "b55ca991a9e58108932ff6c8b86fd141897391c1"
 http_archive(
     name = "io_tweag_rules_haskell",
     urls = ["https://github.com/tweag/rules_haskell/archive/"

--- a/hazel.bzl
+++ b/hazel.bzl
@@ -47,8 +47,7 @@ _all_hazel_packages = repository_rule(
         "files": attr.label_list(mandatory=True),
     })
 
-
-def hazel_repositories(prebuilt_dependencies, packages):
+def hazel_repositories(prebuilt_dependencies, packages, exclude_packages=[]):
   """Generates external dependencies for a set of Haskell packages.
 
   This macro should be invoked in the WORKSPACE.  It generates a set of
@@ -70,28 +69,86 @@ def hazel_repositories(prebuilt_dependencies, packages):
     packages: A dict mapping strings to structs, where each struct has two fields:
       - version: A version string
       - sha256: A hex-encoded SHA of the Cabal distribution (*.tar.gz).
+    exclude_packages: names of packages to exclude.
   """
   hazel_base_repo_name = "hazel_base_repository"
+
+  pkgs = {n: packages[n] for n in packages if n not in exclude_packages}
+
   hazel_base_repository(
       name = hazel_base_repo_name,
       # TODO: don't hard-code this in
       ghc="@ghc//:bin/ghc",
       prebuilt_dependencies = prebuilt_dependencies,
-      packages = {n: packages[n].version for n in packages},
+      packages = {n: pkgs[n].version for n in pkgs},
   )
-  for p in packages:
+  for p in pkgs:
     _cabal_haskell_repository(
-        name = "haskell_" + p,
+        name = "haskell_" + p.replace("-", "_"),
         package_name = p,
-        package_version = packages[p].version,
-        sha256 = packages[p].sha256 if hasattr(packages[p], "sha256") else None,
+        package_version = pkgs[p].version,
+        sha256 = pkgs[p].sha256 if hasattr(pkgs[p], "sha256") else None,
         hazel_base_repo_name = hazel_base_repo_name,
     )
 
   _all_hazel_packages(
       name = "all_hazel_packages",
-      files = ["@haskell_{}//:files".format(p) for p in packages])
+      files = ["@haskell_{}//:files".format(p) for p in pkgs])
 
 def hazel_library(name):
   """Returns the label of the haskell_library rule for the given package."""
-  return "@haskell_{}//:{}".format(name,name)
+  return "@haskell_{}//:{}".format(name.replace("-", "_"), name)
+
+def hazel_custom_package_hackage(
+    package_name,
+    version,
+    sha256=None):
+  """Generate a repo for a Haskell package fetched from Hackage.
+
+  Args:
+    package_name: string, package name.
+    version: string, package version.
+    sha256: string, SHA256 hash of archive.
+  """
+  package_id = package_name + "-" + version
+  url = "https://hackage.haskell.org/package/{0}/{1}.tar.gz".format(
+    package_id,
+    package_id,
+  )
+  fixed_package_name = package_name.replace("-", "_")
+  native.new_http_archive(
+    name = "haskell_{0}".format(fixed_package_name),
+    build_file = "third_party/haskell/BUILD.{0}".format(fixed_package_name),
+    sha256 = sha256,
+    strip_prefix = package_id,
+    urls = [url],
+  )
+
+def hazel_custom_package_github(
+    package_name,
+    github_user,
+    github_repo,
+    repo_sha,
+    archive_sha256=None):
+  """Generate a repo for a Haskell package coming from a GitHub repo.
+
+  Args:
+    package_name: string, package name.
+    github_user: string, GitHub user.
+    github_repo: string, repo name under `github_user` account.
+    repo_sha: SHA1 of commit in the repo.
+    archive_sha256: hash of the actual archive to download.
+  """
+  url = "https://github.com/{0}/{1}/archive/{2}.tar.gz".format(
+    github_user,
+    github_repo,
+    repo_sha,
+  )
+  fixed_package_name = package_name.replace("-", "_")
+  native.new_http_archive(
+    name = "haskell_{0}".format(fixed_package_name),
+    build_file = "third_party/haskell/BUILD.{0}".format(fixed_package_name),
+    sha256 = archive_sha256,
+    strip_prefix = "{0}-{1}".format(github_repo, repo_sha),
+    urls = [url],
+  )

--- a/hazel.bzl
+++ b/hazel.bzl
@@ -47,6 +47,18 @@ _all_hazel_packages = repository_rule(
         "files": attr.label_list(mandatory=True),
     })
 
+def _fixup_package_name(package_name):
+  """Fixup package name by replacing dashes with underscores to get a valid
+  workspace name from it.
+
+  Args:
+    package_name: string: Package name.
+
+  Returns:
+    string: fixed package name.
+  """
+  return package_name.replace("-", "_")
+
 def hazel_repositories(prebuilt_dependencies, packages, exclude_packages=[]):
   """Generates external dependencies for a set of Haskell packages.
 
@@ -84,7 +96,7 @@ def hazel_repositories(prebuilt_dependencies, packages, exclude_packages=[]):
   )
   for p in pkgs:
     _cabal_haskell_repository(
-        name = "haskell_" + p.replace("-", "_"),
+        name = "haskell_" + _fixup_package_name(p),
         package_name = p,
         package_version = pkgs[p].version,
         sha256 = pkgs[p].sha256 if hasattr(pkgs[p], "sha256") else None,
@@ -97,7 +109,7 @@ def hazel_repositories(prebuilt_dependencies, packages, exclude_packages=[]):
 
 def hazel_library(name):
   """Returns the label of the haskell_library rule for the given package."""
-  return "@haskell_{}//:{}".format(name.replace("-", "_"), name)
+  return "@haskell_{}//:{}".format(_fixup_package_name(name), name)
 
 def hazel_custom_package_hackage(
     package_name,
@@ -115,7 +127,7 @@ def hazel_custom_package_hackage(
     package_id,
     package_id,
   )
-  fixed_package_name = package_name.replace("-", "_")
+  fixed_package_name = _fixup_package_name(package_name)
   native.new_http_archive(
     name = "haskell_{0}".format(fixed_package_name),
     build_file = "third_party/haskell/BUILD.{0}".format(fixed_package_name),
@@ -144,7 +156,7 @@ def hazel_custom_package_github(
     github_repo,
     repo_sha,
   )
-  fixed_package_name = package_name.replace("-", "_")
+  fixed_package_name = _fixup_package_name(package_name)
   native.new_http_archive(
     name = "haskell_{0}".format(fixed_package_name),
     build_file = "third_party/haskell/BUILD.{0}".format(fixed_package_name),

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -4,3 +4,4 @@ lens
 network
 zlib
 text_metrics
+fuzzyset

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -1,4 +1,6 @@
 aeson
-language-c
+language_c
 lens
 network
+zlib
+text_metrics

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -139,7 +139,6 @@ def _get_build_attrs(name, build_info, desc, generated_srcs_dir, extra_modules,
           out = boot_module_map[m],
       )
 
-
   # Collect the source files for each module in this Cabal component.
   # srcs is a mapping from "select()" conditions (e.g. //third_party/haskell/ghc:ghc-8.0.2) to a list of source files.
   # Turn "boot_srcs" and others to dicts if there is a use case.
@@ -195,7 +194,7 @@ def _get_build_attrs(name, build_info, desc, generated_srcs_dir, extra_modules,
         # Allow executables to depend on the library in the same package.
         deps[condition] += [":" + p.name + "-lib"]
       else:
-        deps[condition] += ["@haskell_{}//:{}".format(p.name, p.name)]
+        deps[condition] += ["@haskell_{}//:{}".format(p.name.replace("-", "_"), p.name)]
 
   ghcopts += ["-optP" + o for o in build_info.cppOptions]
 

--- a/third_party/haskell/BUILD.text_metrics
+++ b/third_party/haskell/BUILD.text_metrics
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+haskell_library(
+  name = "text-metrics",
+  srcs = ["Data/Text/Metrics.hs"],
+  deps = [
+    "@haskell_text//:text",
+    "@haskell_vector//:vector",
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "containers",
+  ],
+)

--- a/third_party/haskell/BUILD.zlib
+++ b/third_party/haskell/BUILD.zlib
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+  "haskell_cc_import",
+)
+
+cc_library(
+  name = "cbits",
+  hdrs = glob(["cbits/*.h"]),
+  srcs = glob(["cbits/*.c"]),
+  strip_include_prefix = "cbits",
+)
+
+haskell_library(
+  name = "zlib",
+  srcs = glob([
+    "Codec/Compression/*.hs",
+    "Codec/Compression/Zlib/*.hs",
+    "Codec/Compression/Zlib/*.hsc",
+  ]),
+  deps = [":cbits"],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "ghc-prim",
+  ],
+)


### PR DESCRIPTION
I wanted to include some auto-generated package that depends on a manually defined package and so I thought `fuzzyset` could be a good candidate but it fails due to that lens thing:

```
bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Failed to load interface for `Control.Lens.Type'
      no unit id matching `lens-4.15.4' was found
      (This unit ID looks like the source package ID;
       the real unit ID is `externalZShaskellZUlensZSlens-4.15.4')
    * In the type signature:
        _useLevenshtein :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet Bool
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Can't find interface-file declaration for type constructor or class lens-4.15.4:Control.Lens.Type.Lens'
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    * In the type signature:
        _matchDict :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet MatchDict
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Can't find interface-file declaration for type constructor or class lens-4.15.4:Control.Lens.Type.Lens'
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    * In the type signature:
        _items :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet ItemMap
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Can't find interface-file declaration for type constructor or class lens-4.15.4:Control.Lens.Type.Lens'
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    * In the type signature:
        _gramSizeUpper :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet Size
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Can't find interface-file declaration for type constructor or class lens-4.15.4:Control.Lens.Type.Lens'
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    * In the type signature:
        _gramSizeLower :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet Size
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...

bazel-out/k8-fastbuild/bin/external/haskell_fuzzyset/gen-srcs-fuzzyset/Data/FuzzySet/Lens.hs:17:1: error:
    * Can't find interface-file declaration for type constructor or class lens-4.15.4:Control.Lens.Type.Lens'
        Probable cause: bug in .hi-boot file, or inconsistent .hi file
        Use -ddump-if-trace to get an idea of which file caused the error
    * In the type signature:
        _exactSet :: lens-4.15.4:Control.Lens.Type.Lens' FuzzySet ExactSet
   |
17 | makeLensesFor
   | ^^^^^^^^^^^^^...
```