### PR TITLE
Fix Hazel build of `entropy`.

### DIFF
--- a/test-packages.txt
+++ b/test-packages.txt
@@ -1,8 +1,9 @@
 aeson
+entropy
+fuzzyset
+htaglib
 language_c
 lens
 network
-zlib
 text_metrics
-fuzzyset
-htaglib
+zlib

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -207,7 +207,7 @@ def _get_build_attrs(name, build_info, desc, generated_srcs_dir, extra_modules,
       [paths.join(d, f) for d in build_info.includeDirs
        for f in build_info.installIncludes])
   headers = depset(
-      native.glob(desc.extraSrcFiles)
+      native.glob([paths.normalize(f) for f in desc.extraSrcFiles])
       + install_includes)
   ghcopts += ["-I" + native.package_name() + "/" + d for d in build_info.includeDirs]
   lib_name = name + "-cbits"


### PR DESCRIPTION
That package has extra-src-files with `.` in their path, which Bazel
doesn't allow:
```
extra-source-files:   ./cbits/rdrand.c, ./cbits/rdrand.h, README.md
```