### PR TITLE
Make compilation of cabal2bazel more hermetic.

### DIFF
--- a/hazel_base_repository/hazel_base_repository.bzl
+++ b/hazel_base_repository/hazel_base_repository.bzl
@@ -12,8 +12,17 @@ def _hazel_base_repository_impl(ctx):
     l = Label(f)
     ctx.symlink(Label(f), l.name)
 
-  res = ctx.execute(["./ghc", "-Wall", "-Werror", "--make", "-o", "cabal2bazel"]
-                    + [Label(f).name for f in cabal2bazel_srcs])
+  res = ctx.execute([
+            "./ghc",
+            "-Wall",
+            "-Werror",
+            # Only use core packages of GHC, nothing from the the user level:
+            "-clear-package-db",
+            "-global-package-db",
+            "--make",
+            "-o",
+            "cabal2bazel"]
+            + [Label(f).name for f in cabal2bazel_srcs])
   if res.return_code != 0:
     fail("Couldn't build cabal2bazel:\n{}\n{}".format(res.stdout,res.stderr))
 


### PR DESCRIPTION
By default, GHC loads the user database at `~/.ghc/.../package.conf.d`.
This makes the build less hermetic.  For example, my laptop has `Cabal-2.2`
installed in the user DB, even though we're using a GHC with an older version
of Cabal, and this broke the build because cabal2build doesn't
work yet with that version.

I'll make another PR to get cabal2bazel building with newer
versions of Cabal.