### PR TITLE
Use the doctest binary that Hazel itself builds.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_toolchain",
+  "haskell_doctest_toolchain",
 )
 
 exports_files([
@@ -8,9 +9,7 @@ exports_files([
     "paths-template.hs",
 ])
 
-haskell_toolchain(
-    name = "ghc",
-    c2hs = "@c2hs//:bin",
-    version = "8.2.2",
-    tools = "@ghc//:bin",
+haskell_doctest_toolchain(
+    name = "doctest",
+    doctest = "@haskell_doctest//:doctest_bin",
 )

--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -41,7 +41,6 @@ cc_library(
 haskell_toolchain(
     name = "ghc",
     c2hs = "@c2hs//:bin",
-    doctest = "@doctest//:bin",
     version = "8.2.2",
     tools = ":bin",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ nixpkgs_git_repository(
     revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
 )
 
-RULES_HASKELL_SHA = "7dba3375a7b6f595f92defa8807cd292c608036c"
+RULES_HASKELL_SHA = "1d3daac33f90b0e2fec8114fd4599782494471d0"
 http_archive(
     name = "io_tweag_rules_haskell",
     urls = ["https://github.com/tweag/rules_haskell/archive/"
@@ -36,12 +36,6 @@ nixpkgs_package(
   name = "c2hs",
   repository = "@nixpkgs",
   attribute_path = "haskell.packages.ghc822.c2hs",
-)
-
-nixpkgs_package(
-  name = "doctest",
-  repository = "@nixpkgs",
-  attribute_path = "haskell.packages.ghc822.doctest",
 )
 
 nixpkgs_package(
@@ -118,7 +112,10 @@ filegroup (
 """
 )
 
-register_toolchains("@ghc//:ghc")
+register_toolchains(
+    "@ghc//:ghc",
+    "//:doctest",
+)
 
 load("//:hazel.bzl", "hazel_repositories",
      "hazel_custom_package_hackage",
@@ -133,6 +130,11 @@ hazel_custom_package_hackage(
 hazel_custom_package_hackage(
   package_name = "vault",
   version = "0.3.1.1",
+)
+
+hazel_custom_package_hackage(
+  package_name = "ghc-paths",
+  version = "0.1.0.9",
 )
 
 hazel_custom_package_github(
@@ -165,6 +167,7 @@ hazel_repositories(
     prebuilt_dependencies=prebuilt_dependencies,
     exclude_packages = [
       "conduit",
+      "ghc-paths",
       "text-metrics",
       "vault",
       "wai-app-static",

--- a/ghc_paths.bzl
+++ b/ghc_paths.bzl
@@ -1,0 +1,31 @@
+def _ghc_paths_module_impl(ctx):
+  tools = ctx.toolchains["@io_tweag_rules_haskell//haskell:toolchain"].tools
+  ghc = tools.ghc
+  ctx.actions.run_shell(
+      inputs = [ghc],
+      outputs = [ctx.outputs.out],
+      command = """
+      cat > {out} << EOM
+module GHC.Paths (
+        ghc, ghc_pkg, libdir, docdir
+  ) where
+
+libdir, docdir, ghc, ghc_pkg :: FilePath
+
+libdir  = "$({ghc} --print-libdir)"
+docdir  = "DOCDIR_IS_NOT_SET"
+
+ghc     = "{ghc}"
+ghc_pkg = "{ghc_pkg}"
+EOM""".format(
+          ghc = ghc.path,
+          ghc_pkg = tools.ghc_pkg.path,
+          out = ctx.outputs.out.path))
+  return [DefaultInfo(runfiles=ctx.runfiles(collect_data=True))]
+
+ghc_paths_module = rule(
+    _ghc_paths_module_impl,
+    toolchains = ["@io_tweag_rules_haskell//haskell:toolchain"],
+    outputs = {"out": "GHC/Paths.hs"},
+)
+

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,4 +1,8 @@
-load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_test")
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+     "haskell_doctest",
+     "haskell_library",
+     "haskell_test",
+)
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 haskell_test(
@@ -19,3 +23,13 @@ haskell_test(
     prebuilt_dependencies = ["base"],
 )
 
+haskell_library(
+    name = "DoctestExample",
+    srcs = ["DoctestExample.hs"],
+    prebuilt_dependencies = ["base"],
+)
+
+haskell_doctest(
+    name = "doctest-test",
+    deps = [":DoctestExample"],
+)

--- a/test/DoctestExample.hs
+++ b/test/DoctestExample.hs
@@ -1,0 +1,8 @@
+module DoctestExample where
+
+-- |
+-- >>> hello
+-- "hello, world!"
+
+hello :: String
+hello = "hello, world!"

--- a/third_party/haskell/BUILD.ghc_paths
+++ b/third_party/haskell/BUILD.ghc_paths
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl",
+  "haskell_library",
+)
+
+load("@ai_formation_hazel//:ghc_paths.bzl", "ghc_paths_module")
+
+ghc_paths_module(
+    name = "paths_module")
+
+haskell_library(
+    name = "ghc-paths",
+    srcs = [":paths_module"],
+    prebuilt_dependencies = ["base"],
+)


### PR DESCRIPTION
Also adds a rule for ghc-paths.  I left out the `docdir` parameter
since (a) I wasn't sure how to get it, and (b) it's only really useful for
`haddock`, but we already use the one distributed with GHC.