### PR TITLE
Test support for extra source files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ nixpkgs_git_repository(
     revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
 )
 
-RULES_HASKELL_SHA = "a7ed28171ff9e4dfad23c4669eead8c170bc8e0c"
+RULES_HASKELL_SHA = "7dba3375a7b6f595f92defa8807cd292c608036c"
 http_archive(
     name = "io_tweag_rules_haskell",
     urls = ["https://github.com/tweag/rules_haskell/archive/"
@@ -145,12 +145,33 @@ hazel_custom_package_github(
   repo_sha = "34db9267bb4f9dbdee45623944900062e7995d09",
 )
 
+hazel_custom_package_github(
+  package_name = "vault",
+  github_user = "mrkkrp",
+  github_repo = "vault",
+  repo_sha = "753325a36e56e2f714c1f91eb953abbf2303ab79",
+)
+
+hazel_custom_package_github(
+  package_name = "wai-app-static",
+  github_user = "mrkkrp",
+  github_repo = "wai",
+  strip_prefix = "wai-app-static",
+  repo_sha = "c59ed7521d144a02a254ca6e230c46973ef9764f",
+)
+
 load("//:packages.bzl", "packages", "prebuilt_dependencies")
 
 hazel_repositories(
     packages=packages,
     prebuilt_dependencies=prebuilt_dependencies,
-    exclude_packages = ["zlib", "text-metrics", "conduit"],
+    exclude_packages = [
+      "conduit",
+      "text-metrics",
+      "vault",
+      "wai-app-static",
+      "zlib",
+    ],
     extra_libs = {
       "tag_c": "@taglib//:lib",
       "pq": "@postgresql//:lib",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -130,6 +130,11 @@ hazel_custom_package_hackage(
   version = "0.6.2",
 )
 
+hazel_custom_package_hackage(
+  package_name = "vault",
+  version = "0.3.1.1",
+)
+
 hazel_custom_package_github(
   package_name = "text-metrics",
   github_user = "mrkkrp",
@@ -143,13 +148,6 @@ hazel_custom_package_github(
   github_repo = "conduit",
   strip_prefix = "conduit",
   repo_sha = "34db9267bb4f9dbdee45623944900062e7995d09",
-)
-
-hazel_custom_package_github(
-  package_name = "vault",
-  github_user = "mrkkrp",
-  github_repo = "vault",
-  repo_sha = "753325a36e56e2f714c1f91eb953abbf2303ab79",
 )
 
 hazel_custom_package_github(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -154,10 +154,10 @@ hazel_custom_package_github(
 
 hazel_custom_package_github(
   package_name = "wai-app-static",
-  github_user = "mrkkrp",
+  github_user = "FormationAI",
   github_repo = "wai",
   strip_prefix = "wai-app-static",
-  repo_sha = "c59ed7521d144a02a254ca6e230c46973ef9764f",
+  repo_sha = "aaa0dca56231c060372004cda46d719ec6cc3ec5",
 )
 
 load("//:packages.bzl", "packages", "prebuilt_dependencies")

--- a/test-packages.txt
+++ b/test-packages.txt
@@ -13,4 +13,5 @@ pretty_show
 text_metrics
 unix_compat
 unix_time
+wai_app_static
 zlib

--- a/third_party/haskell/BUILD.vault
+++ b/third_party/haskell/BUILD.vault
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
+load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
+
+haskell_library(
+  name = "vault",
+  srcs = [
+    "src/Data/Unique/Really.hs",
+    "src/Data/Vault/IO.h",
+    "src/Data/Vault/Lazy.hs",
+    "src/Data/Vault/ST/Lazy.hs",
+    "src/Data/Vault/ST/ST.h",
+    "src/Data/Vault/ST/Strict.hs",
+    "src/Data/Vault/ST/backends/GHC.h",
+    "src/Data/Vault/Strict.hs",
+  ],
+  src_strip_prefix = "src",
+  compiler_flags = [
+    "-XCPP",
+    "-Iexternal/haskell_vault/src/Data/Vault/ST/",
+    "-Iexternal/haskell_vault/src/Data/Vault/",
+    "-DUseGHC",
+  ],
+  deps = [
+    hazel_library("hashable"),
+    hazel_library("semigroups"),
+    hazel_library("unordered-containers"),
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "containers",
+  ],
+)

--- a/third_party/haskell/BUILD.wai_app_static
+++ b/third_party/haskell/BUILD.wai_app_static
@@ -1,0 +1,46 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
+load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
+
+haskell_library(
+  name = "wai-app-static",
+  srcs = glob([
+    "Network/Wai/Application/Static.hs",
+    "Util.hs",
+    "WaiAppStatic/**/*.hs",
+    "WaiAppStatic/*.hs",
+  ]),
+  extra_srcs = glob(["images/*.png"]),
+  compiler_flags = ["-XCPP"],
+  deps = [
+    hazel_library("blaze-html"),
+    hazel_library("blaze-markup"),
+    hazel_library("cryptonite"),
+    hazel_library("file-embed"),
+    hazel_library("http-date"),
+    hazel_library("http-types"),
+    hazel_library("memory"),
+    hazel_library("mime-types"),
+    hazel_library("old-locale"),
+    hazel_library("optparse-applicative"),
+    hazel_library("text"),
+    hazel_library("unix-compat"),
+    hazel_library("unordered-containers"),
+    hazel_library("wai"),
+    hazel_library("wai-extra"),
+    hazel_library("warp"),
+    hazel_library("zlib"),
+  ],
+  prebuilt_dependencies = [
+    "base",
+    "bytestring",
+    "containers",
+    "directory",
+    "filepath",
+    "template-haskell",
+    "time",
+    "transformers",
+  ],
+  version = "3.1.6.2",
+)


### PR DESCRIPTION
Originally the idea was to make Hazel automatically detect and pass right `extra-source-files` but existing code won't build that way anyway because corrections to file paths are necessary: they should be prefixed with package names (including `external/` when necessary). Also see tweag/rules_haskell#292.

The only solution is so far is to fork and fix source code. Let me know what you think.