### PR TITLE
Fix an executable depending on the package's library.

### DIFF
--- a/test-packages.txt
+++ b/test-packages.txt
@@ -6,6 +6,7 @@ http_client
 language_c
 lens
 network
+pretty_show
 text_metrics
 unix_compat
 zlib

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -203,9 +203,6 @@ def _get_build_attrs(name, build_info, desc, generated_srcs_dir, extra_modules,
         if p in _PREBUILT_INCLUDES:
           cdeps += [_PREBUILT_INCLUDES[p]]
           deps[condition] += [_PREBUILT_INCLUDES[p]]
-      elif p == desc.package.pkgName:
-        # Allow executables to depend on the library in the same package.
-        deps[condition] += [":" + p + "-lib"]
       else:
         deps[condition] += ["@haskell_{}//:{}".format(p.replace("-", "_"), p)]
 


### PR DESCRIPTION
The current logic was broken in a previous refactor that removed
the trailing `"-lib"`.  Add `pretty-show` to the CI tests.

It turns out that we can just remove the special case altogether,
since it's fine to refer to a target in the same BUILD file by its
absolute path.