### PR TITLE
Updates WORKSPACE snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,33 +35,35 @@ as described in their
 [`README`](https://github.com/tweag/rules_nixpkgs/blob/master/README.md):
 
 ```
+RULES_NIXPKGS_SHA = "cd2ed701127ebf7f8f21d37feb1d678e4fdf85e5"
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-cd2ed701127ebf7f8f21d37feb1d678e4fdf85e5",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/cd2ed70.tar.gz"],
+    strip_prefix = "rules_nixpkgs-" + RULES_NIXPKGS_SHA,
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/" + RULES_NIXPKGS_SHA + ".tar.gz"],
 )
-RULES_HASKELL_SHA = "f6f75f4b551202bff0a90e026cb572c181fac0d8"
+
+RULES_HASKELL_SHA = "67f2f87691f93a8a674283a1e1ab2ce46daf0f99"
 http_archive(
     name = "io_tweag_rules_haskell",
-    urls = ["https://github.com/tweag/rules_haskell/archive/"
-            + RULES_HASKELL_SHA + ".tar.gz"],
+    urls = ["https://github.com/tweag/rules_haskell/archive/" + RULES_HASKELL_SHA + ".tar.gz"],
     strip_prefix = "rules_haskell-" + RULES_HASKELL_SHA,
 )
+
 # Replace with a more recent commit, as appropriate
-HAZEL_SHA=dca41ff6d9ce7a00e4af91ebe621f0c939e7e465
+HAZEL_SHA = "f2d6128811aae75f927d062348dc9686072fe9ce"
 http_archive(
     name = "ai_formation_hazel",
-    strip_prefix = "hazel-dca41ff6d9ce7a00e4af91ebe621f0c939e7e465",
-    urls = ["https://github.com/FormationAI/hazel/archive/{}.tar.gz".format(
-              HAZEL_COMMIT)],
+    strip_prefix = "hazel-" + HAZEL_SHA,
+    urls = ["https://github.com/FormationAI/hazel/archive/" + HAZEL_SHA + ".tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 
+NIXPKGS_REVISION_SHA = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca"
 nixpkgs_git_repository(
     name = "nixpkgs",
     # A revision of 17.09 that contains ghc-8.2.2:
-    revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
+    revision = NIXPKGS_REVISION_SHA,
 )
 
 nixpkgs_package(
@@ -70,6 +72,33 @@ nixpkgs_package(
     attribute_path = "haskell.packages.ghc822.ghc",
     # NOTE: this uses the ghc bindist template provided by Hazel
     build_file = "@ai_formation_hazel//:BUILD.ghc",
+)
+
+nixpkgs_package(
+    name = "c2hs",
+    repository = "@nixpkgs",
+    attribute_path = "haskell.packages.ghc822.c2hs",
+)
+
+nixpkgs_package(
+    name = "taglib",
+    repository = "@nixpkgs",
+    attribute_path = "taglib",
+    # Inline the definition of a nonexistent build file
+    build_file_content =
+"""
+package(default_visibility = ["//visibility:public"])
+
+load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_cc_import")
+
+filegroup (
+  name = "lib",
+  srcs = glob([
+    "lib/libtag_c.so",
+    "lib/libtag_c.dylib",
+  ]),
+)
+""",
 )
 
 load("@io_tweag_rules_haskell//haskell:repositories.bzl", "haskell_repositories")
@@ -86,7 +115,8 @@ load("//:packages.bzl", "prebuilt_dependencies", "packages")
 
 hazel_repositories(
     prebuilt_dependencies=prebuilt_dependencies,
-    packages=packages)
+    packages=packages
+)
 ```
 
 ## Using Hazel in build rules


### PR DESCRIPTION
I noticed a few problems in the WORKSPACE snippet that I had to correct to get this to build for me:

- Made all SHAs reference descriptive variables (this is a preference that made it easier to change things, I can revert it if you'd prefer)
- Updated SHAs
  - updated `rules_haskell` and `rules_nixpkgs` to latest
  - updated `hazel` to latest, as the referenced SHA doesn't support the `prebuilt_dependencies` arg as far as I can tell
- added `c2hs` and `taglib` `nixpkgs`
  - I wasn't able to get anything to build without these in my `WORKSPACE`, and they're referenced in this project's `WORKSPACE` so they seemed necessary

---

It might also be useful to note that `hazel` seems to introduce a load order dependency in `WORKSPACE` files. In my specific case, loading `rules_docker` and running `container_repositories()` _before_ `hazel`  produces the following error:

```
ERROR: /Users/jkachmar/src/bazel_test/WORKSPACE:94:1: Traceback (most recent call last):
	File "/Users/jkachmar/src/bazel_test/WORKSPACE", line 94
		haskell_repositories()
	File "/private/var/tmp/_bazel_jkachmar/ffe4cd5ef111b84b0d631e8d7acbc3a8/external/io_tweag_rules_haskell/haskell/repositories.bzl", line 7, in haskell_repositories
		native.http_archive(name = "bazel_skylib", strip_prefi...", ..."])
Cannot redefine repository after any load statement in the WORKSPACE file (for repository 'bazel_skylib')
```

I can open an issue for this separately if that would be better.