### PR TITLE
Get `unix-compat` building.

### DIFF
--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -33,6 +33,13 @@ cc_library(
   strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
 )
 
+# TODO: detect this more automatically.
+cc_library(
+  name = "unix-includes",
+  hdrs = glob(["lib/ghc-*/unix-*/include/*.h"]),
+  strip_include_prefix = glob(["lib/ghc-*/unix-*/include"], exclude_directories=0)[0],
+)
+
 haskell_toolchain(
     name = "ghc",
     version = "8.2.2",

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -7,4 +7,5 @@ language_c
 lens
 network
 text_metrics
+unix-compat
 zlib

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -7,5 +7,5 @@ language_c
 lens
 network
 text_metrics
-unix-compat
+unix_compat
 zlib


### PR DESCRIPTION
The package expects to be able to import a header from the `unix` package's
`install-includes`, which are part of the GHC distribution.

Error:
```
ERROR:
/private/var/tmp/_bazel_judah.jacobson/0dd0c61b72eb0880ee09f3b1c25cfb68/external/haskell_unix_compat/BUILD:14:1:
C++ compilation of rule '@haskell_unix_compat//:unix-compat-cbits' failed
(Exit 1)
In file included from external/haskell_unix_compat/cbits/HsUnixCompat.c:1:
external/haskell_unix_compat/include/HsUnixCompat.h:1:10: fatal error:
'HsUnixConfig.h' file not found
         ^~~~~~~~~~~~~~~~
```

This solution is a little hacky because it hard-codes the logic
specifically for `unix` in `BUILD.ghc` and `cabal_package.bzl`.  It should
be possible to add more install-includes in the future, though at first glance
I couldn't find any other packages that would need it.

Honestly, long-term we should probably replace `BUILD.ghc` with a more
principled repository rule.  But hopefully this change will give us some more
mileage out of the current approach.