### PR TITLE
Fix the old-time and unix-time packages.

### DIFF
--- a/hazel_base_repository/hazel_base_repository.bzl
+++ b/hazel_base_repository/hazel_base_repository.bzl
@@ -75,5 +75,5 @@ hazel_symlink(
   src = "package.bzl",
   out = "package-bzl",
 )
-cabal_haskell_package(package, prebuilt_dependencies, extra_libs)
-""")
+cabal_haskell_package(package, prebuilt_dependencies, "{}", extra_libs)
+""".format(ghc_version))

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -10,4 +10,5 @@ network
 pretty_show
 text_metrics
 unix_compat
+unix_time
 zlib

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,3 +9,13 @@ haskell_test(
     prebuilt_dependencies = ["base"],
 )
 
+haskell_test(
+    name = "old-time-test",
+    srcs = ["old-time-test.hs"],
+    main_file = "old-time-test.hs",
+    deps = [
+        hazel_library("old-time"),
+    ],
+    prebuilt_dependencies = ["base"],
+)
+

--- a/test/old-time-test.hs
+++ b/test/old-time-test.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+main :: IO ()
+main = return ()
+
+-- Force the dynamic linker to load all symbols from its dependencies
+{-# ANN main () #-}


### PR DESCRIPTION
- unix-time declares one of the `./configure` script's outputs in `extra-tmp-files`
- old-time's C library expects `__GLASGOW_HASKELL__` to be set.