### PR TITLE
Hide other-modules to avoid module conflicts

### DIFF
--- a/test-packages.txt
+++ b/test-packages.txt
@@ -1,4 +1,5 @@
 aeson
+aeson_extra
 conduit
 entropy
 fuzzyset

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -370,9 +370,12 @@ def cabal_haskell_package(
         )
         elibs_targets.append(":" + elib_target_name)
 
+      hidden_modules = [m for m in lib.libBuildInfo.otherModules if not m.startswith("Paths_")]
+
       haskell_library(
           name = name,
           srcs = select(srcs),
+          hidden_modules = hidden_modules,
           version = description.package.pkgVersion,
           deps = select(deps) + elibs_targets,
           visibility = ["//visibility:public"],


### PR DESCRIPTION
The PR demonstrates the issue with `aeson-extra` and then fixes it.