### PR TITLE
Gets hazel working with GHC 8.4.3 and LTS 12.1

### DIFF
--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -41,7 +41,7 @@ cc_library(
 haskell_toolchain(
     name = "ghc",
     c2hs = "@c2hs//:bin",
-    version = "8.2.2",
+    version = "8.4.3",
     tools = ":bin",
     locale_archive = select({
       # For some reason glibcLocales is not available on Darwin.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,25 +4,26 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl",
      "http_archive",
 )
 
+RULES_NIXPKGS_SHA = "896c2d96a70a408c545cc491974068c36f507009"
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    strip_prefix = "rules_nixpkgs-cd2ed701127ebf7f8f21d37feb1d678e4fdf85e5",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/cd2ed70.tar.gz"],
+    strip_prefix = "rules_nixpkgs-" + RULES_NIXPKGS_SHA,
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/" + RULES_NIXPKGS_SHA + ".tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "nixpkgs_package")
 
+NIXPKGS_REVISION = "56fad146a12a6f934d1d5ef875eb729be1b19129"
 nixpkgs_git_repository(
     name = "nixpkgs",
-    # A revision of 17.09 that contains ghc-8.2.2:
-    revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
+    # A revision of 18.03 that contains ghc-8.4.3:
+    revision = NIXPKGS_REVISION,
 )
 
 RULES_HASKELL_SHA = "3e68a0f3420f7589b1afa6afd3b9e37741978edc"
 http_archive(
     name = "io_tweag_rules_haskell",
-    urls = ["https://github.com/tweag/rules_haskell/archive/"
-            + RULES_HASKELL_SHA + ".tar.gz"],
+    urls = ["https://github.com/tweag/rules_haskell/archive/" + RULES_HASKELL_SHA + ".tar.gz"],
     strip_prefix = "rules_haskell-" + RULES_HASKELL_SHA,
 )
 
@@ -32,14 +33,14 @@ haskell_repositories()
 nixpkgs_package(
     name = "ghc",
     repository = "@nixpkgs",
-    attribute_path = "haskell.packages.ghc822.ghc",
+    attribute_path = "haskell.packages.ghc843.ghc",
     build_file = "@ai_formation_hazel//:BUILD.ghc",
 )
 
 nixpkgs_package(
   name = "c2hs",
   repository = "@nixpkgs",
-  attribute_path = "haskell.packages.ghc822.c2hs",
+  attribute_path = "haskell.packages.ghc843.c2hs",
 )
 
 nixpkgs_package(

--- a/hazel_base_repository/Skylark.hs
+++ b/hazel_base_repository/Skylark.hs
@@ -1,5 +1,6 @@
 -- | Datatypes for constructing and rendering BUILD file contents.
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Skylark
     ( Statements
@@ -10,6 +11,8 @@ module Skylark
     , renderStatements
     , renderExpr
     ) where
+
+import Prelude hiding ((<>))
 
 import Text.PrettyPrint
     ( Doc

--- a/hazel_base_repository/cabal2bazel.hs
+++ b/hazel_base_repository/cabal2bazel.hs
@@ -7,16 +7,25 @@
 --    package = struct(...)
 --
 -- which can be loaded into Bazel BUILD files.
+{-# LANGUAGE CPP #-}
 module Main (main) where
 
+#if MIN_VERSION_Cabal(2,2,0)
+import Distribution.PackageDescription.Parsec
+    (readGenericPackageDescription, parseHookedBuildInfo, runParseResult)
+#else
 import Distribution.PackageDescription.Parse
     (readGenericPackageDescription, parseHookedBuildInfo, ParseResult(..))
+#endif
 import Distribution.Text (display, simpleParse)
 import Distribution.Verbosity (normal)
 import System.Environment (getArgs)
 import System.FilePath ((<.>))
 import System.Process (callProcess)
 
+#if MIN_VERSION_Cabal(2,2,0)
+import qualified Data.ByteString as BS
+#endif
 import qualified Distribution.Package as P
 import qualified Distribution.PackageDescription as P
 import qualified System.Directory as Directory
@@ -38,16 +47,28 @@ main = do
 
 maybeConfigure :: P.PackageDescription -> IO P.PackageDescription
 maybeConfigure desc = case P.buildType desc of
+#if MIN_VERSION_Cabal(2,2,0)
+    P.Configure -> do
+#else
     Just P.Configure -> do
+#endif
         callProcess "./configure" []
         let buildInfoFile = display (P.packageName desc) <.> "buildinfo"
         buildInfoExists <- Directory.doesFileExist buildInfoFile
         if buildInfoExists
           then do
+#if MIN_VERSION_Cabal(2,2,0)
+              hookedBIParse <- runParseResult . parseHookedBuildInfo <$> BS.readFile buildInfoFile
+              case hookedBIParse of
+                  (_, Left (_, e)) -> error $ "Error reading buildinfo " ++ show buildInfoFile
+                                                ++ ": " ++ show e
+                  (_, Right hookedBI) -> return $ P.updatePackageDescription hookedBI desc
+#else
               hookedBIParse <- parseHookedBuildInfo <$> readFile buildInfoFile
               case hookedBIParse of
                   ParseFailed e -> error $ "Error reading buildinfo " ++ show buildInfoFile
                                               ++ ": " ++ show e
                   ParseOk _ hookedBI -> return $ P.updatePackageDescription hookedBI desc
+#endif
           else return desc
     _ -> return desc

--- a/packages.bzl
+++ b/packages.bzl
@@ -1,27 +1,26 @@
 prebuilt_dependencies = (
 { "array": "0.5.2.0",
-  "base": "4.10.1.0",
+  "base": "4.11.1.0",
   "binary": "0.8.5.1",
   "bytestring": "0.10.8.2",
-  "containers": "0.5.10.2",
+  "containers": "0.5.11.0",
   "deepseq": "1.4.3.0",
-  "directory": "1.3.0.2",
-  "filepath": "1.4.1.2",
-  "ghc": "8.2.2",
-  "ghc-boot": "8.2.2",
-  "ghc-boot-th": "8.2.2",
-  "ghc-prim": "0.5.1.1",
-  "ghci": "8.2.2",
-  "hoopl": "3.10.2.2",
+  "directory": "1.3.1.5",
+  "filepath": "1.4.2",
+  "ghc": "8.4.3",
+  "ghc-boot": "8.4.3",
+  "ghc-boot-th": "8.4.3",
+  "ghc-prim": "0.5.2.0",
+  "ghci": "8.4.3",
   "hpc": "0.6.0.3",
-  "integer-gmp": "1.0.1.0",
-  "pretty": "1.1.3.3",
-  "process": "1.6.1.0",
+  "integer-gmp": "1.0.2.0",
+  "pretty": "1.1.3.6",
+  "process": "1.6.3.0",
   "rts": "1.0",
-  "template-haskell": "2.12.0.0",
-  "terminfo": "0.4.1.0",
+  "template-haskell": "2.13.0.0",
+  "terminfo": "0.4.1.1",
   "time": "1.8.0.2",
-  "transformers": "0.5.2.0",
+  "transformers": "0.5.5.0",
   "unix": "2.7.2.2",
 }
 )
@@ -32,23 +31,29 @@ packages = (
       sha256 =
         "b8364da380f5f1d85d13e427851a153be2809e1838d16393e37566f34b384b87",
     ),
+  "ANum":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "f6ae0d1b663100a2aa3dfdab12f4af0851408659eb5c2f78b8b443b0d29dbb1a",
+    ),
   "Agda":
     struct(
-      version = "2.5.3",
+      version = "2.5.4",
       sha256 =
-        "aa14d4a3582013100f71e64d71c5deff6caa2a286083e20fc16f6dbb0fdf0065",
+        "b40971e3312461771e36a11aaf4002424178301cf315b21a679f527b79c09e09",
+    ),
+  "Allure":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "6b83013281da6ccc5f0bf4c483a53acdbff7679c7234a1dfa57261c45a8cf8fb",
     ),
   "BiobaseNewick":
     struct(
       version = "0.0.0.2",
       sha256 =
         "6432f684a75fd8a2cea59a5359a59f48020ead19119efaed7018ecae726d13bd",
-    ),
-  "BlastHTTP":
-    struct(
-      version = "1.2.1",
-      sha256 =
-        "cee85e0fba0530aff57209b3d91a800db52b63c3f7e4a431a04e7a9cbd355bd5",
     ),
   "Boolean":
     struct(
@@ -64,39 +69,21 @@ packages = (
     ),
   "Cabal":
     struct(
-      version = "2.0.1.1",
+      version = "2.2.0.1",
       sha256 =
-        "802bc6d0113fdb734ea938ad2aadc14f590e372b55d56be6712de319bb343d1b",
+        "02b5301304df73cea3c7d544b5026b228141dc3ac1d5b08c9a206f99aa330a7b",
     ),
   "ChannelT":
     struct(
-      version = "0.0.0.4",
+      version = "0.0.0.7",
       sha256 =
-        "76437ff58b44bfcf805494a12916b127c0e591718b6e7372315992782720d91b",
-    ),
-  "Chart":
-    struct(
-      version = "1.8.2",
-      sha256 =
-        "8442c16959e2a46355418b82c0c6fc3174d04b41ea6e2e320c56588a563be28d",
-    ),
-  "Chart-cairo":
-    struct(
-      version = "1.8.2",
-      sha256 =
-        "7cd8ba9da4c43ff4d6ba468d65e91b7239a0543038996a9a626818dc1a408fc1",
-    ),
-  "Chart-diagrams":
-    struct(
-      version = "1.8.2",
-      sha256 =
-        "ca181dec04bac1029101dd75951f48710ebc42f5333e06c57943e3245bba9f41",
+        "3e215d425e3cfccf2e4d84b1402fb39a2081cb33b6556059db616e722a7c77a0",
     ),
   "ChasingBottoms":
     struct(
-      version = "1.3.1.3",
+      version = "1.3.1.4",
       sha256 =
-        "38984a3514fb6a3be12c7a5ea50bced9c674d67d83917b37240c5721b4e45c12",
+        "639867018f33a645305ff60f1bf9ecca2efea4ac630d8c8f9fd72d064db79e19",
     ),
   "Clipboard":
     struct(
@@ -106,15 +93,9 @@ packages = (
     ),
   "ClustalParser":
     struct(
-      version = "1.2.1",
+      version = "1.2.3",
       sha256 =
-        "0034a9fdca3e4bcb70edb961536ee4acb162fec0ab1b2c67108598bfcd75879d",
-    ),
-  "ConfigFile":
-    struct(
-      version = "1.1.4",
-      sha256 =
-        "ae087b359ff2945a62b671449227e0a811d143ee651179f4e7e9c66548e0f514",
+        "fed67bdcb9d89d871b02f556e5a294d0ea6fd05576f92621a8797abff4325a72",
     ),
   "DAV":
     struct(
@@ -130,9 +111,9 @@ packages = (
     ),
   "Decimal":
     struct(
-      version = "0.4.2",
+      version = "0.5.1",
       sha256 =
-        "c5f53652949eedd48dbafc1bb3e08c05348d5e25c248e8e1543bc380a9f84261",
+        "575ca5c65a8ea5a5bf2cd7b794a0d16622082cb501bf4b0327c5895c0b80f34c",
     ),
   "Diff":
     struct(
@@ -142,9 +123,9 @@ packages = (
     ),
   "Earley":
     struct(
-      version = "0.12.0.1",
+      version = "0.12.1.0",
       sha256 =
-        "fc26a93c20b2c13fc9d4717926e724f1e9abfb7c8543657d835e35ba6e56d5b1",
+        "731493be9cb960c3159458dc24b1a217d6f26e1f46a840bef880accd04d5bd1d",
     ),
   "Ebnf2ps":
     struct(
@@ -160,21 +141,9 @@ packages = (
     ),
   "EdisonCore":
     struct(
-      version = "1.3.1.1",
+      version = "1.3.2.1",
       sha256 =
-        "3e0720ee3b179304f563b99dd446c1d6911e31ddc4d0f78d6550b18e59ed501b",
-    ),
-  "EntrezHTTP":
-    struct(
-      version = "1.0.4",
-      sha256 =
-        "b86ffe46c049bdfa7d7ebe99215ac994735fe5772dadf6c2f48ae702f278e5be",
-    ),
-  "FPretty":
-    struct(
-      version = "1.1",
-      sha256 =
-        "b8ac0122e923b0e20cee6ba77ffb07dfeaa96a194cdc1622808e97f443a8eb42",
+        "73c6014d07107a9ed21df76a59f70c9d68d64ac84cced35f7b628f1d792cf239",
     ),
   "FenwickTree":
     struct(
@@ -182,17 +151,17 @@ packages = (
       sha256 =
         "9c172d62b24365e663a0355e8eaa34362a1a769c18a64391939a9b50e384f03c",
     ),
+  "Fin":
+    struct(
+      version = "0.2.3.0",
+      sha256 =
+        "2fd02d1fc6426fb9b50db291d56b19dfc6da85cd3777f0aa64514c15a2b95ab2",
+    ),
   "FindBin":
     struct(
       version = "0.0.5",
       sha256 =
         "279c7967e0803ca3b9a0a1956ce7ba9b9a2294eb9f971bea8a557b5f80ddfda4",
-    ),
-  "FloatingHex":
-    struct(
-      version = "0.4",
-      sha256 =
-        "b277054db48d2dec62e3831586f218cbe0a056dec44dbc032e9a73087425a24c",
     ),
   "FontyFruity":
     struct(
@@ -206,65 +175,41 @@ packages = (
       sha256 =
         "fe74067fee601844de5c839a115f2bd75d4a1be9f0ee8ec42c0150bcf886693f",
     ),
-  "Frames":
-    struct(
-      version = "0.3.0.2",
-      sha256 =
-        "26a1b821f1dca29ac25c6c964984cba1cca3db0176c73271b545e2e8dac00da8",
-    ),
   "GLFW-b":
     struct(
-      version = "1.4.8.1",
+      version = "3.2.1.0",
       sha256 =
-        "438a49ec5cf6cbda95966fcc42750b9245f54fe7daf69a6493e7703c3f178ae9",
+        "31c022e0ad63f259ff9fa582a235924786e929a95b52efae10a3d29fef7cb6a6",
     ),
   "GLURaw":
     struct(
-      version = "2.0.0.3",
+      version = "2.0.0.4",
       sha256 =
-        "582cf8c0c1b8c0123ee9a8a06eba65fffded6decfe4e2e08bfea308f55f7ccee",
+        "b863fd5cb26b1a37afb66ef8a81c0335bc073d33b0a67ec5190dfc62cb885dc4",
     ),
   "GLUT":
     struct(
-      version = "2.7.0.12",
+      version = "2.7.0.13",
       sha256 =
-        "66f516bd9f836e5252fe0186e447b68a61b594d9247466c502b74994d3e9f1b5",
-    ),
-  "GPipe":
-    struct(
-      version = "2.2.3",
-      sha256 =
-        "77baca8d7a7933d069a3b20d6a16270e8560f1f6aff941c950e71a180e1976a5",
-    ),
-  "Genbank":
-    struct(
-      version = "1.0.3",
-      sha256 =
-        "2baf631ac851b1c29ba531ae1c16b8ba3c4b672bac9d4840a3b9afc0a89d2b93",
+        "3d217c0ee5e040992ebc278f5e20911460202a6e13767c8a0ddb01ef4adabac8",
     ),
   "GenericPretty":
     struct(
-      version = "1.2.1",
+      version = "1.2.2",
       sha256 =
-        "175e334292904d365c630c9dfcc5a94f0c052a88a10d34513f39ebc36205672d",
+        "eeea7ae7081f866de6a83ab8c4c335806b8cbb679d85e416e6224384ffcdae3c",
     ),
   "Glob":
     struct(
-      version = "0.9.1",
+      version = "0.9.2",
       sha256 =
-        "80cb0b048d78f71ba5af1e58c8d651f5b6f1b37766d4da9b18e30a40edd4f567",
-    ),
-  "H":
-    struct(
-      version = "0.9.0.1",
-      sha256 =
-        "5fc04dfefcac9f6882cea9e65755479f7b1d853618c89258a005df63c8d57134",
+        "8fc7134e9a930dd53fd168f200bde8ca07905365788f70adc6a1a4c413667ce5",
     ),
   "HCodecs":
     struct(
-      version = "0.5",
+      version = "0.5.1",
       sha256 =
-        "b1bf109a5e0877b47eb2f942ad0d1aa2368b9c006882ba07fe345dd0a90a1756",
+        "a724616b79ac12c2d661dc3f54cfa0e7d530d1ba3eafa1e6c3e7116e035a3143",
     ),
   "HDBC":
     struct(
@@ -280,9 +225,9 @@ packages = (
     ),
   "HDBC-session":
     struct(
-      version = "0.1.1.1",
+      version = "0.1.2.0",
       sha256 =
-        "255c4e55f888c873bfa6f9af25ccb7fb0eb004f398b86b74ed7878d39c59ce99",
+        "aa057f18bbc9d2f9876152246682f546c9cf140192515c7c23b5be2fccc296e3",
     ),
   "HPDF":
     struct(
@@ -296,11 +241,17 @@ packages = (
       sha256 =
         "eba93be5a76581585ae33af6babe9c2718fae307d41989cd36a605d9b0e8d16a",
     ),
+  "HSlippyMap":
+    struct(
+      version = "3.0.1",
+      sha256 =
+        "27eb37f3b1e70780173e732a949776fc0b0ecc5b1ba515c2e239d6545a2beb0d",
+    ),
   "HStringTemplate":
     struct(
-      version = "0.8.6",
+      version = "0.8.7",
       sha256 =
-        "7022cb9c1e1c223cfb8adf5ca6994b9f4709399ae197cb7541247c0b5d0255cd",
+        "4f4ea4aa2e45e7c45821b87b0105c201fbadebc2f2d00c211e728403a0af6b0e",
     ),
   "HSvm":
     struct(
@@ -310,15 +261,15 @@ packages = (
     ),
   "HTF":
     struct(
-      version = "0.13.2.2",
+      version = "0.13.2.4",
       sha256 =
-        "1db49f6b796699e5f86ae9485bd3f5874eca23bc01a0c8e1ac58519f47e1c3ba",
+        "36c5cafd35683c37379a93098dea61e6194aa1b9cfd0cdad4e0f1643f4cf2bf6",
     ),
   "HTTP":
     struct(
-      version = "4000.3.9",
+      version = "4000.3.12",
       sha256 =
-        "05962b8a6248d348977af2a755f0ed57a6ab523185235546dd66cf90a54663ff",
+        "a3ff6a9c93771079121083f1691188fe45f84380118e0f76bc4578153c361990",
     ),
   "HUnit":
     struct(
@@ -334,15 +285,9 @@ packages = (
     ),
   "HaTeX":
     struct(
-      version = "3.17.3.1",
+      version = "3.19.0.0",
       sha256 =
-        "ab19f779ba7c265f80d14d2bae85d26c611c031b877f228432b833909c1702ef",
-    ),
-  "HaXml":
-    struct(
-      version = "1.25.4",
-      sha256 =
-        "d77467b8c855ba85d900b5d1a9b771aa498c80d570f9ac60a9f10803cfc01db5",
+        "1fd977a582f44a62dafe32ad72acde8c0c01b0ae0ce5f7d6bbc4d91b68e24749",
     ),
   "HandsomeSoup":
     struct(
@@ -362,23 +307,17 @@ packages = (
       sha256 =
         "83ae92547fd5d52b5b74402101ec254423abeac0c0725e14a112d6ffc843040f",
     ),
-  "Hclip":
-    struct(
-      version = "3.0.0.4",
-      sha256 =
-        "d8c80bd2d035571cd76ce4f69453e9fcef4096dbc8868eb4cfcd7eb74fe5f712",
-    ),
   "Hoed":
     struct(
-      version = "0.4.1",
+      version = "0.5.1",
       sha256 =
-        "074f44d54aa0ed0334d9ff317b1293b03802f8a6971217d082b597d3afe7a491",
+        "a8f6dc9717e15642f00cd84a8d1030ac6a7c7870f7015e380bd728a843c3f4e7",
     ),
   "HsOpenSSL":
     struct(
-      version = "0.11.4.12",
+      version = "0.11.4.14",
       sha256 =
-        "356a526263d988254d5830dd5a368380163975174dfc9230b697e6129e5c15a2",
+        "443d0271b24dbc6cb1736994f6e8c290ce502909738f4e03879b27d30bb47489",
     ),
   "HsOpenSSL-x509-system":
     struct(
@@ -388,21 +327,9 @@ packages = (
     ),
   "IPv6Addr":
     struct(
-      version = "1.0.1",
+      version = "1.1.0",
       sha256 =
-        "dff7e9d19e60f08401fd79a8d5004b2166d45d0a1160e5705aac821268a54207",
-    ),
-  "IPv6DB":
-    struct(
-      version = "0.2.4",
-      sha256 =
-        "eda3378299623ca8aceb7a6ade18ebc5a06d8e7a0df1cae41c90b5c960bbb7ab",
-    ),
-  "IfElse":
-    struct(
-      version = "0.85",
-      sha256 =
-        "8ad3bfc3e2c867e6330d9bff874b3105476c35b2e1638fd448f233e9f80addcd",
+        "494c10e6bacf79b35a0601b056bb89b82902c10ca3b9b3de41d8971ddf64ed38",
     ),
   "Imlib":
     struct(
@@ -410,35 +337,41 @@ packages = (
       sha256 =
         "3ed318a7777a3b0752327b7b128edb3a1d562202b480a6d6b793b79ed90ebd1c",
     ),
-  "Interpolation":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "1bf68489dafd52f25d93a3aad672a2dc7110d77ffb85348cb82c3e5a51e8cb10",
-    ),
   "IntervalMap":
     struct(
-      version = "0.5.3.1",
+      version = "0.6.0.0",
       sha256 =
-        "9a575459f66ad48b734ca79885b599ab5a5eed800bb409b11f08c8a7d53f8c21",
+        "8f7d0d81c23a2d2dc7e7333b82824070a53144d40e08741456c8afe078b2111a",
     ),
   "JuicyPixels":
     struct(
-      version = "3.2.9.4",
+      version = "3.2.9.5",
       sha256 =
-        "ff35047d6f453f9fd5cccb99b2170375ecbf7f73ba350db6ac89b091d91f92d6",
+        "849c6cf4a613f906f7e553a1baefe9c0dc61c13b41a5f5b9605cf80e328cc355",
+    ),
+  "JuicyPixels-blp":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "2c8e0773e41fb841e90a36fb8c839670d2afebc6b89271f782fc5df250cbcc99",
     ),
   "JuicyPixels-extra":
     struct(
-      version = "0.2.2",
+      version = "0.3.0",
       sha256 =
-        "8d7e375f8f30b0f98912dd24365920a4b466aecb49e28f7325408fd378d71eb8",
+        "c5a03a9747bcd984924d6f7c9b4771188e297df82160e7d667ea8f4f671b0e22",
     ),
   "JuicyPixels-scale-dct":
     struct(
-      version = "0.1.1.2",
+      version = "0.1.2",
       sha256 =
-        "9abd9d00520424912201b58343f252362b9f34760023d3324732ca00a906fe96",
+        "f7381b88446224897e6677692bbdc39cb5b755216212f0ad8050046865cd3013",
+    ),
+  "LambdaHack":
+    struct(
+      version = "0.8.3.0",
+      sha256 =
+        "5a9b23a893ba809d8f7ff1ef810d4d542fcd7419876aef4208cf237a3662076c",
     ),
   "LibZip":
     struct(
@@ -454,15 +387,9 @@ packages = (
     ),
   "ListLike":
     struct(
-      version = "4.5.1",
+      version = "4.6",
       sha256 =
-        "b70745335b563cd9039bb17a1e2faf7edb1b68febdd19586b28ab67c55562a8d",
-    ),
-  "MFlow":
-    struct(
-      version = "0.4.6.0",
-      sha256 =
-        "4e93f7488152d88359fd100a742c2ea96788284d262f3cd1b50d936f80f1a342",
+        "c1cdec79a5f585a5839eea26a2afe6a37aab5ed2f402a16e7d59fe9a4e925a9a",
     ),
   "MemoTrie":
     struct(
@@ -484,21 +411,21 @@ packages = (
     ),
   "MonadRandom":
     struct(
-      version = "0.5.1",
+      version = "0.5.1.1",
       sha256 =
-        "9e3f0f92807285302036dc504066ae6d968c8b0b4c25d9360888f31fe1730d87",
+        "abda4a297acf197e664695b839b4fb70f53e240f5420489dc21bcf6103958470",
     ),
   "MusicBrainz":
     struct(
-      version = "0.3.1",
+      version = "0.4",
       sha256 =
-        "3518fd97581cbb90a15c5dc62b637cde5d71911b3f10d62c37ed17157415f3fd",
+        "b9cbd130921da38a693abe3f3dd5e58c883b382d0b70c112e625b64158605629",
     ),
   "Network-NineP":
     struct(
-      version = "0.4.1",
+      version = "0.4.3",
       sha256 =
-        "9d7a456c672c1e7ef1075e27654b21ecacd8062917e1482c8060e404f3960f4a",
+        "8169e46ddfd690b96f25bc9a577568a363a270c2bddbb9fb3e1e7f1959644ec3",
     ),
   "NineP":
     struct(
@@ -511,12 +438,6 @@ packages = (
       version = "0.1.1",
       sha256 =
         "9b663a234c034e0049126ae7f06d1756dc496012177bf18548c6d8caeec43b3d",
-    ),
-  "NoTrace":
-    struct(
-      version = "0.3.0.2",
-      sha256 =
-        "39ea78488aa2a172691b2d97b3bc6673a423f1eb0c184381da546de61d94125b",
     ),
   "NumInstances":
     struct(
@@ -532,9 +453,9 @@ packages = (
     ),
   "OneTuple":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "4b6f74b6d92df112b0f4eaf15ccdc5fbb763d59f07e9a2afa5690ef89159a2f4",
+        "d82e702485bcbdefbda0d12b6a250d318a269572ee58d63b60eee531e56624dc",
     ),
   "Only":
     struct(
@@ -550,33 +471,21 @@ packages = (
     ),
   "OpenGL":
     struct(
-      version = "3.0.2.0",
+      version = "3.0.2.1",
       sha256 =
-        "faa99459724d614d2cf2d2b83c7bda4898ee71752a253bf4699c096822450efb",
+        "7acb891b911de8bb6933afeaa7f8c5291cc986da5557c922c0fc1717c5a559bf",
     ),
   "OpenGLRaw":
     struct(
-      version = "3.2.7.0",
+      version = "3.3.0.1",
       sha256 =
-        "62723d0fc287e5e5e93853b1fed0ca76495e6b693261aa9aae35340182a58a08",
-    ),
-  "PSQueue":
-    struct(
-      version = "1.1",
-      sha256 =
-        "a8e0871ad10f916f55c3b9baec53eff23c4e97e09cf96d6c66771789e00a49cc",
+        "d889e4040791957157f001d0236c148f531a45007a2215b7e03adbad90baf14b",
     ),
   "ParsecTools":
     struct(
       version = "0.0.2.0",
       sha256 =
         "ef4843353127aa3e6f6ab0aece9f4245225d375802921e151a1751d797857a87",
-    ),
-  "PortMidi":
-    struct(
-      version = "0.1.6.1",
-      sha256 =
-        "b89e9293d5b80d23b197dbb9bf196737765c66ffe96eaabdb9517fe20b516690",
     ),
   "QuasiText":
     struct(
@@ -586,15 +495,9 @@ packages = (
     ),
   "QuickCheck":
     struct(
-      version = "2.10.1",
+      version = "2.11.3",
       sha256 =
-        "1dbb56786854fd539315497086284dfff039a52a487319e648140e4987b6d5e5",
-    ),
-  "RNAlien":
-    struct(
-      version = "1.3.7",
-      sha256 =
-        "de54278982eecd9568ee155a3155f632b503776fff7634b8b3746e29d28248a5",
+        "488c5652139da0bac8b3e7d76f11320ded298549e62db530938bfee9ca981876",
     ),
   "RSA":
     struct(
@@ -604,9 +507,9 @@ packages = (
     ),
   "Rasterific":
     struct(
-      version = "0.7.2.1",
+      version = "0.7.3",
       sha256 =
-        "7f6d86495a5a3aa72dd9c13f2dd8d93526cd5166889f39c5e7dde529cef44d74",
+        "fd0a8770acaf2c594b64aafd15e8288ec5af370d901ac03a933b642deb802279",
     ),
   "RefSerialize":
     struct(
@@ -622,9 +525,9 @@ packages = (
     ),
   "SHA":
     struct(
-      version = "1.6.4.2",
+      version = "1.6.4.4",
       sha256 =
-        "c470176f63cbe49fd0502a1b32ef22bc01b1af42385583b8be94547750958a8c",
+        "6bd950df6b11a3998bb1452d875d2da043ee43385459afc5f16d471d25178b44",
     ),
   "STMonadTrans":
     struct(
@@ -634,9 +537,9 @@ packages = (
     ),
   "SVGFonts":
     struct(
-      version = "1.6.0.3",
+      version = "1.7",
       sha256 =
-        "bc8f8863799070c345fdd88c065852c6434af9e802fd0171df2a3dbd37f35887",
+        "da3ccd65e0963473df035f4543b56dfc84b45edca540990050e5de444fa431cd",
     ),
   "SafeSemaphore":
     struct(
@@ -652,69 +555,27 @@ packages = (
     ),
   "ShellCheck":
     struct(
-      version = "0.4.7",
+      version = "0.5.0",
       sha256 =
-        "184955264d42c5dca0300fb9688b9a6c9a1c70c345dbcd8e30bb48a049a70d7c",
+        "2b9430736f48de17a60c035546a6a969c14392521bec30119e1c869017d3307c",
     ),
   "Spintax":
     struct(
-      version = "0.3.2",
+      version = "0.3.3",
       sha256 =
-        "f7e620817ce065f06ae163b08461eb3ce3dc0254caf0dcbd00d01836759bf048",
-    ),
-  "Spock":
-    struct(
-      version = "0.12.0.0",
-      sha256 =
-        "8392d1ee34b46238c6bfe951080f06e11e1f3622d8402e7762c70aa61430e3d9",
-    ),
-  "Spock-api":
-    struct(
-      version = "0.12.0.0",
-      sha256 =
-        "8cfdbcbd2fa426c595fb7d29f8a6395dea17476c15d5ae863da2605b1c6ebe00",
-    ),
-  "Spock-api-server":
-    struct(
-      version = "0.12.0.0",
-      sha256 =
-        "29734206823875ec71d7cad14bf012adb70b01700975e2181a7cb52713b131ce",
-    ),
-  "Spock-core":
-    struct(
-      version = "0.12.0.0",
-      sha256 =
-        "e69b70ea3027fa644d546bcae25bbf75e38abd6f4a7f88f0628fea6e16e97895",
-    ),
-  "Spock-lucid":
-    struct(
-      version = "0.4.0.1",
-      sha256 =
-        "3126d512e9528a6cf8830ad355dd2f0429bfd41f0ae048138818ae8dcedc2397",
-    ),
-  "Spock-worker":
-    struct(
-      version = "0.3.1.0",
-      sha256 =
-        "edc009d59fe528ab3bee887b8092f720a8a4ee85b550dec065964ed55c76dc4b",
+        "21df2193bf1216d55a0d43691182125993eeadc6f097eaf5eb995c23f2016b13",
     ),
   "StateVar":
     struct(
-      version = "1.1.0.4",
+      version = "1.1.1.0",
       sha256 =
-        "7ad68decb5c9a76f83c95ece5fa13d1b053e4fb1079bd2d3538f6b05014dffb7",
+        "1a89cd2632c2fc384b4c71fdc12894cc1c3902badbf4771497437e4044274e80",
     ),
   "Strafunski-StrategyLib":
     struct(
-      version = "5.0.0.10",
+      version = "5.0.1.0",
       sha256 =
-        "308a1a051df6bb617c9d37bda297fdbedfb8b4c7f6ea5864443cfb9f15e80cc2",
-    ),
-  "Stream":
-    struct(
-      version = "0.4.7.2",
-      sha256 =
-        "990be249b3ef1b0075563026d4d2c803b86e3cbf168965ba6f9f2b4227a007d1",
+        "a018c7420289a381d2b491a753f685b9d691be07cea99855cc5c8e05d5a9a295",
     ),
   "TCache":
     struct(
@@ -722,35 +583,11 @@ packages = (
       sha256 =
         "f134b45fcdd127fa1a4214f01d44dc34e994fed137cec63f4c4ea632363ab7bd",
     ),
-  "Taxonomy":
-    struct(
-      version = "1.0.3",
-      sha256 =
-        "b6f793127ba68fce97e1ab5482e41c8833b9577f01ef9b41470ab143c50e9270",
-    ),
-  "TypeCompose":
-    struct(
-      version = "0.9.12",
-      sha256 =
-        "3a182c2cc93f8291b3aedfc32c0b1faa84a982601c1a24cbe7fe1ecc50e333e2",
-    ),
-  "Unique":
-    struct(
-      version = "0.4.7.2",
-      sha256 =
-        "b56155043817187170d02e6fa7c5ec69c72dc2a1c00b50bdd34d6d2875795b6b",
-    ),
   "ViennaRNAParser":
     struct(
       version = "1.3.3",
       sha256 =
         "7ee941d106b8b0c57e1ca5104d19b94215721e4a7b8aeb53fa353d246efbaefe",
-    ),
-  "Win32":
-    struct(
-      version = "2.5.4.1",
-      sha256 =
-        "cc183e9e545ad04fe8e509eb9447e9d11b160b2027482230cee8cdc141fd3d64",
     ),
   "Win32-notify":
     struct(
@@ -758,17 +595,11 @@ packages = (
       sha256 =
         "0c21dbe06cb1ce3b3e5f1aace0b7ee359b36e7cb057f8fe2c28c943150044116",
     ),
-  "Workflow":
-    struct(
-      version = "0.8.3",
-      sha256 =
-        "c89b4b3a4a29fe576f8972ffa1e698eff8ac0ceb433642fc0b3f9c0308d22123",
-    ),
   "X11":
     struct(
-      version = "1.8",
+      version = "1.9",
       sha256 =
-        "541b166aab1e05a92dc8f42a511d827e7aad373af12ae283b9df9982ccc09d8e",
+        "10138e863d8c6f860aad1755a6f1a36949cc02d83e5afacf6677fb3999f10db9",
     ),
   "X11-xft":
     struct(
@@ -781,18 +612,6 @@ packages = (
       version = "0.1",
       sha256 =
         "ba332dea9ec152b3f676d22461eee81a657e16987c3dfb8249e9dbe0cda56ed7",
-    ),
-  "Yampa":
-    struct(
-      version = "0.10.7",
-      sha256 =
-        "14b13dcb9e52a4c6f738d7515d82d681618720de5598ec11448646333193d1c5",
-    ),
-  "YampaSynth":
-    struct(
-      version = "0.2",
-      sha256 =
-        "a1c6a0ea57aee855ca3f558f1b6d7ec167abb57333052d8a9f7b46ef323d0a09",
     ),
   "abstract-deque":
     struct(
@@ -811,84 +630,6 @@ packages = (
       version = "0.3.3",
       sha256 =
         "248a8739bd902462cb16755b690b55660e196e58cc7e6ef8157a72c2a3d5d860",
-    ),
-  "accelerate":
-    struct(
-      version = "1.1.1.0",
-      sha256 =
-        "a4f482472bbd0e858bbe568834490af46d882bafb598576213b63a44be828ee1",
-    ),
-  "accelerate-arithmetic":
-    struct(
-      version = "1.0",
-      sha256 =
-        "62a467818285031330ecc85968d58d86986e1dacebe901c9d86b0fa53ba60c3f",
-    ),
-  "accelerate-bignum":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "7c18c467d646ed30131ad197144c4f7fa6ce3e821d41c6db3dba4361f04e30a5",
-    ),
-  "accelerate-blas":
-    struct(
-      version = "0.1.0.1",
-      sha256 =
-        "cda96b600cfa251036db1c3568778235cb766d6f9bcff80420b4de48867a4c66",
-    ),
-  "accelerate-examples":
-    struct(
-      version = "1.1.0.0",
-      sha256 =
-        "3de4806f0d4e76733dc76824e737820e53ece0eb42787754739284b1cdacf27e",
-    ),
-  "accelerate-fft":
-    struct(
-      version = "1.1.0.0",
-      sha256 =
-        "34d9ae4f15b63067803febd5887a08cf067d7e61dec1c61702a7d66795855160",
-    ),
-  "accelerate-fftw":
-    struct(
-      version = "1.0",
-      sha256 =
-        "ff4ca5aaaef9105a6e16b8dc275b3ba0fe8444a2a4140774a49b5239f6c9922c",
-    ),
-  "accelerate-fourier":
-    struct(
-      version = "1.0.0.3",
-      sha256 =
-        "cbaeb5606d1bc5b83ad0727c0c7032943ff99256832e3e5d2d726ba8955506f6",
-    ),
-  "accelerate-io":
-    struct(
-      version = "1.0.0.1",
-      sha256 =
-        "f5a68d160adb378b1b9e42596786f8cc0ece4bb54af68f0d4f1e5d03c92474e0",
-    ),
-  "accelerate-llvm":
-    struct(
-      version = "1.1.0.0",
-      sha256 =
-        "1c0324a64b9515a9b81f3566040bacc7cab230dad7e1d4c74429d5e6947a82f4",
-    ),
-  "accelerate-llvm-native":
-    struct(
-      version = "1.1.0.1",
-      sha256 =
-        "b4ec3931647ed297a9588b8eb03d3f1d3dcdaa41d4f2fe808459b3aa69d2bc43",
-    ),
-  "accelerate-llvm-ptx":
-    struct(
-      version = "1.1.0.1",
-      sha256 =
-        "b26c1b2d2a3a9f438e255661f3fe28120443c16e9e4e0fd18a2988fe80273248",
-    ),
-  "accelerate-utility":
-    struct(
-      version = "1.0",
-      sha256 =
-        "939a7eae149915090c7e0fb4697553b67db534e7e7aaf3340113b694543e399a",
     ),
   "accuerr":
     struct(
@@ -922,15 +663,15 @@ packages = (
     ),
   "adjunctions":
     struct(
-      version = "4.3",
+      version = "4.4",
       sha256 =
-        "b948a14fafe8857f451ae3e474f5264c907b5a2d841d52bf78249ae4749c3ecc",
+        "507c2ef55337ae61c805f8cbc1213dfd7d2b85187342675d662254b8d8a16ae9",
     ),
   "adler32":
     struct(
-      version = "0.1.1.0",
+      version = "0.1.2.0",
       sha256 =
-        "578cb9ea7451dc905a22de15e46f8d6fc27f76e4c6f75352a70ebfe53a6928ec",
+        "26b43c9f389f45ed792698ea4880d24ba56ab61c6f7cae51e582a05e0b5866a4",
     ),
   "aern2-mp":
     struct(
@@ -946,9 +687,15 @@ packages = (
     ),
   "aeson":
     struct(
-      version = "1.2.4.0",
+      version = "1.3.1.1",
       sha256 =
-        "3401dba4fddb92c8a971f6645b38e2f8a1b286ef7061cd392a1a567640bbfc9b",
+        "843f302f8186c1ee6e0d9c0630588e4c7fc0f41763333a2d0d4b6f07087a31c4",
+    ),
+  "aeson-attoparsec":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "a5868390477938b3086e820f4a432f9d6a3972454f561fc386520634eec72104",
     ),
   "aeson-better-errors":
     struct(
@@ -964,45 +711,57 @@ packages = (
     ),
   "aeson-compat":
     struct(
-      version = "0.3.7.1",
+      version = "0.3.8",
       sha256 =
-        "59740dc1e37b08e60abb47f38b87de5b9805611a1b468cd18294d5982a1dcacb",
+        "71e4434abe630c48644ebfc38b4fa04d16600187a8af8921f23f88f9ee089b48",
     ),
   "aeson-diff":
     struct(
-      version = "1.1.0.4",
+      version = "1.1.0.5",
       sha256 =
-        "87f1e4f9462ddb04d67c517a8810f6769cd628ee792868c490afee1d2b7c8b0e",
+        "61d9dd60b6c19dd5aa350b85083ebed3eab8d8611893db1279e55e43d7c7fbcf",
     ),
   "aeson-extra":
     struct(
-      version = "0.4.1.0",
+      version = "0.4.1.1",
       sha256 =
-        "1e35bda18aca4f847178606e4cc4d24001bd0bae5c40e2934c039b64979f9085",
+        "d48a65d976cbf496c8e5e9c927118ffcc878d6a83adf2fc9cebd418186d6fdf8",
     ),
   "aeson-generic-compat":
     struct(
-      version = "0.0.1.1",
+      version = "0.0.1.2",
       sha256 =
-        "ba46aa8e57d79c5e865d0224e8642c20facc59a4d2a9fba3b669928ec8835bb5",
+        "6308ce74043a47289ee183918a362508677e9dd93fbed2b1033dc5132dca0422",
     ),
-  "aeson-injector":
+  "aeson-iproute":
     struct(
-      version = "1.1.0.0",
+      version = "0.2",
       sha256 =
-        "8ea78f3cf94be2e50654ba1ff8110c528f710f648e1fa10c621fa6f89f3e74b6",
+        "ee4d53338bfdc4a6ce0039dea24e797a0ff1e22c312b31be2e73ddc0bddf268f",
+    ),
+  "aeson-picker":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "b20e23905c395d7b61fce6c5f6343758e3753a2dbee61800d3e15e753ac7c452",
     ),
   "aeson-pretty":
     struct(
-      version = "0.8.5",
+      version = "0.8.7",
       sha256 =
-        "dd17e86c64b3fe2efb7a855b27b0e5490e42dc58194ae1809d8b662d4e42a9f9",
+        "c1c1ecc5e3abd004a6c4c256ee6f61da2a43d7f1452ffa391dee250df43b27d5",
     ),
   "aeson-qq":
     struct(
       version = "0.8.2",
       sha256 =
         "6db252c94601efcb1ce395de0084ccf931a3525339ccdca011a740e7b11cc152",
+    ),
+  "aeson-typescript":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "2d9aa1534d2cc86a7f95a5876d7ff28006c34dbead6fb7a03aa86d6f5e310187",
     ),
   "aeson-utils":
     struct(
@@ -1016,23 +775,17 @@ packages = (
       sha256 =
         "af4355bc315a152592e9c06f5cc41bdb5ce7b236d85fe572a292c6bac02faa74",
     ),
-  "airship":
+  "al":
     struct(
-      version = "0.9.2",
+      version = "0.1.4.2",
       sha256 =
-        "776b9159569aa696e3f3863cd264ec503b01d87211a8054d34bce48dfd01260b",
+        "8bf0f3b3a05ea7b7b8e43da282e1952e5c532ed23247d3384d394cd5046cecd2",
     ),
   "alarmclock":
     struct(
-      version = "0.4.0.3",
+      version = "0.5.0.2",
       sha256 =
-        "b66f5b18b0efc4471b32704dd7bdb650d09629c5bc006e54f4354b1265650f5e",
-    ),
-  "alerta":
-    struct(
-      version = "0.1.0.6",
-      sha256 =
-        "d5b5553678adca16770e45fa8d0f9e8378b31962ba8dd1baab600af6d035e6b5",
+        "2574a30897a9a63f09ba97a51f1aead1baeade3cd8b4b063a74d5bb8fa73d64c",
     ),
   "alerts":
     struct(
@@ -1042,15 +795,27 @@ packages = (
     ),
   "alex":
     struct(
-      version = "3.2.3",
+      version = "3.2.4",
       sha256 =
-        "1a63791417b3e6e36e8b79849317beeaf9ea09efa21bea021c2347b49266212e",
+        "d58e4d708b14ff332a8a8edad4fa8989cb6a9f518a7c6834e96281ac5f8ff232",
     ),
-  "algebraic-graphs":
+  "alg":
     struct(
-      version = "0.0.5",
+      version = "0.2.5.0",
       sha256 =
-        "fd7bfc709966c4999e2376376863b894da0c921530ff9e9f71c4f273f201c510",
+        "dd9344c61dffff753f22af7bdd71d1cfd33245d6b32d5f2c2898a2e208cc9c04",
+    ),
+  "algebra":
+    struct(
+      version = "4.3.1",
+      sha256 =
+        "25982f929b6f9930ad4df7b2c4084da473178a6e1f33ccc556ec96ee6f541224",
+    ),
+  "almost-fix":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "20597d015fe9b6bb6bfcb0eaee3eb58b28e38a1f4f43049ad0aeebcc6409a70f",
     ),
   "alsa-core":
     struct(
@@ -1058,17 +823,11 @@ packages = (
       sha256 =
         "eb50495ef05ecc7c06a0147da7f0d3efde832a44d23caaf5172dc114882270ab",
     ),
-  "alsa-mixer":
-    struct(
-      version = "0.2.0.3",
-      sha256 =
-        "f76deb4081a2ce4a765e78a017b2e13c073d2aaa5a2d2652fd5e635dd169cf8d",
-    ),
   "alsa-pcm":
     struct(
-      version = "0.6.0.4",
+      version = "0.6.1",
       sha256 =
-        "9aae1379903b8445073f8a2b6ccf86b904b4045247747516530a165a3f76ca2a",
+        "453d768f7b90aaa0b5fd5462bcd7f8f40a97aa9d0ca7dfc7e61fe69e74934e5d",
     ),
   "alsa-seq":
     struct(
@@ -1084,543 +843,543 @@ packages = (
     ),
   "alternators":
     struct(
-      version = "0.1.2.0",
+      version = "1.0.0.0",
       sha256 =
-        "afe401a4a5ccef58a503f31fd9cf0fdc9618333772e9a80fb5a2696b22f422a6",
+        "44395b8b42193fdd78f94fd9f62560bfa69aef345a0fb2602df0d8d3613fd339",
     ),
   "amazonka":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "fc1aa4ba13add06a6b8f77d0bc6e9bc03f2328605393bb2f891036cf6758ae3c",
+        "3721892c87946c12bbd87ddba38d9e244aa962db190d8897c16a264c4f3fc41c",
     ),
   "amazonka-apigateway":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "249102fb489b137ff780eef6cd792a7558d3699ccf30d0b449244a4879b855f9",
+        "56e63ecfbd8358d0d2766e08f8f2b08362bb435c1059a5791964089dbab75ae8",
     ),
   "amazonka-application-autoscaling":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "d6d52f98c775a7017f037cc2eb87407851f83a0e63d342b432c459c7d3fc9947",
+        "5536a7d1c24cd5907b85bd743df5989d91cb3325602944062c9c640178a61df7",
     ),
   "amazonka-appstream":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "6c45433f252e08cb9e4b7eacba4095e41917b78c98c1e210dc5f8d8dccefe515",
+        "eb90692b932d62c4e7006d661b8022c4dd9f7d4dcc07e5499eceae14b33747df",
     ),
   "amazonka-autoscaling":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "734734869e469923927dd6ef8015f64e593c149544c3b56b1eace9924bf8b7ca",
+        "1b52132b23ef899937d20cef595d9f8757f85861d142616bcb5ee0ba8ed5f8d3",
     ),
   "amazonka-budgets":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "0a99ee474fa0fd0838ff89a8b07291512c5e986a72cd1b932a8892c72319d1cf",
+        "ccc692856a7f7ddfba573cde6506108a30a59f641748ecc787aece894d7ce4b7",
     ),
   "amazonka-certificatemanager":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "7816c83cbabf192f9e30ca5fd3d2ec217149d5fce60192764c38cf3f934edc42",
+        "1fdf93c685a1b348a851b793b170a0a2282b06dc65a91c016d4756ea5726aa6a",
     ),
   "amazonka-cloudformation":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "71d71ee28e0a5616f2d779a674d4bf7ce48e1e93a30a66b0e0291ae1f8ed83e8",
+        "15e2c82574906a13d390f68f5a57a83f4bbfc37fb9ce590c9f73e00dcafa8335",
     ),
   "amazonka-cloudfront":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "6025ac536ad52017cff5c39bda9c5e5e36773f1a77954bb944326525a9285115",
+        "956a60988ff3b9bef042bf523b63c882cd7b2c386483cc3f1d1d8534aad334a2",
     ),
   "amazonka-cloudhsm":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a5d787f20bb59f714a6a26faed3ee1e921bc46b571d2d84fb09c87706da38498",
+        "e4227038a39486e8c390198997571ca1b14ebf5e15fec1146169da7378a41b5f",
     ),
   "amazonka-cloudsearch":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2c81ea7616815c7d2ae5d9381d1cf05fd728bb5676be5eefc0bc887ca6f8dddf",
+        "dd17345576acd8f44fd3af82f07b00fdce0781abbd51ab2df827fa48528c6394",
     ),
   "amazonka-cloudsearch-domains":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "306beb51bdaefd3511dcadde27f1999053233f70196d9f6a605b46fae50df44f",
+        "24f0d36f9aeed5041fd893b8a0d60e5df6f31c8a126cead4652115c6b28f7ca7",
     ),
   "amazonka-cloudtrail":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "08805257c6c4ef47ded4413975fff455a8b1656c6b4671217a5b2c686c8104d4",
+        "d9d99df96ac2e46321e0da7d1797f12472ee32011f126d2881a2f19aa7491c24",
     ),
   "amazonka-cloudwatch":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "4530f10c056153070f1fa177e2304622da928846b2f9e624afd02997224d7b58",
+        "25c812b364b22d96d082e3598cd75d988cb8e3decdb8e3291a0deb9714dbee51",
     ),
   "amazonka-cloudwatch-events":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "172ccc6e305fb6f92ed4965b936593ab8b7575b7e91d2ef29cb7fc75e4f68060",
+        "13fb5e436fc4c534d6e01c47ef23f589c01042f8a9d7efb622e89bd8f5d2ec4d",
     ),
   "amazonka-cloudwatch-logs":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "d9ca3dd12e6482a4fe851c41fdfad3bb49c8cab58b483436770c48de17051016",
+        "80e4e74af0fb29f5ecc04f4d956ba0e9950f7936c858c1ff84461b62ca87ee7d",
     ),
   "amazonka-codebuild":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "4164938a44ea35a3fbd9ef3d83f1bbc2a5a6ae2210882ede5d22b1e858ce05cd",
+        "fdbf43578e0aa54c616b2daf8b442b32a8765b62da0c3b7f6b1df95f4e55a0ab",
     ),
   "amazonka-codecommit":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "c2df8d30d7cb6987afb9d13dc8362733d8f5ef36fbe86a04170aec109580247b",
+        "8a2f2630bfabd3c71fdb811a9bbafefb058ce085ad18c1756a82f59bdd682415",
     ),
   "amazonka-codedeploy":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "48a3881297eefe4790e4b3808f3492a7662e73003eecbed02acea9a1fb930523",
+        "3315b99ab8851acb5ae1251344474e0ec03796e9fd59f1d18278abc7add3c2df",
     ),
   "amazonka-codepipeline":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "57a5a1b8918e18256ec2a4344df06c8b141a4a03bab00f6c87e7961bf6632949",
+        "c46eea221931601ced439454d3a3fe0030acccbb776bf153182010ca8f2ec043",
     ),
   "amazonka-cognito-identity":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a7e6e631325cbc2d218a24bf37b9e139ac57b41a11781bf2134b42f9deb78322",
+        "3aac30e210d3fc0f45166b6211c4c61eb7cc4480fb550f106cd6206c8dc9b6d5",
     ),
   "amazonka-cognito-idp":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "7c7cb958a7cf3164a1c034e3a58f113808ad6e2bcfec2a1a9f1560e7278354a3",
+        "a98989c8ca10bb938fb4f27803920462fc8f88d7104cebb5106b9e3728e81fff",
     ),
   "amazonka-cognito-sync":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "ea2d75877be42efa9330c2e9501c3daf3ec6594ddbf6d54ab7f73067d3447678",
+        "5fde10d8e1f31e676433dfd32d061739d805a076ee58abd9c05d8faba36cf435",
     ),
   "amazonka-config":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "6359b32c44e66773b6e61e29cbe0a3000f5035de26a4d4e8d46364375ce3d1d2",
+        "5cb03ebc049efbccfb48ab926e08f0e9824880bb349129601f724679fe42c9cd",
     ),
   "amazonka-core":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "d3f6f9ace5c18680d909d72ca86ba617999267c8e91527a7b658a63b666d759c",
+        "afe1c5b74aadc0222419bd792688fd179e4f5693aeb75b74232f770fff093dc9",
     ),
   "amazonka-datapipeline":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "614a13b1d8a582c886b8880cfc915dee6a94fe50879afc33785667c48773163a",
+        "1b212dd70864ef1ccc45e3a7deca936e0e1803c97aacefc34fad966fd85f3ae5",
     ),
   "amazonka-devicefarm":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "0ee3f07808755407ccc042a5cef6874d88872640b37a1010758840aa54801bb1",
+        "d81b74b8b0c254a487ce464b1d6f0679d774bd42daf32312867e4dd37e35c569",
     ),
   "amazonka-directconnect":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2060b96b398214fbb26ee03ac5cd3e5bd20b4d960fb5ecb1c2fec7f140e86b92",
+        "8d85b9ce865eac817610a3a1db2e28100ff0069b85f41c4359a6aa5978533832",
     ),
   "amazonka-discovery":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a620e2b0f5a3ef62cb6e7922a2fb142c7155597f3729d5943054a6be93cf9354",
+        "7bc67ad76b1413c2aebe48324d56b2e6f4279db6e7d4951e93bdaa5329199213",
     ),
   "amazonka-dms":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "02d2e651c2c87736f5e9925235110f86a2fdb734ae040d713496b43cbda734b5",
+        "a75f19dc2a7642840a97a135f24cd9120d3f5a81ad924aad6a46c514fba180f3",
     ),
   "amazonka-ds":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "92c5b5c1abac4052ce917d6f138a1ade37991b236f4474329794668eabb42957",
+        "06fa338938aee62f81f93755cdc7039515dc0c6b32bb7c0bac33d7c92066d389",
     ),
   "amazonka-dynamodb":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "c8022fdcd22a3302d09ec8016a3a2357abecec94600354397bd77c1400c321c8",
+        "33f54ee4f898972f1539a00e65a851bb940c8d26058d63ddfcd07fbca57f9a3f",
     ),
   "amazonka-dynamodb-streams":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "21ceb7b12186fd6a8eed54e1c61865096df9b783407ea39ced52bbda4f950049",
+        "b3f832ddf70e95232cb79d71633276aa65c72e51c6c553118b4bc9db3a48e57f",
     ),
   "amazonka-ec2":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "b00d0d47d83766d9927657a31f11f28288ce6892e55d919c24cac09625e21f41",
+        "2221c2c4e188aac9f0c9e4bb2e0bce65eb21102e6199c3783c20f3797da955cc",
     ),
   "amazonka-ecr":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "68bd790b4dd2568fce08ba992382951acc7f0a7dc1a86a5ba10329c4d64fca58",
+        "42088ad4b4d4c01b87267a372fec706f57db4db19b27c06a3c6826ef62ef8450",
     ),
   "amazonka-ecs":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "45eea9bc27ec26834125cc4316bfcf825630739dc00d5da6dcf69e8674b3a222",
+        "309535abe8359475b3430488c84c398ed8d25a05321101c725e4a04d5f4cde3f",
     ),
   "amazonka-efs":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "45064be76d9ac2997f781a8d51b2359c2e86b4371bc3062289ea091011852f2d",
+        "268456294406d63eb49422027226af8ef15ce08dc2095be9a6657bf9bf41afbb",
     ),
   "amazonka-elasticache":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "e5e4c41e7e290b64f1f29ef8cef1d14769fca58a00353239070044bb26880116",
+        "e4a74a2ce2d89534fd738c429dc9a0ee7564ee3539bd93488eba211176763969",
     ),
   "amazonka-elasticbeanstalk":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "74652cf68d5d937acd4aec4c176a5d8cdefff5248520e1a7338ba8d38fd360b3",
+        "c1dc065763475b705aabf61086546bcd312e6802dbb328775b9777e682b2386a",
     ),
   "amazonka-elasticsearch":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "17f2e6932e69726118b93532feed61aef21f0a02bf946aa58adf74698076d4d7",
+        "3429fcae1c6fec5ebbc8acf1597532615b39def394d2296d641614c0225f3083",
     ),
   "amazonka-elastictranscoder":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a10466246c5dd1f30ce680bb55b5d2754f27ec87a2384d646166a9e72bdef38b",
+        "ab12a7c97e09cd1a60e81525e793f5f7b84799f8f9968a2b62bae8b9c9f3c10a",
     ),
   "amazonka-elb":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "0c6c340d02b3b16f2097824cf0d11a27402d52869af3b6d69e47922ba3de54fe",
+        "59c974009a2c26f7d267ae9736c71893a82ae69c19f344b87b4e3afd19f97e4d",
     ),
   "amazonka-elbv2":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "b063c7c71e2cbd027572c3777432a7404ec24d0957cc88ac8473b5ca7f03d858",
+        "2a53d35e29b613ac7261a3202023cb8221607fd8df5f034c572d6aa751c622c9",
     ),
   "amazonka-emr":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "5c5b92255086d6c50d99d82ac62d57c78ebbc1a591e78799d3091c342b61bb60",
+        "e9a07458ee61feadeff2e98fc83c1542320d5b97744225304dc1cc568ad9774f",
     ),
   "amazonka-gamelift":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "b87b1cdb85d6dba0d2d06579324c2b27fa1796a4e0bfc18a2107cff9b2c574da",
+        "ebcdbd4a43c8d02dc0a0d7302f4b27c8e106a783e910c5cdaa68a7a7ee775ffc",
     ),
   "amazonka-glacier":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "024793c865d9dd67da07816bb5227f0d3ab185aa571095ca1cd9a402ac9730fb",
+        "5307434d1fbddfba54b56ceb5eea2e5dfa3ece05b9353e61a998788af3e0f913",
     ),
   "amazonka-health":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "136243654071707eac190b2c646e04dd2913f309c6fb68fa6b6002a30252141f",
+        "c216b18e93e998ff04b00a5fc3ab6df8d36ef95d4b9988587eceb837615ba67b",
     ),
   "amazonka-iam":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "9a5d66048d36d1fef69168eaf122a6ec16c3602f09cc4c4f2b0ec2252681bcee",
+        "a335813a795c3d28400b95b94f1b14ada3e621e83d07cb9fd9c7e7edb285905d",
     ),
   "amazonka-importexport":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "3469b32680a2f6e8c20c3b3822ac358141d1eba81cef2c4197536d00cc34d569",
+        "0951f2bcd74e24c687ab39a044cfc9334b68fdb3c885d54693c918a1c97dcd04",
     ),
   "amazonka-inspector":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "66d88b2a2e4b043f396b84778bf440c35baf7b1c53f51749a7afa1e28d2bfa46",
+        "bcef005e38e63b742c1d7c63de84f582a447042a19ea611b1b617751f3cce13e",
     ),
   "amazonka-iot":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "9d36c1b6841648d1e5c9ab2c8ef5297bcbc0be9562586bbf196139b7fbdecd54",
+        "180b2169c97bd021e5f013cc72b64fe701270a7a5000950e20fa6373d38a26d0",
     ),
   "amazonka-iot-dataplane":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "45701875c5b5c41ea5924ab97b6cae41f373705d45796db04c7eb5799d694310",
+        "aee63bc0e6eca4cc4f76f7c8aa5e20f97e3f98268160006099014c66f4a88742",
     ),
   "amazonka-kinesis":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "6cd5d697dde3e39ec3930bacabaefe8d116cfe1ff951b3123163e4c7e16abd1d",
+        "549e41d29e46ff6aa485676436cb7cf15d2d37c2d0c62e6358b9b12b92e22f38",
     ),
   "amazonka-kinesis-analytics":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "99e69790c5d42097edc58c80da210ded3a5e2c5284cdd28251496a5ff3faeb1a",
+        "7efb5438596ef4541ebca35e4b87adf3c989bf88032be2d2e617bb14a7f685ee",
     ),
   "amazonka-kinesis-firehose":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "7f80feb9c546c8e4b907eaf9dc4b89368a3f746c10038140b1d57f55e32135c2",
+        "120545cdc888c031290b2f8a6745b911ebc6e2e5c077005067683118d197549c",
     ),
   "amazonka-kms":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a44ec473ba44f1a90e9828d3310bb9068aca18fb75510e7da560705b3ec05752",
+        "7aa5333583b494d0a5585f78ead67833a7e72942b264673ee8b91d7be89e8e99",
     ),
   "amazonka-lambda":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "bde6519b04db0ec4146ddae76db997b714feb1d406221a2b4ffacf3bd1289c12",
+        "649626896a7572979c5628e9406eb9be090106b7468473455e77aa59cec99b06",
     ),
   "amazonka-lightsail":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "7bdacf134fcb4acec69bc6906c889b29137a166c5e331ba6bbd5cefa7ef28bd9",
+        "741b4c6aff2f0e08fe9868aa858708a8ab36f95859bc0a9eecfdd9bd2060aceb",
     ),
   "amazonka-marketplace-analytics":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "8013a28ef701b2e10d33faac905a03095aa3eb9712f0bfa6a3e089a09914343a",
+        "4d6c0db0e9c17b5131c6b03cd27bc53fbddb144c3910d46639edfdccbecd5d6a",
     ),
   "amazonka-marketplace-metering":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "d3667751d6cdd7bbbbecff3d863cd08424d7c2abce6504cfc7dc425673cb37a9",
+        "672de14acac579673c8c3cf032c3806554355cc84ae1b61882a589af2afb5f77",
     ),
   "amazonka-ml":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "984badaa88a087799117c073fba500e5e1da3d23e08321780b5cf014a52d7751",
+        "9dc12d7b71a72ea720efe9de60668ab904adddfdfbe9c422f5ebda940a556dfe",
     ),
   "amazonka-opsworks":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "06af7f975198f386d8a4a2220f487b631bd0ddd52ee60d02ee216cd5bdf99ac1",
+        "9a4372339b8ec556331b0198b5faf74bd8116f0816176aa8626d31f3b372d918",
     ),
   "amazonka-opsworks-cm":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "8593c80d1dabb1526d0bc234d028f20e270884b5bf032504a85bc11b1a47c9f1",
+        "4f9e9b755f70fffd15cea08d0dfef5dc23ee4f822471f8e89f4d9b2f77a748f4",
     ),
   "amazonka-pinpoint":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "963fa4d6d5c41561add01f7adee2f83813d786fb7cfb77755bf365eebc294552",
+        "b0f8cdaabd9f357d5a687999ce83c7670f43023507ab9b25e94bc717f916b005",
     ),
   "amazonka-polly":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "f330c0de365543271bd481d0d74933a921fd8db05fe8544f30f49793d712b585",
+        "773edcfa2628cb9e616b9f1f5fab461cd6f0e5822dafa43fef4403c54e958ad0",
     ),
   "amazonka-rds":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "b6b7147e3108d49fa49cd5a476496944f31d5fe8a8aa45de593c05d91c022647",
+        "c793613c53773b3ba8c5db1fa342e68c25fcada39f8557c6ed39feb05f1bc24d",
     ),
   "amazonka-redshift":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "1e4f00c724ce597686b3104f236bb607fbd45214d364d4eb00846f0248af84d2",
+        "426ab96936e8d42ed85b31f076d99304148a6eb0896edbe90c6b1e570a90b329",
     ),
   "amazonka-rekognition":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2a918d96928ab7d7a10e08d7f2e6c04cf791bc84958d77b80807d8a120703fea",
+        "462e427021e5362747b155ba4f77e4c1d99d794087dca273697fae93aff532a8",
     ),
   "amazonka-route53":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "a421b26083991680bae75f67c8c98b353c8432d39cc67f79654847a50bb15469",
+        "68ef773bd9c44b28cb6166d86e3e499d9d32581915548ba08670f5cb1caa6317",
     ),
   "amazonka-route53-domains":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "83c2f5596dbaf896590aa5b138be71293ee96ba886cdd5401397f4601b14063b",
+        "f75bfe2f5f57c7367412479f3406cabcafa11a1436dd19f9a00ead6932e1a5ea",
     ),
   "amazonka-s3":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2f6bf829b143045d59a29d3aa4c6b65514e741162cd919d60d53bc806c73650f",
+        "eca18ebbd0df13a78768d9665827c7624282f76d512b3cf8f0f22a3afd463f47",
     ),
   "amazonka-sdb":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "43f907d9206d980fedacdeca4e375f681c742109bcd1c67aea0b099f094fefe5",
+        "b9c28b21326fdb78a0acee0968188ffb6fb156c7fe0faf688a2ec83d3f5fbdfd",
     ),
   "amazonka-servicecatalog":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2cf95f868368335a4015a085aba7515662f8012586faaaef5923c1969c027726",
+        "11f8df3b1b2b43ec636eb5a428c43c8534eae9d9554071298688005bcb46f264",
     ),
   "amazonka-ses":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "cea4d2d7a04c84b237fe3cd4cd9dfc80e18f9b5fa4089f35151fe250202269ad",
+        "778d32e738faae3fd1a7e12a67dddce063c0480740b95e1a58b5c23dc052bd02",
     ),
   "amazonka-shield":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "d8ce8bc1b42438907a2178b88aacde2252ca90eacb8940def35924daf10a85fb",
+        "b983a85b2b5a617bc3cbc911bc8d00a3fbf199ddd5dee67bdb3882b23747ebf4",
     ),
   "amazonka-sms":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "0966ff88e2d686b0749bdda729959469b0915cdc604d73af0b79f2041be10b7d",
+        "fc4d359d2988d7604780a5eca5b3371d3d3034180e96d2cbc6148559f0cda47f",
     ),
   "amazonka-snowball":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "2451536d632559274a315fa861929199244060bcf8291dee1146ca98e2c09f8f",
+        "534b30fe9205ba1edf8b1c5c4f4f91dccbe124f95a599f5efdf0cc4cd502ee25",
     ),
   "amazonka-sns":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "81b4ceac3519f19b8c620d7c6018a279a6eb78f20dcca8ebf13a3456f4507335",
+        "1d16b548031359ed593b14d172e7880847934e76bbedf535d014674414e37573",
     ),
   "amazonka-sqs":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "06fc91d8c46e0e87a505ba7f4d217618f6a6ecc33922e5849dd7d87054c9adc6",
+        "743838707d28707095700afdf2d875ff34c5fe1d90b214f5a7e48be04c900433",
     ),
   "amazonka-ssm":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "58667e2e4ecf94291da33a1cccb283977442d56047f73d8c217d3019c06efff4",
+        "11218249760a2d06cfd5ad2b41bf67233b6178f86e2ab979c199088a5a1c701a",
     ),
   "amazonka-stepfunctions":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "e20b83c1b94218191dea65f3019ffad3aa1f639e82b0cca7c821eb412bc27177",
+        "99ac8e545d28d7d765e180a26572d216f88d1e6ab9a2cd0f0a874992fa89acbf",
     ),
   "amazonka-storagegateway":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "0f269f4269d78f8fdba2ca741c69f09436626c05b629821746a0c21515f36429",
+        "6f06376650f03107ebd13a622b77b1983da91c6030927e2d10afb4040b48b43d",
     ),
   "amazonka-sts":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "1ee7da85be6da495b7ab877e5079821ad177a300acf3e18249fe220452048f30",
+        "36056b67d6f97a5b137f7ae35f39fb5417c61991333347129ed3e77f79a99a12",
     ),
   "amazonka-support":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "04dda81e97dbfe98e9c1dd7c2dd5acb75ac55672e8b07757a65748c3cdd1a1d9",
+        "7f434aef975f2817d4b9d7aa1c6055d788988e817fdb5c8fae20a787f26853e9",
     ),
   "amazonka-swf":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "441193b1ff65fc414379deae5514e0dbd1801d82bf19f857b1816e9b566bd125",
+        "1f0e437ba9c1511f46c64df16ae4551667fee39ade3c32f251f9e34b2255aa90",
     ),
   "amazonka-test":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "47e721ed18df6e89ee7efd13275501db262372f0737dbc184c860fa33ea91808",
+        "46a8b77900370524a487f2ca0490473e23d0155664db2461c5504678d275dd28",
     ),
   "amazonka-waf":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "8a2591b9ce3c0965aea5d44fa536753b34cde6c22717c9b99b16dae10430626f",
+        "880b9ec52be2d8fb0f5711d1e5357b0ce566e98b775e3bb7921e8f4295bbb980",
     ),
   "amazonka-workspaces":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "733e7105cb1200b30885dd20121e000c0364cab47a7440172817c8c957ed5ece",
+        "56cf348d8c519a4db23693e81cccf822975ec5b37e74dda54f9f020415c91c84",
     ),
   "amazonka-xray":
     struct(
-      version = "1.5.0",
+      version = "1.6.0",
       sha256 =
-        "f3819af0bfa70d5058c40e6254920499ec8ca4cccdc20d0f738ea24401453ac5",
+        "8f510075361aa600cd7759763f4de55aed07b8a7cce65eb445dfcf9f475590f0",
     ),
   "amqp":
     struct(
@@ -1636,27 +1395,15 @@ packages = (
     ),
   "ansi-terminal":
     struct(
-      version = "0.7.1.1",
+      version = "0.8.0.4",
       sha256 =
-        "6fc87697dfff772f7fbb4fe49e29c366b184f9ad288520831a9e0b572aa554fc",
+        "eb3cb8b0d0ce1c67ae3146c0b73a83e640c6f049d36bd6e859b6b951117e4810",
     ),
   "ansi-wl-pprint":
     struct(
       version = "0.6.8.2",
       sha256 =
         "a630721bd57678c3bfeb6c703f8249e434cbf85f40daceec4660fb8c6725cb3e",
-    ),
-  "ansigraph":
-    struct(
-      version = "0.3.0.5",
-      sha256 =
-        "2e8dcf6b182c0b0608f515582b780b7b9cf73a63ec8d1f4bf9ce4b3063397a0e",
-    ),
-  "apecs":
-    struct(
-      version = "0.2.4.7",
-      sha256 =
-        "1ad954536d6ed1c7f576c8bfd7150d9e69e6e1aa6c19dfe0691f21230a061d43",
     ),
   "api-field-json-th":
     struct(
@@ -1678,9 +1425,9 @@ packages = (
     ),
   "apply-refact":
     struct(
-      version = "0.4.1.0",
+      version = "0.5.0.0",
       sha256 =
-        "7c8eb33266ea4d8e3c668aa1f2f322421b78a83456703e2d0749edec79731502",
+        "1f5fb9b53f5750c5c73e36f93a708189e15f7300cd2fb95da77ba87a215b74af",
     ),
   "apportionment":
     struct(
@@ -1696,9 +1443,9 @@ packages = (
     ),
   "arithmoi":
     struct(
-      version = "0.6.0.1",
+      version = "0.7.0.0",
       sha256 =
-        "15cffd4c0349024fd5649b5f37c14ff0dc9e9177a4808c796a20c45d72291936",
+        "8b33049122c6194d61467b3685294c2c0029a3e877f481598f4b21b7285e030c",
     ),
   "array-memoize":
     struct(
@@ -1718,29 +1465,11 @@ packages = (
       sha256 =
         "33f836f23648aa2cea11533f7a9941127c397eecdca105b2084dded9e039d5d8",
     ),
-  "arrowp-qq":
-    struct(
-      version = "0.2.1.1",
-      sha256 =
-        "258ee29e14727d35efa04c682b35a510c09c0ec24f0096e838a786f194d4ac6b",
-    ),
-  "arrows":
-    struct(
-      version = "0.4.4.1",
-      sha256 =
-        "5b104bd8f8fac5ad0fd194088819423302e52c2a796cc99f6d32bbc134bfebe2",
-    ),
   "ascii-progress":
     struct(
       version = "0.3.3.0",
       sha256 =
         "7e3fa6b80c09a83c9ba8a0644ef304ca92d65b76383b8dd023ff9f89ebec913e",
-    ),
-  "asciidiagram":
-    struct(
-      version = "1.3.3",
-      sha256 =
-        "694948f5f408aa7dfcab17ffefb74e413f1d3dacf2c523bfbf9ecaf972645f18",
     ),
   "asn1-encoding":
     struct(
@@ -1768,21 +1497,15 @@ packages = (
     ),
   "astro":
     struct(
-      version = "0.4.2.0",
+      version = "0.4.2.1",
       sha256 =
-        "86fdc23f0420d46e5cf65cb657c448a61c9398163c312ecb8b4344925ffd47ae",
+        "da5dde1bcf42e4f48f5f23dbf3a890a2904ecaf86df3d75e365e071b924afe29",
     ),
   "async":
     struct(
-      version = "2.1.1.1",
+      version = "2.2.1",
       sha256 =
-        "cd83e471466ea6885b2e8fb60f452db3ac3fdf3ea2d6370aa1e071ebc37544e2",
-    ),
-  "async-dejafu":
-    struct(
-      version = "0.1.3.0",
-      sha256 =
-        "d893a14c85af9cb947e3b3298b77c3665112a54cc8876dca8fc08e6871952afd",
+        "8f0b86022a1319d3c1c68655790da4b7f98017982e27ec3f3dbfe01029d39027",
     ),
   "async-extra":
     struct(
@@ -1792,21 +1515,21 @@ packages = (
     ),
   "async-refresh":
     struct(
-      version = "0.2.0.2",
+      version = "0.3.0.0",
       sha256 =
-        "9a328b67a12980b26360ae7dac30a92f059f78327ead2e2ccf22bcfd6c8201c3",
+        "da68061b2548a9b5b3e6f4af60120554ebfae9638dfa0b10cf7a244710a334c9",
     ),
   "async-refresh-tokens":
     struct(
-      version = "0.3.0.1",
+      version = "0.4.0.0",
       sha256 =
-        "bdedc61d44eac7a36442f1a3af51d9a9e7b84901e1fe316a96b9286a5bfea796",
+        "67a7419449428fc5f80e9cfc392df115f03721811d6cd73a6c7cbd83f48dc7df",
     ),
   "async-timer":
     struct(
-      version = "0.1.4.0",
+      version = "0.2.0.0",
       sha256 =
-        "638eeb8107f7fe9c845097ab858cf423a23a111479cbf68e23b45e0e70876d02",
+        "0632bfc4c141aa47c461747b3edb59f76ef5523a66ac03be0f32868a5e04cee0",
     ),
   "atom-basic":
     struct(
@@ -1822,9 +1545,9 @@ packages = (
     ),
   "atomic-primops":
     struct(
-      version = "0.8.1.1",
+      version = "0.8.2",
       sha256 =
-        "90f579c60f5affffc171ec3a4eaacc048120c0f174063b42f355d63247442172",
+        "67f8872e0c1e634d819a967365eb4ad514e9b2cde967fbc710da7cdc4d17d933",
     ),
   "atomic-write":
     struct(
@@ -1837,6 +1560,12 @@ packages = (
       version = "0.13.2.2",
       sha256 =
         "dd93471eb969172cc4408222a3842d867adda3dd7fb39ad8a4df1b121a67d848",
+    ),
+  "attoparsec-base64":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "0833530c8b4a46217272d14638f91325e156b22046fa291b528228afe66173e7",
     ),
   "attoparsec-binary":
     struct(
@@ -1870,15 +1599,15 @@ packages = (
     ),
   "attoparsec-uri":
     struct(
-      version = "0.0.3",
+      version = "0.0.4",
       sha256 =
-        "d6a0f0a2202acdcbb60a75640e042dc48d0951f1286d3adf3bf7a366df7c09d9",
+        "4e032ccaa65f96edac79556431ade75ad400371d0a5c19aeed6a7adbd3d2f1f3",
     ),
   "audacity":
     struct(
-      version = "0.0.1.2",
+      version = "0.0.2",
       sha256 =
-        "4bd172addb40f3876dc0dbe50b05b88561d9871e06d73ce49540bee0ccdcc9b5",
+        "d9d2dfb1c4e6ad39b535561feb720a7889dc1151ad6625fd5522d4212dbc26a4",
     ),
   "authenticate":
     struct(
@@ -1906,27 +1635,15 @@ packages = (
     ),
   "autoexporter":
     struct(
-      version = "1.1.3",
+      version = "1.1.10",
       sha256 =
-        "d5ec955e0808bdf58f88be06d4f856ecd7415c348201029150c6daefb6586f66",
+        "1938c27312af0adef6e2fc60a2870fd92dfe366800a420337bb6d46f0f44c265",
     ),
-  "avers":
+  "avro":
     struct(
-      version = "0.0.17.1",
+      version = "0.3.2.0",
       sha256 =
-        "1b45d8aa036b3c2ec7ea180327ff3cdce28dc1e1ef319c062be79f0ffa7626f5",
-    ),
-  "avers-api":
-    struct(
-      version = "0.1.0",
-      sha256 =
-        "5c1765976fd1ac49444023452e31cbe5200fd9c8480e1927aa4334e8752d5a3e",
-    ),
-  "avers-server":
-    struct(
-      version = "0.1.0",
-      sha256 =
-        "1f80f4c234cba9627e190a4fe5d180fd7c8ab6627650beaa856e050aca4d0055",
+        "40053917302ac3c3af9f077756dd8e1b0765a9d99f344baa2bcf8a5b0ea6d610",
     ),
   "avwx":
     struct(
@@ -1934,41 +1651,17 @@ packages = (
       sha256 =
         "b4299cc4e05a4c94f53d06f05b30baac1e15c59663b59afd1dd32417a280fb0a",
     ),
-  "aws":
-    struct(
-      version = "0.18",
-      sha256 =
-        "b2e738b0767b735d4bf297055bf12b586670ae2bb33457fa97bdb03df938e440",
-    ),
-  "axiom":
-    struct(
-      version = "0.4.6",
-      sha256 =
-        "8365128ce841379023fee062c16ad1d31c27260f5d994a0a49d9d1fae7cae844",
-    ),
-  "b9":
-    struct(
-      version = "0.5.35",
-      sha256 =
-        "5b059a37c176e08a8f35ae0333d46e41b68a08c9f3dc80dbf93d593840ae4286",
-    ),
   "backprop":
     struct(
-      version = "0.0.3.0",
+      version = "0.2.5.0",
       sha256 =
-        "ae199a345a134f2251deec151cd7d32cbe28f327a142fb3c5ed883e992d858e6",
-    ),
-  "bake":
-    struct(
-      version = "0.5",
-      sha256 =
-        "1cc3b57b6270a2c80f0b0a8b90fc3929eb0d1da9e113d18bc10d92b40a2d60f5",
+        "aa2dbe41de6aa015cd3c0d9edb21ab24254d19b9205fbc440fc2a6cbccae6bf5",
     ),
   "bank-holidays-england":
     struct(
-      version = "0.1.0.6",
+      version = "0.1.0.7",
       sha256 =
-        "57ed284bffdadcaf3dd26795de9815c032c5876034e5200216ae21ac94f434ab",
+        "7a4af621db84fba450edcab43d275b5c3f5f8bf3ed5b5211d75e5275986ad4a4",
     ),
   "barrier":
     struct(
@@ -1978,21 +1671,27 @@ packages = (
     ),
   "base-compat":
     struct(
-      version = "0.9.3",
+      version = "0.10.4",
       sha256 =
-        "7d602b0f0543fadbd598a090c738e9ce9b07a1896673dc27f1503ae3bea1a210",
+        "0d693707a70bcb553acd133129a9fbca0ea257eeebe714700de3e8fe404a574f",
+    ),
+  "base-compat-batteries":
+    struct(
+      version = "0.10.1",
+      sha256 =
+        "15578bafe45db81f7c7ad33253b2b047dab9b6df4ca7ca57f541d64084f113c9",
     ),
   "base-orphans":
     struct(
-      version = "0.6",
+      version = "0.7",
       sha256 =
-        "c7282aa7516652e6e4a78ccdfb654a99c9da683875748ad5898a3f200be7ad0e",
+        "0aaddc39e3d0bba13acfcf0009ef57bf91d2ee74b295041d63e14c6caf4dee14",
     ),
   "base-prelude":
     struct(
-      version = "1.2.0.1",
+      version = "1.3",
       sha256 =
-        "811a494f5996ff1012be15a1236cc4afb6a67fc2a9f54fdb53f4e94a8fde119e",
+        "e3cc66e99d6c83aac548c4d8e6a166e5bd9cf557947cde49161026d0341267fe",
     ),
   "base-unicode-symbols":
     struct(
@@ -2024,6 +1723,12 @@ packages = (
       sha256 =
         "ab25abf4b00a2f52b270bc3ed43f1d59f16c8eec9d7dffb14df1e9265b233b50",
     ),
+  "base64-bytestring-type":
+    struct(
+      version = "1",
+      sha256 =
+        "74019bd11f8012ae5ccc88c206bc5a8024f7605130099aabbac012073160e440",
+    ),
   "base64-string":
     struct(
       version = "0.2",
@@ -2032,9 +1737,9 @@ packages = (
     ),
   "basement":
     struct(
-      version = "0.0.4",
+      version = "0.0.8",
       sha256 =
-        "68448325bacc85dcb8764d9f78d27285b56e978df03187bee912edbf1adab8fd",
+        "c7f41b97f2b0a71804c3c7d760047dc9adc9734e789084ca1198c4764ce192a4",
     ),
   "basic-prelude":
     struct(
@@ -2054,17 +1759,23 @@ packages = (
       sha256 =
         "e4331788eda7b65064d88930b4b7a50f5011bdec0ad46059d8c4ee6a5e72fcef",
     ),
+  "beam-core":
+    struct(
+      version = "0.7.2.2",
+      sha256 =
+        "1231aedb995f40758924ad39d3476a51b3a186e5e849f3d4b284860838500f98",
+    ),
+  "beam-migrate":
+    struct(
+      version = "0.3.2.1",
+      sha256 =
+        "2d195926ead3ed550e5efddd32f87f4cc93a5bad6ac8c2906478387ed0f39373",
+    ),
   "bench":
     struct(
-      version = "1.0.8",
+      version = "1.0.11",
       sha256 =
-        "74d388f69d638bcc42a6e1610555ed420b8ec44b1646912cb5d6fbf0fd949ea2",
-    ),
-  "benchpress":
-    struct(
-      version = "0.2.2.10",
-      sha256 =
-        "e6b0c5ef9e880a866cb438cc1c7efe83bc69ddbc5b0e941833495e43456f39c7",
+        "a84e6faa55e62b7cb9f7d28a1d1828298f1c37b24c2a16da86954a35534a3b97",
     ),
   "bencode":
     struct(
@@ -2072,23 +1783,11 @@ packages = (
       sha256 =
         "3b8efdfecee9bc486d9bcdbb633b7128ca235360f102478a7e0f8c895281f68a",
     ),
-  "bento":
-    struct(
-      version = "0.1.0",
-      sha256 =
-        "eba28420daba13af9de264ec0e3d605535496536b9aff9bc23798cdbcc209192",
-    ),
   "between":
     struct(
       version = "0.11.0.0",
       sha256 =
         "8337351326c5a613d9b7520b6a8203234c04454e23550a81739beaa6f671465d",
-    ),
-  "bhoogle":
-    struct(
-      version = "0.1.2.5",
-      sha256 =
-        "519e7f2c8c0c49f27da2b58cdbe9710183bf1e4d912395e30781821d917b259a",
     ),
   "bibtex":
     struct(
@@ -2098,9 +1797,9 @@ packages = (
     ),
   "bifunctors":
     struct(
-      version = "5.5.2",
+      version = "5.5.3",
       sha256 =
-        "332bb2ea19e77dac55282daff8046d89f69514ced5b987779d887e53b5d7cb11",
+        "d434528fd2ea765bace57c4ade0bc9fa32ba2c425f563b33a4b60f625ecfc9ca",
     ),
   "bimap":
     struct(
@@ -2122,9 +1821,15 @@ packages = (
     ),
   "binary-conduit":
     struct(
-      version = "1.2.5",
+      version = "1.3",
       sha256 =
-        "21d417aae0f9441ecd0e4f5aaac03bf9692fb9e85e48076c774d961567d14b1b",
+        "43f9bd47b679b552b295132680a8cd0ade6489fc33d5d98aed1f5c948320cccd",
+    ),
+  "binary-ext":
+    struct(
+      version = "2.0.4",
+      sha256 =
+        "6e58e19bde26d6f271916ceb43a28903136e28cf7868d86f65e68a60152ade08",
     ),
   "binary-ieee754":
     struct(
@@ -2170,21 +1875,21 @@ packages = (
     ),
   "binary-tagged":
     struct(
-      version = "0.1.4.2",
+      version = "0.1.5",
       sha256 =
-        "311fab8c2bac00cb6785cb144e25ed58b2efce85e5dc64e30e2b5a2a16cdc784",
+        "d4b733a9013069f19249acad76e7f73fb41303c44dcbd2229de8d534558605e8",
     ),
   "bindings-DSL":
     struct(
-      version = "1.0.24",
+      version = "1.0.25",
       sha256 =
-        "234d8f51dece232e4926943c11427e621757c856be0f27a0a104e7dc71f9c80e",
+        "63de32380c68d1cc5e9c7b3622d67832c786da21163ba0c8a4835e6dd169194f",
     ),
   "bindings-GLFW":
     struct(
-      version = "3.1.2.3",
+      version = "3.2.1.1",
       sha256 =
-        "33ee17f169e5faa7cbdb07743550439a1918e99855c0cc546c96f72b57e7b5f6",
+        "6b24c66b20ebfd8ff2e4ac32e3b435889bba0a32477598ba69fc7adc9608160e",
     ),
   "bindings-libzip":
     struct(
@@ -2197,42 +1902,6 @@ packages = (
       version = "0.1",
       sha256 =
         "130e75c3fd95e232452c7d903efbfab2d2ff6c9d455b617adeaebe5d60235cd3",
-    ),
-  "bioace":
-    struct(
-      version = "0.0.1",
-      sha256 =
-        "6f43645b2a0ccbca20069aa25fae6fc2ae1704a3a0c48b069852fbfb8ce16222",
-    ),
-  "bioalign":
-    struct(
-      version = "0.0.5",
-      sha256 =
-        "b9152e81abbd7c79099520b69aeca3ff21970f1151b3c072a2994ea31b7acf00",
-    ),
-  "biocore":
-    struct(
-      version = "0.3.1",
-      sha256 =
-        "212b7d7395138d4c231968e1f5bb047c03f61adc6c5eb36162602f42c24db41a",
-    ),
-  "biofasta":
-    struct(
-      version = "0.0.3",
-      sha256 =
-        "6221a89cde259e8f9a2d4da11230a8a53d78b24d3367e70be5e7b1279e06e7d0",
-    ),
-  "biofastq":
-    struct(
-      version = "0.1",
-      sha256 =
-        "74e51887569c4900f5de266eca0dd28082c8abdf6ef0f34787a91baec562a310",
-    ),
-  "biopsl":
-    struct(
-      version = "0.4",
-      sha256 =
-        "b2be254020a276df342ede835a1c1b1b989763098d7d8a5536c0b86c5f7a3bed",
     ),
   "bit-stream":
     struct(
@@ -2288,6 +1957,12 @@ packages = (
       sha256 =
         "657e557bb913b53fb3b3fc7eda820cf3c85a5b89692d242275d3e8e8d9479c93",
     ),
+  "bits-extra":
+    struct(
+      version = "0.0.1.3",
+      sha256 =
+        "692b08b3e9a490f5b2776b8f20277320fad247d9c4ea158225fee0f27f91afed",
+    ),
   "bitset-word8":
     struct(
       version = "0.1.1.0",
@@ -2296,9 +1971,9 @@ packages = (
     ),
   "bitx-bitcoin":
     struct(
-      version = "0.11.0.1",
+      version = "0.12.0.0",
       sha256 =
-        "926a57fb85bd42185c2e8abb00e6ff309062abb6b24fce2eef61507896fb219c",
+        "31f2398bbb0deff80361fdabb108c1552ae097b15a44c6ca6674977ae735c871",
     ),
   "blake2":
     struct(
@@ -2308,33 +1983,27 @@ packages = (
     ),
   "blank-canvas":
     struct(
-      version = "0.6.2",
+      version = "0.6.3",
       sha256 =
-        "0461ff6b4b72f67dbe8cfadaebcd194ee3c15deb59b7a435d89672a462df0de2",
+        "739d24ff7035fd675e95c2d33bd9d3cb7d1ef0cca94c16bbf950c4a7f7b320b4",
     ),
   "blas-carray":
     struct(
-      version = "0.0",
+      version = "0.0.1.1",
       sha256 =
-        "6642e4b2fdc7d91fcf7d75b767814a0ef3c8418f4cb9cb612f94fcd772f9338c",
+        "bdad1b777d36e46a63bec022190bd009d2782018d7a447f41e3c2db772635f46",
     ),
   "blas-ffi":
     struct(
-      version = "0.0",
+      version = "0.0.1.1",
       sha256 =
-        "42330c392ebc4595db313279d51996c5730cce34e050577662260d7df3926d9c",
+        "ee0d88ad15d127e08dd273264befe2259bb64646156adb9e830aa8692dc3f036",
     ),
   "blas-hs":
     struct(
       version = "0.1.1.0",
       sha256 =
         "80e06b0927982b391d239f8656ed437cd29665969d1a078ea4e42a2bf196b086",
-    ),
-  "blastxml":
-    struct(
-      version = "0.3.2",
-      sha256 =
-        "0c0089c42306c8189a9a26905677372d26adfde03772ae79b4742771d0de986a",
     ),
   "blaze-bootstrap":
     struct(
@@ -2344,21 +2013,27 @@ packages = (
     ),
   "blaze-builder":
     struct(
-      version = "0.4.0.2",
+      version = "0.4.1.0",
       sha256 =
-        "9ad3e4661bf5556d650fb9aa56a3ad6e6eec7575e87d472e8ab6d15eaef163d4",
+        "91fc8b966f3e9dc9461e1675c7566b881740f99abc906495491a3501630bc814",
+    ),
+  "blaze-colonnade":
+    struct(
+      version = "1.2.2",
+      sha256 =
+        "1f2f7116ffea5ad2a04337b9bdc1277de0b12a71fb4b830b216c37911d8ea14c",
     ),
   "blaze-html":
     struct(
-      version = "0.9.0.1",
+      version = "0.9.1.1",
       sha256 =
-        "aeceaab3fbccbf7f01a241819e6c16c0a1cf19dccecb795c5de5407bc8660a64",
+        "ea0e944298dbbd692b41af4f15dbd1a1574aec7b8f91f38391d25106b143bb1b",
     ),
   "blaze-markup":
     struct(
-      version = "0.8.2.0",
+      version = "0.8.2.1",
       sha256 =
-        "4436af476abb3420e246c1ab7ce8dc95af250b76b6955776252717d97d1e7054",
+        "90ab7cbc29df9fbe24e208ade58ca9828e3074f1163618f1faaf4da8f0600146",
     ),
   "blaze-svg":
     struct(
@@ -2371,24 +2046,6 @@ packages = (
       version = "0.2.1.0",
       sha256 =
         "1042795ab0bab891c034c24a51bafecbb89870ccd28af39534ab3d9ae7f46c2d",
-    ),
-  "bloodhound":
-    struct(
-      version = "0.15.0.2",
-      sha256 =
-        "3109a143ccb0f7aac7d2346926a3769ceffd0ed0122f4670e0b589330b02bc9f",
-    ),
-  "bloomfilter":
-    struct(
-      version = "2.0.1.0",
-      sha256 =
-        "6c5e0d357d5d39efe97ae2776e8fb533fa50c1c05397c7b85020b0f098ad790f",
-    ),
-  "blosum":
-    struct(
-      version = "0.1.1.4",
-      sha256 =
-        "44b12d24d56bfadec7a53c1d620e1cc52f4126ba01ab541a135b187846c10380",
     ),
   "bmp":
     struct(
@@ -2404,15 +2061,9 @@ packages = (
     ),
   "boltzmann-samplers":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.1.0",
       sha256 =
-        "5707065a83cb30223ffedbd740ac07d3d879bb0895ba7666d23d659e3b69883f",
-    ),
-  "bookkeeping":
-    struct(
-      version = "0.2.1.4",
-      sha256 =
-        "ff4294e6c9c03c99cdcda31586ffaedde1f20a4d21fbdd28b2f82a5754ea27e4",
+        "de7c3e1f77b0ae27c78cb53e539dbaa8dc2f6e3f3605c25f1611545806ad878e",
     ),
   "boolean-like":
     struct(
@@ -2426,17 +2077,17 @@ packages = (
       sha256 =
         "096fa9377241520ee114403fd53b51a7369187fb4dca65f19f85a727d689828f",
     ),
-  "boomerang":
-    struct(
-      version = "1.4.5.3",
-      sha256 =
-        "d461a3df761b4d0fd1923060fa08efecd0921fb33dbeb628165e7e5efa089388",
-    ),
   "bordacount":
     struct(
       version = "0.1.0.0",
       sha256 =
         "cb691095f688dc2c1726750d5e5d267d3f49466377869a574d6416090a46fdce",
+    ),
+  "boring":
+    struct(
+      version = "0.1",
+      sha256 =
+        "73d60829c3a789f3d377d56ce7844aaaea6b517bcea43e06579ab785181b4664",
     ),
   "both":
     struct(
@@ -2464,21 +2115,21 @@ packages = (
     ),
   "boxes":
     struct(
-      version = "0.1.4",
+      version = "0.1.5",
       sha256 =
-        "4e3ee9a88a28ed14a61b2c885b111922f201f56392ff68d350418ff6e98dfdd8",
+        "38e1782e8a458f342a0acbb74af8f55cb120756bc3af7ee7220d955812af56c3",
     ),
   "brick":
     struct(
-      version = "0.29.1",
+      version = "0.37.2",
       sha256 =
-        "3fa5118b7f7ff8039eb3eb9386bd06500adb7b7184c44f7a3ae3e587b5c354cb",
+        "7cb86cd88d344d4a8b997677f805e3a3adaecf37d65478e06081737efbc1d99c",
     ),
   "brittany":
     struct(
-      version = "0.9.0.0",
+      version = "0.11.0.0",
       sha256 =
-        "813dade700e6506c7df1c39a85799be3b5e96e84bd0cb8aa867cc5e5d13d283a",
+        "46a80e13ff5543913d6f019a58ad7f0b2dc34faa190dc0d0d4ecf882498decb9",
     ),
   "broadcast-chan":
     struct(
@@ -2486,11 +2137,17 @@ packages = (
       sha256 =
         "ad5bd65a301aff6df38c4111f02e73cce3bcfed7bfae6c66c2e70310f1e985f2",
     ),
+  "bsb-http-chunked":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "28cb750979763c815fbf69a6dc510f837b7ccbe262adf0a28ad270966737d5f4",
+    ),
   "bson":
     struct(
-      version = "0.3.2.3",
+      version = "0.3.2.6",
       sha256 =
-        "9b3aba435365cdfbbd0ba8ccb3400e961d56329da57f6de2e1e391004c374982",
+        "738dc3615aafa1dd553f51a67373af2f27db90e75266ed6cdee5cecb7f6fce80",
     ),
   "bson-lens":
     struct(
@@ -2506,9 +2163,9 @@ packages = (
     ),
   "buffer-builder":
     struct(
-      version = "0.2.4.4",
+      version = "0.2.4.6",
       sha256 =
-        "01c0bafb776784a08c041abfc89c3eaee3236bf5555b98e9542676dc43db2dd8",
+        "54383e4d9a412eeefd06ec6b92db065347536b0917f5d2d94fe9cdc472b15d64",
     ),
   "buffer-pipe":
     struct(
@@ -2518,15 +2175,27 @@ packages = (
     ),
   "butcher":
     struct(
-      version = "1.2.1.0",
+      version = "1.3.1.1",
       sha256 =
-        "5c0cf0d0c835aeb8e5a7a4f9a3d7224c5b3acc65eba4d44cc9688abb302d556d",
+        "1f1ca26d2f0657f1762a60d623e065132d57aabe84ef494255c7918a1ed690d2",
+    ),
+  "butter":
+    struct(
+      version = "0.1.0.6",
+      sha256 =
+        "8640b2681a57c0bc545684c821e80a97d57fe14bc6036e9030dc4cc63c2e4164",
     ),
   "bv":
     struct(
-      version = "0.4.1",
+      version = "0.5",
       sha256 =
-        "dd092150f1792e76e168365d69798d3a27b911ce9de8b21a47c5fed42acf45bb",
+        "04a189ab1758f6adc51ffff0a10705d8c8b54959946a90a3b9a750c930c77bda",
+    ),
+  "bv-little":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "68e6d6d1ed6922e92e471e93ecb5c643f28f2e9c761f9c1a3697e9527c696b94",
     ),
   "byteable":
     struct(
@@ -2548,9 +2217,9 @@ packages = (
     ),
   "bytes":
     struct(
-      version = "0.15.3",
+      version = "0.15.5",
       sha256 =
-        "d8dcd6b66492db37e48b95535cf3bf91b1b0f356fedba403eb73f81158e0cd4d",
+        "039935e6b367eb8657aa3eb109e719b257a06524b0d9ff5246e8029bb7a07118",
     ),
   "byteset":
     struct(
@@ -2578,21 +2247,15 @@ packages = (
     ),
   "bytestring-strict-builder":
     struct(
-      version = "0.4.5",
+      version = "0.4.5.1",
       sha256 =
-        "cf192d9951a42cf76f35c4b6dcc8d04868c5df3e279b7b29079ebcd076f8f3ce",
+        "1879edb56e530169f5c4a738fff46ac56faeb30f9ac3d59f1361183111a5c69e",
     ),
   "bytestring-tree-builder":
     struct(
-      version = "0.2.7.1",
+      version = "0.2.7.2",
       sha256 =
-        "ae03a5b2e24068870dfcff6c6dc8d6d243aaebdb7c66746d499e7cf6cfd16bd5",
-    ),
-  "bytestring-trie":
-    struct(
-      version = "0.2.4.1",
-      sha256 =
-        "2fe4feb526a03d32aaf673506623b3af4ce3fee126f745a8852c5fd676a61363",
+        "a12df2ef970eab34c7bb968ba1a157fb01e478cd9abada097fc3e4ec61b5020e",
     ),
   "bzlib":
     struct(
@@ -2602,15 +2265,15 @@ packages = (
     ),
   "bzlib-conduit":
     struct(
-      version = "0.2.1.5",
+      version = "0.3.0.1",
       sha256 =
-        "5685c0e4f7778a6bcdc6b41eb4f6b5d21190441ecf80dec2a3c62d67324667af",
+        "43d811549f7fb0710e4895ad54f78418271579f7e27d75e3c3470b74b285a239",
     ),
   "c2hs":
     struct(
-      version = "0.28.3",
+      version = "0.28.5",
       sha256 =
-        "80cc6db945ee7c0328043b4e69213b2a1cb0806fb35c8362f9dea4a2c312f1cc",
+        "bd10ab1260f5c838bbe239170d11d44ca2d7caef683f0d4df5190dc64e4a2df6",
     ),
   "cabal-doctest":
     struct(
@@ -2618,47 +2281,53 @@ packages = (
       sha256 =
         "decaaa5a73eaabaf3c4f8c644bd7f6e3f428b6244e935c0cf105f75f9b24ed2d",
     ),
-  "cabal-file-th":
-    struct(
-      version = "0.2.4",
-      sha256 =
-        "0b55d7ffacd0c6324fa7c8b8f148e788e6b899fb9bf8795285dea66575bed91c",
-    ),
   "cabal-install":
     struct(
-      version = "2.0.0.1",
+      version = "2.2.0.0",
       sha256 =
-        "f991e36f3adaa1c7e2f0c422a2f2a4ab21b7041c82a8896f72afc9843a0d5d99",
+        "c856a2dd93c5a7b909597c066b9f9ca27fbda1a502b3f96077b7918c0f64a3d9",
     ),
   "cabal-rpm":
     struct(
-      version = "0.12",
+      version = "0.12.4",
       sha256 =
-        "0e092375d137916ffe0b788b6cb88e2f8f26b36e03b81665c0cafcc638ce6516",
-    ),
-  "cabal-toolkit":
-    struct(
-      version = "0.0.5",
-      sha256 =
-        "98ad3cc723fd196fd25b3ac4bea2b50bad0cc2d5f24d5557785184bb55396cf0",
+        "62a466f0805c2ca2fca3d8241571a90a766c31bacd2188ef4583f153aa5dfaf3",
     ),
   "cabal2nix":
     struct(
-      version = "2.7.2",
+      version = "2.9.3",
       sha256 =
-        "1efe847160adda73c9cf7bb39426e4522a95e9338b5048d171fdc27a4f52e68c",
+        "129fcefe74fcb0c15aa4747603116820d751b0ea904376cd1603381a339a8182",
+    ),
+  "cabal2spec":
+    struct(
+      version = "2.1.1",
+      sha256 =
+        "ad063835309823388883324a42d951f15c5da9b4e324bfe3de97751f4fdca9ba",
     ),
   "cache":
     struct(
+      version = "0.1.1.0",
+      sha256 =
+        "14756f8383e991affe6120d299ba23c4f53753519700f8a771cfcec9782b78ff",
+    ),
+  "cachix":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "94f1c5ba33ff9c34d5e06e756ae8aa7c38c9a71e436e539d154f3722e4b06ae4",
+    ),
+  "cachix-api":
+    struct(
       version = "0.1.0.1",
       sha256 =
-        "0d0713104e109e788a338cbc1fd4c36c19fcb1cf0334553e80ef41e768d2672f",
+        "c60feb84da86c12d3dc72095c875b56f7b34c752864eb408c3de6384225b2d7d",
     ),
   "cairo":
     struct(
-      version = "0.13.4.2",
+      version = "0.13.5.0",
       sha256 =
-        "0fe675cda4a00ffeee4cecdbf858b9634433ab9a2bb9f021ff4ee6198f19a36a",
+        "420acd81e0b5578ad188bcdd38463135293c233221abb741cc4004d4c8a6bef3",
     ),
   "calendar-recycling":
     struct(
@@ -2672,23 +2341,23 @@ packages = (
       sha256 =
         "f25f5e0992a39371079cc25c2a14b5abb872fa7d868a32753aac3a258b83b1e2",
     ),
+  "capataz":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "a4dfc60ccd24bb3102127cb0226f23abfc12b7263fe45e74747cf674d736022c",
+    ),
   "carray":
     struct(
       version = "0.1.6.8",
       sha256 =
         "8f1967d54c7cf9680481c6f630eafa66f6d916b93c98f3b3c47449f682f11613",
     ),
-  "cartel":
-    struct(
-      version = "0.18.0.2",
-      sha256 =
-        "7b27aa2cbeb73b1d5bf93214f290275025c3231fee23b32d80de104ec76ec270",
-    ),
   "case-insensitive":
     struct(
-      version = "1.2.0.10",
+      version = "1.2.0.11",
       sha256 =
-        "66321c40fffb35f3a3188ba508753b74aada53fb51c822a9752614b03765306c",
+        "a7ce6d17e50caaa0f19ad8e67361499022860554c521b1e57993759da3eb37e3",
     ),
   "cased":
     struct(
@@ -2704,9 +2373,9 @@ packages = (
     ),
   "casing":
     struct(
-      version = "0.1.2.1",
+      version = "0.1.4.0",
       sha256 =
-        "a8bff2e6ed42915a472fa6f62873d78f21c2d31390845a8d3b5ea2638101a638",
+        "8e8a3631ef5823ae53dfeb7497ad4856c6758e3e380ff164f6a261f41685f6d7",
     ),
   "cassava":
     struct(
@@ -2716,15 +2385,15 @@ packages = (
     ),
   "cassava-conduit":
     struct(
-      version = "0.4.0.1",
+      version = "0.5.0",
       sha256 =
-        "3e49fa4589f71feae0e31241c1fbd17639f22fd52a789a16829cc13141a69f78",
+        "19460ab99942455cc12fa38b15c07da80df496eb5494675e7e524d197d874876",
     ),
-  "cassette":
+  "cassava-records":
     struct(
-      version = "0.1.0",
+      version = "0.1.0.4",
       sha256 =
-        "fd40b3fd44eebce549216f3a4c1852f5b109edddfff3d6d7e243b64574981613",
+        "11f832c11125bd7a73b57941284d9aeb7f1e7572004da7e37311b34d3366af8d",
     ),
   "cast":
     struct(
@@ -2732,11 +2401,11 @@ packages = (
       sha256 =
         "24d545e5974436b6e3ee9dfda7ed68218c9f698103adae676a60860d90d7bc91",
     ),
-  "cayley-client":
+  "category":
     struct(
-      version = "0.4.2",
+      version = "0.2.0.1",
       sha256 =
-        "e81bada32bb28f53c1c5f1885959122f6a4fae2d9ee0d76d3d226acce4c9fadf",
+        "07d0b37638ec5c46d96874c9318ca385ea489ae0538c62e9c559b6f56809ab6c",
     ),
   "cereal":
     struct(
@@ -2746,9 +2415,9 @@ packages = (
     ),
   "cereal-conduit":
     struct(
-      version = "0.7.3",
+      version = "0.8.0",
       sha256 =
-        "05bf926a6292ad6e17f2667c248c33f820266ea8a703749923cc936a824c00a2",
+        "d95c4518a9984feacfd811c64be993705bff74c1f2daa00b4687bbb79f3a39eb",
     ),
   "cereal-text":
     struct(
@@ -2768,6 +2437,18 @@ packages = (
       sha256 =
         "ff0685a6c39e7aae32f8b4165e2ae06f284c867298ad4f7b776c1c1b2859f933",
     ),
+  "cfenv":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "8ce96643559ebe4504c0641f9817d8795b22631f614084af50c88e51277e747e",
+    ),
+  "chan":
+    struct(
+      version = "0.0.3",
+      sha256 =
+        "f9e988023fd53fc60b00fbb5546f9e75045ab1dc83e21aa0c56288c681072232",
+    ),
   "charset":
     struct(
       version = "0.3.7.1",
@@ -2776,15 +2457,15 @@ packages = (
     ),
   "charsetdetect-ae":
     struct(
-      version = "1.1.0.3",
+      version = "1.1.0.4",
       sha256 =
-        "fed4d478a49dec246e7ac0dd989d90dc6fd6499f9bc83774409a4504ce4b6e96",
+        "9bbaa48d3026abdd403ed59ee5f41978b2f5be6d0dc545e142c86d5aa790410c",
     ),
   "chart-unit":
     struct(
-      version = "0.5.5.0",
+      version = "0.7.0.0",
       sha256 =
-        "f9008b6b30963a12a56f1b4f7554c0947c691e31c2a79caf7742c0131e735343",
+        "97f893f3a9f28cf93d8ad30991ed6fec04c908e8a5bbc4f8e018f06a00bab20e",
     ),
   "chaselev-deque":
     struct(
@@ -2794,9 +2475,9 @@ packages = (
     ),
   "chatwork":
     struct(
-      version = "0.1.3.0",
+      version = "0.1.3.4",
       sha256 =
-        "247b866bd3b9a74bb67b4550776b4102606f4da7fc2e7d054d8161b2852bdaac",
+        "624f2cc2ea0d1e967170099646c112c35329b947d6354ff6a79fb6c4b15b289b",
     ),
   "cheapskate":
     struct(
@@ -2824,15 +2505,27 @@ packages = (
     ),
   "checkers":
     struct(
-      version = "0.4.9.5",
+      version = "0.4.10",
       sha256 =
-        "f184b291235ae9125b5255f9d2a0b5294847a7931f0fec23e39ae0ba41774ef5",
+        "89f739106f528998cc83bc25ab1b3e483cd2ffb21ca120fcb8b2e5c43306711e",
+    ),
+  "checksum":
+    struct(
+      version = "0.0",
+      sha256 =
+        "337a0f6fcf7687469ecd410a3ed41c85ab68de08b5da0798d0d0aeb861a4470c",
     ),
   "choice":
     struct(
       version = "0.2.2",
       sha256 =
         "d367e4321329df5913216f9746528e4526e14b5ad1f33edc82de8288ad719e61",
+    ),
+  "chronologique":
+    struct(
+      version = "0.3.1.1",
+      sha256 =
+        "c538bc2e7b1cb9c1f4ae4177a5545c08d3ff66c29c80ef8faddd92daaa499e16",
     ),
   "chunked-data":
     struct(
@@ -2884,45 +2577,63 @@ packages = (
     ),
   "cisco-spark-api":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.0.3",
       sha256 =
-        "baa1014e9091e2738dd894a0a79f99affcf6b83dfdd60298954c11b0012a3f72",
+        "7e962a9f34e5b0c66fe858f4c6a322d22586bc7a8ac602a317697d2d9b6228ba",
     ),
   "clang-compilation-database":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.0.1",
       sha256 =
-        "8ab6fbf59e673598c0d08fc52f9eabec49ee896c57638d43bd7782425267cbda",
+        "114601a1769471e4fc2e8d100c5546e95fa803b9e56dcd342dab9829d0dc1ca8",
+    ),
+  "clash-ghc":
+    struct(
+      version = "0.99.2",
+      sha256 =
+        "44ec74bca8294f182521dfefaf11aab8f29dd3ff81e4d93b44ec844d78cfa7b8",
+    ),
+  "clash-lib":
+    struct(
+      version = "0.99.2",
+      sha256 =
+        "6e5f3df6fa6c266643f337e1b2242e122ab068082549c9cdf60d3703e0ecf36a",
+    ),
+  "clash-prelude":
+    struct(
+      version = "0.99.2",
+      sha256 =
+        "f1ac0ba1a41c0f5e1249709e9c100a24dc56d124f5fa2e7c52027bf1e67044bf",
     ),
   "classy-prelude":
     struct(
-      version = "1.3.1",
+      version = "1.4.0",
       sha256 =
-        "cd73a1246565f78c46aa77a95d8a22f26c390d4d6844e12d49f3d61b27806166",
+        "2b3b255676ab0fdeb39aebafa3543535ddd684d00c645b643e50cb9e2d25f9e0",
     ),
   "classy-prelude-conduit":
     struct(
-      version = "1.3.1",
+      version = "1.4.0",
       sha256 =
-        "5264705d7e1b6fe7eca93eb476141d3f92cc8ccd74b42883dfec17f29661e658",
+        "39ef2567a3542ebf91f6ebc103cc4afb64c2a4ec051c7ce578b577ef9931c424",
     ),
   "classy-prelude-yesod":
     struct(
-      version = "1.3.1",
+      version = "1.4.0",
       sha256 =
-        "3d65c6f8cec08f40c66f78b6563c4f590bf7705c7b9694d1c632d0f5c8e5f3fb",
+        "0cd2a88f42c3541ba4bce6801c8b8d9c331e1c49a6288bf16f764676a34b9e28",
+    ),
+  "classyplate":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "9548f228998d7aa00372385e94d51d2802f1a5400b3b85dcb31fda4d75f7d12b",
     ),
   "clay":
     struct(
-      version = "0.12.2",
+      version = "0.13.1",
       sha256 =
-        "ea8b95a24568c8a37e2f8deda7f24c5c15a84886ad19f255d6d637e06786e98a",
-    ),
-  "cli":
-    struct(
-      version = "0.1.2",
-      sha256 =
-        "580a31fc25eb988dbb5ad3aebfb72d49f089cbee9693edf78dae722b2fde4acb",
+        "844e9101cc1835eb12bac50e289d00f19c24eeee12bcdebae1b633edffa328a3",
     ),
   "clientsession":
     struct(
@@ -2942,17 +2653,17 @@ packages = (
       sha256 =
         "a9ed097aa9d48b53c6a555bc5f67e347249b08e2252dd4fc998fb4ab42edda59",
     ),
+  "closed":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "7a301c6c543ae60354b737c56c2259dfc9e01ddf9eee452e4469c6262c53c21c",
+    ),
   "clr-host":
     struct(
       version = "0.2.0.1",
       sha256 =
         "5306ea1368b922d595159f237877f5b76fb9744e082f8c286c4546dc1a6f0e96",
-    ),
-  "clr-inline":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "10def81e96417b4cb6f9e92fcbb3b70bafc9c8f64e59abf64453f9d62b72547d",
     ),
   "clr-marshal":
     struct(
@@ -2966,29 +2677,11 @@ packages = (
       sha256 =
         "fd4b303d206eaf242c779bb65c42256e42220c8497a6bcf3bc59589b9396c495",
     ),
-  "cmark":
-    struct(
-      version = "0.5.6",
-      sha256 =
-        "855c4b7aca6d4e9eb076beb6cc6f74e7578fae7aa3625fd3fca5e3b4901a32b0",
-    ),
   "cmark-gfm":
     struct(
-      version = "0.1.3",
+      version = "0.1.4",
       sha256 =
-        "731cb392e4edfd18d0dae709904791610588e6770934e5112cbdd5e6f3d271ba",
-    ),
-  "cmark-highlight":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "de769cd703d3fcd5d69428477184fad57019db55a71b1315a9bbb54317f0812b",
-    ),
-  "cmark-lucid":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "d2927b9fed0e32fe7afc539e7b427e0a95f8c9297bb6bc531101b476ba8a3c03",
+        "15f02f37dd59e8d5cfb1ed7b17d412c6034a0172a192d1f5546832e5eea14c4a",
     ),
   "cmdargs":
     struct(
@@ -3014,17 +2707,41 @@ packages = (
       sha256 =
         "ffc261b58108c3d90c0b0b68461857d1148208d1a9645916e63241aaa3c25b28",
     ),
+  "codec-beam":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "61eb624e5f347ec9249f976bc8b62ae597777604d82ab0e62acb9901374ae365",
+    ),
+  "codec-rpm":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "a34b88378dc79b08b56c39515763b6d940166595c24dc45e61cc8d2bb4ed4b97",
+    ),
   "codo-notation":
     struct(
       version = "0.5.2",
       sha256 =
         "78eb57004541ed29eb4c54196b91ac2dd1028a3315f51cd4dc00debfc0938eaf",
     ),
+  "coercible-utils":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "2a624986cdc010c7fc3e90f8c94f722995af9fe6e88b9d52a94ebaa319b08c98",
+    ),
+  "colonnade":
+    struct(
+      version = "1.2.0.1",
+      sha256 =
+        "32ebd86360c9a363d62a2490b7120de5651a6674a79c4f9d85e13d2cc8cb3e8b",
+    ),
   "colorful-monoids":
     struct(
-      version = "0.2.1.0",
+      version = "0.2.1.1",
       sha256 =
-        "426e36c9219ebc19108f0968aee8900bad7642937b5800d6045c5085c2b06532",
+        "0bf5f8d9632dec436a6744d584003d09b15169e600e9e5c2636e2c3f4d4f2e58",
     ),
   "colorize-haskell":
     struct(
@@ -3038,23 +2755,17 @@ packages = (
       sha256 =
         "0f439f00b322ce3d551f28a4dd1520aa2c91d699de4cdc6d485b9b04be0dc5eb",
     ),
-  "colour-accelerate":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "ec7f80370e271b7cd87a2b0255cfeee63d73cbc895a346c447efc8e214332780",
-    ),
   "combinatorial":
     struct(
-      version = "0.0",
+      version = "0.1",
       sha256 =
-        "466f2af4e7a25cec1766c55934821f16cf36bc9dfa14009a4355c53811960d6c",
+        "096e6dacd9f99c7ce63e95b991df33b74645f71f7df2dd90627843d96324b4a8",
     ),
   "comfort-graph":
     struct(
-      version = "0.0.2.1",
+      version = "0.0.3",
       sha256 =
-        "f6c56922ebed1f8ffb5cdb82f1bba8b1daf11fc70cdf3ab4b6071bbdf39a7909",
+        "b9d67c0f19e34c27fe759c149939c37d655a170482760389de07cca9cb534387",
     ),
   "commutative":
     struct(
@@ -3064,27 +2775,9 @@ packages = (
     ),
   "comonad":
     struct(
-      version = "5.0.3",
+      version = "5.0.4",
       sha256 =
-        "a7f4584d634051123c547f0d10f88eaf23d99229dbd01dfdcd98cddd41e54df6",
-    ),
-  "comonad-transformers":
-    struct(
-      version = "4.0",
-      sha256 =
-        "dfec0c4ce1eccd34c228951454a8f2ebab0bfbdf1cde68a70688196db2b9ff8f",
-    ),
-  "comonads-fd":
-    struct(
-      version = "4.0",
-      sha256 =
-        "3a70386e2ef3d6f444585f082de42e842a47dfe7bdbd807550839faf1bd8b7a7",
-    ),
-  "compact":
-    struct(
-      version = "0.1.0.1",
-      sha256 =
-        "ee8533e16b94bbbf3519ccad26f3e569d60d33a5a9d2e3636e0764aff7b2d653",
+        "78a89d7f9f0975b40b3294adcb70885649572b687ac5f5dc98e452471838e825",
     ),
   "compactmap":
     struct(
@@ -3103,6 +2796,18 @@ packages = (
       version = "0.1.0",
       sha256 =
         "8cf4c57e1b4d61b1163969faa6e9f2cb8f22073fa75bf982d9b8a328225f5ce3",
+    ),
+  "componentm":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "efe23d927d3ad2aee5052ef379f7a472f60e1b0749195e9b46bbf0d8c756b6a7",
+    ),
+  "componentm-devel":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "2dd7303c9b26d748baf1a0893b19072ef2a2817c8c77639e3c844e559cd85b0a",
     ),
   "composable-associations":
     struct(
@@ -3128,6 +2833,18 @@ packages = (
       sha256 =
         "c998244a8fd160af3dd7ee93c417f665af51a46a04ce6b7d4623f46596ba7129",
     ),
+  "composition-prelude":
+    struct(
+      version = "1.5.0.8",
+      sha256 =
+        "ec6adf0c05bd7e2c47fdf2a509047c10d9deeb4e39770351a2d1da5b5695f7dd",
+    ),
+  "compressed":
+    struct(
+      version = "3.11",
+      sha256 =
+        "d77bbf2f445d32f138dfde9e860e68db5de8ae04c52ffda23941ddf7bdabdd3d",
+    ),
   "concise":
     struct(
       version = "0.1.0.1",
@@ -3136,21 +2853,21 @@ packages = (
     ),
   "concurrency":
     struct(
-      version = "1.2.3.0",
+      version = "1.6.0.0",
       sha256 =
-        "b835a0f66936b36b083cc6712ce4b251f9eabeab5b72b2850af881a5f0a079a9",
+        "93f2567005f470689b190f526cc39d625fb402b7396240b61dd7be5aeee2eb93",
     ),
   "concurrent-extra":
     struct(
-      version = "0.7.0.11",
+      version = "0.7.0.12",
       sha256 =
-        "a516b056780478ea1a06651b5aff47bd03821b66879ac1c8013d7a68447d6e2f",
+        "040e6db9e0147de9929661759930f1566a7250add4c7f65b04dc6e070c991df9",
     ),
   "concurrent-output":
     struct(
-      version = "1.10.3",
+      version = "1.10.6",
       sha256 =
-        "48c1d6eb83de02408c15d5fe9d6e2bfa64c9d628859eb0219888f07e0fabe56a",
+        "2301a6d8be9b0defd5d3a640a7e1a293bb77016bbd548ff8ccec6122e30e97e2",
     ),
   "concurrent-split":
     struct(
@@ -3172,21 +2889,21 @@ packages = (
     ),
   "conduit":
     struct(
-      version = "1.2.13",
+      version = "1.3.0.3",
       sha256 =
-        "239d1bac614bc1085315ad8d15275471fc7c0eaef05950429d40a65bd73711ac",
+        "bb741f1650c2c90ef5104489541258689240e750869c9230fd2d458c417d56e9",
     ),
   "conduit-algorithms":
     struct(
-      version = "0.0.7.1",
+      version = "0.0.8.1",
       sha256 =
-        "2726882b40d6f363c5966d5dd18dbfb54dcb880caccbdd163c092ad420256f94",
+        "cda5a50fa746c63001e39a8210d945015412c1c335078249e06eadd00616fd1d",
     ),
   "conduit-combinators":
     struct(
-      version = "1.1.2",
+      version = "1.3.0",
       sha256 =
-        "840baed33ca32b5197817d6db1e70c4fb53eba01f86bd11c3b358cd8e08d6138",
+        "9717d916a0422a7fb7cc262302333269607530d40cd0bea3be947872f906e7d3",
     ),
   "conduit-connection":
     struct(
@@ -3196,9 +2913,9 @@ packages = (
     ),
   "conduit-extra":
     struct(
-      version = "1.2.3.2",
+      version = "1.3.0",
       sha256 =
-        "1d5b66284703a4b9fb96a4c6a2213727208639871a675da9755e9a963fa230f6",
+        "2c41c925fc53d9ba2e640c7cdca72c492b28c0d45f1a82e94baef8dfa65922ae",
     ),
   "conduit-iconv":
     struct(
@@ -3208,9 +2925,9 @@ packages = (
     ),
   "conduit-parse":
     struct(
-      version = "0.1.2.2",
+      version = "0.2.1.0",
       sha256 =
-        "296bfb9bb3b20771fd4bc0d3e5cdb9bb27bc1050cef45a6347e8b196ed54dca7",
+        "b585dbdc0c1e3a844a9cd97cd1e72d7a73521b66b856001960afe4057130dae1",
     ),
   "conduit-throttle":
     struct(
@@ -3226,9 +2943,9 @@ packages = (
     ),
   "configuration-tools":
     struct(
-      version = "0.3.0",
+      version = "0.3.1",
       sha256 =
-        "9fa7a42f9247054f5e37eb2bb897d52ed51f3b0c9fcccf7056edefc3aaadf24e",
+        "e0df7e71b084c1bd831cd9887584f06e016e359291dc4f71b72d2027f7f86e47",
     ),
   "configurator":
     struct(
@@ -3250,9 +2967,9 @@ packages = (
     ),
   "connection-pool":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "2364c5a7b5d0dbeb00478070a4e527ab019ffb86e14e726a2a9ee56f8cb884dc",
+        "f2cf43b7698b719b05467b3625884d00c748de2b3eb1229d19490b029a667353",
     ),
   "console-style":
     struct(
@@ -3260,11 +2977,17 @@ packages = (
       sha256 =
         "6d818ea841d7acfe6c42cc3fc7751e324656abfd0509ce470bc8bdbf52d1bd7f",
     ),
+  "constraint":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "22800d629e3255c7e37d9265ac70b9a4ec4bee2d5f4cc19948e8d28b911ddf47",
+    ),
   "constraints":
     struct(
-      version = "0.9.1",
+      version = "0.10.1",
       sha256 =
-        "276e012838861145fca65d065dd9839f7cbd71236032b557194389180a30a785",
+        "5880ec261e053841b307c7c8c59614f46c2efbd5189f0f2a3c817589cedec3f7",
     ),
   "consul-haskell":
     struct(
@@ -3286,9 +3009,9 @@ packages = (
     ),
   "contravariant-extras":
     struct(
-      version = "0.3.3.1",
+      version = "0.3.4",
       sha256 =
-        "f35d9df4d1c0fa767afca6500c6ab598f052128abc513259930ef5b6bc7c79d5",
+        "36a9239d5a84bc6a418a3aa1a0df145d76ece24d00b76deb817b92441913e63d",
     ),
   "control-bool":
     struct(
@@ -3301,12 +3024,6 @@ packages = (
       version = "0.6.1",
       sha256 =
         "fea9173d3c29729a8e0789d654bf3b16928e0b740465bd8798ac2cfeec492286",
-    ),
-  "control-monad-loop":
-    struct(
-      version = "0.1",
-      sha256 =
-        "f29b08497897268daf4c547390dad69f4ee00032082e3d5305c33e6eee257300",
     ),
   "control-monad-omega":
     struct(
@@ -3322,9 +3039,9 @@ packages = (
     ),
   "cookie":
     struct(
-      version = "0.4.3",
+      version = "0.4.4",
       sha256 =
-        "fbfb0c4fcebe6cb85cb6b84572287a57ee7e3a380f2fe51c4885bfb460f3ed62",
+        "3245ed04ae933cf7becede816d1f76043b851472700abf558ae90b28414cc0e3",
     ),
   "countable":
     struct(
@@ -3334,15 +3051,21 @@ packages = (
     ),
   "country":
     struct(
-      version = "0.1.4",
+      version = "0.1.6",
       sha256 =
-        "74817f19e5c41eb01a3bf5f4ccf626772e5a7b32c336eb7820317a6d9925f108",
+        "09b36e30dfb1fa5fa7a2c5c38f316a70e0c740b8a4dd6e340abe9770ad149928",
     ),
   "courier":
     struct(
       version = "0.1.1.5",
       sha256 =
         "ac9e674ff33de347b173da2892859b3807a408b341d10d6101d2a7d07ac334d3",
+    ),
+  "cpio-conduit":
+    struct(
+      version = "0.7.0",
+      sha256 =
+        "8f0be7538b234496ef3b2fb2633336908ae99040ecb6d9832b3dbd1d0750f513",
     ),
   "cpphs":
     struct(
@@ -3370,27 +3093,33 @@ packages = (
     ),
   "cql":
     struct(
-      version = "3.1.1",
+      version = "4.0.1",
       sha256 =
-        "45b0d9599dfb6b5df02eb17e18d45cef8abd7e175d4eb7f99ab94f9d50866da3",
+        "89294c6a6ed2c6f8c6037ee2ca4236d3606bf9019a39df9e39b7ad8dcd573808",
     ),
   "cql-io":
     struct(
-      version = "0.16.0",
+      version = "1.0.1",
       sha256 =
-        "82e5aff9b929fd9dec92760b9d0e75ca509ce2619942628e5c7e3a66f4204004",
+        "b874e70d55c144064d8ed2df1e90063071811ec55734a051b6f240279969351a",
     ),
-  "crackNum":
+  "credential-store":
     struct(
-      version = "1.9",
+      version = "0.1.2",
       sha256 =
-        "a5a78b774e17837513b7c6048856c375457095898a59b7f3bbb7f49abb1639c5",
+        "4dadbc219a7187442258608c1d834f4297652fb605fc6bbbb41d751fef6a9284",
     ),
   "criterion":
     struct(
-      version = "1.2.6.0",
+      version = "1.4.1.0",
       sha256 =
-        "6c05ad0e97dc16fe54c3066df572ce6919e5f4564b791873f4a331727c953729",
+        "c49306676aa7927c3ca3c1807b081d1e86771eb8da99c8391f9c4dacb24a826c",
+    ),
+  "criterion-measurement":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "fe6423d77a5c7f3571bf16abac2b9729a45feaba2d3f293bce6029592debc6ce",
     ),
   "cron":
     struct(
@@ -3430,9 +3159,9 @@ packages = (
     ),
   "crypto-enigma":
     struct(
-      version = "0.0.2.10",
+      version = "0.0.2.12",
       sha256 =
-        "e60a405a382c9fb0d15774457ced1569809af267e5f970bba314ea340f57ebb0",
+        "2bb942397a3ca2a099e8c4b59a3810a0fe3a4d255c077e8e0db8e8764fb6b83c",
     ),
   "crypto-numbers":
     struct(
@@ -3469,6 +3198,12 @@ packages = (
       version = "0.6.2",
       sha256 =
         "34b9e62dee36c4019dd0c0e86576295d0bd1bb573eeb24686ec635a09550e346",
+    ),
+  "cryptocompare":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "d12e0f6fd133e538852e5700b0a31d81c6885dc8b1e9e88d1b331dcec38316b3",
     ),
   "cryptohash":
     struct(
@@ -3508,9 +3243,9 @@ packages = (
     ),
   "cryptonite":
     struct(
-      version = "0.24",
+      version = "0.25",
       sha256 =
-        "17c3312343ef9bbfa87566d1f701d24870c2d34e015b104ff02faf1c9e1b5a86",
+        "89be1a18af8730a7bfe4d718d7d5f6ce858e9df93a411566d15bf992db5a3c8c",
     ),
   "cryptonite-conduit":
     struct(
@@ -3520,21 +3255,27 @@ packages = (
     ),
   "cryptonite-openssl":
     struct(
-      version = "0.6",
+      version = "0.7",
       sha256 =
-        "a8cb97c96bfb3e7b7ff8d59629317882dbf3cea12ba978d8475c96a6c28750a6",
+        "9e4e1c08264f26e602ef3054f3c827c3c65d153e5b9d68a0cb44f446ca0844f6",
+    ),
+  "csg":
+    struct(
+      version = "0.1.0.4",
+      sha256 =
+        "9d9537fec60bf44b98b87445b99e9f9300e317ca48402b8d26e059ec55a231b7",
     ),
   "csp":
     struct(
-      version = "1.3.1",
+      version = "1.4.0",
       sha256 =
-        "d83c5e51dd32a796af8cfacac94312cb99691be30d924e159bc1c4b8cef9530b",
+        "08877f5ff196772675ac55b3c43ab39b527259114da8cfc36122c0cd7ce93496",
     ),
   "css-syntax":
     struct(
-      version = "0.0.5",
+      version = "0.0.7",
       sha256 =
-        "3969e0bf83c81dd970cdde9bb07386071264f0f390215078eb86a5cfa1e50b9e",
+        "23fc1d47e94620eee586001c56c4e0c1ba17f5dab9c496245c7cff7ab9cd6064",
     ),
   "css-text":
     struct(
@@ -3547,12 +3288,6 @@ packages = (
       version = "0.1.2",
       sha256 =
         "8cf43442325faa1368f9b55ad952beccf677d9980cdffa3d70a7f204a23ae600",
-    ),
-  "csv-conduit":
-    struct(
-      version = "0.6.7",
-      sha256 =
-        "501e6b0b7c6f0e80ba381b5f18af5ec343eb5e1afb4f5fc4e5e318ce51eeb33d",
     ),
   "ctrie":
     struct(
@@ -3572,29 +3307,11 @@ packages = (
       sha256 =
         "5b6ced9ca65b0d01ddceaf18605c8f915491d8d4a6aaef73475c4e8d4b1a9b79",
     ),
-  "cublas":
-    struct(
-      version = "0.4.0.0",
-      sha256 =
-        "7ceee752ee0fd508f62ed9f41a97a885e3940c0c53a81f07b23fc7f874e63bf8",
-    ),
-  "cuda":
-    struct(
-      version = "0.9.0.0",
-      sha256 =
-        "8d1a5c825f596d458614c9d1982291e3ffa580c15bdfe81229e9ad982364717d",
-    ),
   "cue-sheet":
     struct(
       version = "1.0.1",
       sha256 =
         "214a58e87a849c8311eb652ca215b4f5789d724e7499324544b3a01187577f8f",
-    ),
-  "cufft":
-    struct(
-      version = "0.8.0.0",
-      sha256 =
-        "f7bdd8117b35baf630ae8b276a2dea0fd47e0cbc5e6e50802e4007d2d201dd58",
     ),
   "curl":
     struct(
@@ -3602,23 +3319,23 @@ packages = (
       sha256 =
         "9087c936bfcdb865bad3166baa3f12bf37acf076fa76010e3b5f82a1d485446e",
     ),
+  "curl-runnings":
+    struct(
+      version = "0.6.0",
+      sha256 =
+        "44204017b483d96659948011a3abe78f05afa5b63cd561bcaa36ea5f21efac19",
+    ),
   "currencies":
     struct(
-      version = "0.1.1.1",
+      version = "0.2.0.0",
       sha256 =
-        "d58e021d319917d70ea5e7069daef67788f4c2081c095d44c511fd392e3f0bf0",
+        "fb7292d4a5b9c4389690d1386fe24ce6a93eacbcfa952936ca6d4fd3afa98499",
     ),
-  "cusolver":
+  "currency":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.0",
       sha256 =
-        "a58cce0773553cfc064ad9f9922dcc55a9782c3684914bfbd294a66f34207102",
-    ),
-  "cusparse":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "b6db49628dc316d1c3fd6dfb419bad1e4bb5e35572cdf769c9a06c14fc598528",
+        "bcd517f3d9f47f0dd3c4e802143159239e4a90db2fc552be4a99d759ffe9417a",
     ),
   "cutter":
     struct(
@@ -3626,11 +3343,23 @@ packages = (
       sha256 =
         "117319c36a20efea6d9edd0a8d902e37ec0386512f2eb8a6e5563411c00c6ac2",
     ),
+  "cyclotomic":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "f72098bac1ec2fe561a2cc654334d8931b1a9074424be0081157901df56f5ffd",
+    ),
   "czipwith":
     struct(
-      version = "1.0.0.0",
+      version = "1.0.1.0",
       sha256 =
-        "45a2af0fd73f4cb7968c382465d8c5c6f4807d195d85e5b35bccef8f5e7c2ce1",
+        "17b89163347298f78b6e9537b38d621286dff39bd105116a7e852774ccf92f68",
+    ),
+  "darcs":
+    struct(
+      version = "2.14.1",
+      sha256 =
+        "61ddbc99acaf06df3a114437064e9241e0da467c23d1d3fb520a782eee32cd35",
     ),
   "data-accessor":
     struct(
@@ -3646,9 +3375,9 @@ packages = (
     ),
   "data-accessor-template":
     struct(
-      version = "0.2.1.14",
+      version = "0.2.1.15",
       sha256 =
-        "c46f0b3fffa0f7c700f69dbf1c4488fb865d5ef361047e8297e20440fe581b65",
+        "802b7f55ef02773b44d42c19175f52b5ef1b122df0e91ad0ef9a8add4d33ba6f",
     ),
   "data-accessor-transformers":
     struct(
@@ -3668,12 +3397,6 @@ packages = (
       sha256 =
         "70f01f857865edcf1d1d20128b0202320b1635cc03b00954b6d1447cd699db7d",
     ),
-  "data-check":
-    struct(
-      version = "0.1.1",
-      sha256 =
-        "013f215d30b634ae1ac38ea6b0a87ab754aaf0c1cdace2495ff56f85bf16b101",
-    ),
   "data-checked":
     struct(
       version = "0.3",
@@ -3682,9 +3405,9 @@ packages = (
     ),
   "data-clist":
     struct(
-      version = "0.1.2.0",
+      version = "0.1.2.1",
       sha256 =
-        "ce3c374e8e93086020238caff3dc3ca112db308850b56fe8ba6f78a1dc211626",
+        "9a1882e286e2f5428517375e129dc3c6fb12114f360cd4a767e7a699d67c8416",
     ),
   "data-default":
     struct(
@@ -3697,12 +3420,6 @@ packages = (
       version = "0.1.2.0",
       sha256 =
         "4f01b423f000c3e069aaf52a348564a6536797f31498bb85c3db4bd2d0973e56",
-    ),
-  "data-default-instances-base":
-    struct(
-      version = "0.1.0.1",
-      sha256 =
-        "844fe453f674b6b0998da804465914abce8936c5e640d8bb8bff37ad07d7a17a",
     ),
   "data-default-instances-containers":
     struct(
@@ -3724,15 +3441,15 @@ packages = (
     ),
   "data-diverse":
     struct(
-      version = "2.0.1.0",
+      version = "4.6.0.0",
       sha256 =
-        "ab801d352521780f39112d642bc8d626fbdf88e0b2e79dc19984baaa80ad2725",
+        "094d44446b2429bad5707b4aef0f1f63a9d101739d9a244cb2131f7646eccbd4",
     ),
   "data-diverse-lens":
     struct(
-      version = "1.0.0.1",
+      version = "4.3.0.0",
       sha256 =
-        "a78347f99f01a975ebc631022ba4fba88da0ec8ba6fc37353452af2b6ca87947",
+        "97d049769f0a3693428bac8eb8de73e004f6fc9a1d0e3dc0c567f9d39f8ed986",
     ),
   "data-dword":
     struct(
@@ -3766,9 +3483,9 @@ packages = (
     ),
   "data-inttrie":
     struct(
-      version = "0.1.2",
+      version = "0.1.4",
       sha256 =
-        "8ddae7ad7d3cafdf349d93c0eed5767ab1213d854980bc28d7d935163c5f1df9",
+        "6b3a7d8d49b0676c09486ac08107b0e5a6dfd66d9627443be440e9fd11e7bd54",
     ),
   "data-lens-light":
     struct(
@@ -3820,9 +3537,9 @@ packages = (
     ),
   "data-serializer":
     struct(
-      version = "0.3.2",
+      version = "0.3.4",
       sha256 =
-        "d41023a0a507dd2fd1517c1c2c6aad448373652af5445454ea9899c7f124aa14",
+        "e793156aa2262ca294183a9d045f37e6ff2070825b40d2ffe5a8d64e0b455ec6",
     ),
   "data-textual":
     struct(
@@ -3832,9 +3549,15 @@ packages = (
     ),
   "data-tree-print":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.0.1",
       sha256 =
-        "655a7746891af9cf93e94d6997a13a77515b6ceb3e91da66070ea5bd8e6bd537",
+        "cec8c278e1033695ce97e2d7bf5db2b1b45a764976e59d06c67a6fe4fc5401fe",
+    ),
+  "datadog":
+    struct(
+      version = "0.2.2.0",
+      sha256 =
+        "450fb6fba21d9739c8269f167ecf084d966e2248084386ab5c04b2748b4b6944",
     ),
   "datasets":
     struct(
@@ -3862,27 +3585,33 @@ packages = (
     ),
   "dbus":
     struct(
-      version = "0.10.15",
+      version = "1.0.1",
       sha256 =
-        "6455659dc4e2b3078887506099039dc06fdda559a9cddb3ff9df5584b792baa8",
+        "a325b5c6958a343b30fd378d54ac01f9db889a4d7cadb14b2103da7ef4e7e8f5",
     ),
   "debian-build":
     struct(
-      version = "0.10.1.0",
+      version = "0.10.1.1",
       sha256 =
-        "a41033dee53346bda2f77a4192f85b54dbe3d25ef9b1fd158fdc09b4411e90b4",
+        "d3e6a924367ddd7087f00ac448afb3f12cb5a70392194f1bcd15a33b81766537",
     ),
   "debug":
     struct(
-      version = "0.0.2",
+      version = "0.1.1",
       sha256 =
-        "a3446734bcbdcaefe5a4be9d444ac4bac3c0502cd302da280e6a7de6b143bd8d",
+        "330f44c6341833c5e0cccf08fa7674dd54f14a843a2b5703e25ce08ffed49248",
+    ),
+  "debug-trace-var":
+    struct(
+      version = "0.2.0",
+      sha256 =
+        "174f79d31d905c99adc880dd79899b3f335e1a7c552a7bcff8664abbffb6b489",
     ),
   "declarative":
     struct(
-      version = "0.5.1",
+      version = "0.5.2",
       sha256 =
-        "4ed591067e741682da3f319284dbf1d77c70bdf9d5c78e32575d5018d3f4c624",
+        "1ea8cf5eb0283ed9d9a7e1d46e5386960587c1671f7ce568d6eaf1d1b8ba9a04",
     ),
   "deepseq-generics":
     struct(
@@ -3892,9 +3621,9 @@ packages = (
     ),
   "dejafu":
     struct(
-      version = "0.9.1.2",
+      version = "1.11.0.3",
       sha256 =
-        "5a11f4101859426a3de3580a2a08d1706af8a406cc9fa4244c753c2ea89bbab3",
+        "dd2e23a975eddc01d4f281f6c9c19a0e815ed39dd1546a8a9661b62936074aa4",
     ),
   "dependent-map":
     struct(
@@ -3916,57 +3645,87 @@ packages = (
     ),
   "deque":
     struct(
-      version = "0.2",
+      version = "0.2.1",
       sha256 =
-        "86768d22492c58b35688c28592b222cb16cc996ca6576b35add9c54a470d3e56",
-    ),
-  "derive":
-    struct(
-      version = "2.6.3",
-      sha256 =
-        "f23e08f2e51aa22bb51bead0a71a4530185591b8032d53dfb641d7ad65a8a31a",
+        "019d197e306724f1a09ad53ab9309cee1cfbbf5456f2956d3ab52a59fe523264",
     ),
   "deriving-compat":
     struct(
-      version = "0.3.6",
+      version = "0.5.1",
       sha256 =
-        "0c1fab416505e3fabaec007828073c065db077f004dcc6955f2cd32ca139356d",
+        "7e17ab1664c32026059f35776d2f8b57fc5386b254d8b67e00061e122aafb3a2",
     ),
-  "descriptive":
+  "derulo":
     struct(
-      version = "0.9.4",
+      version = "1.0.3",
       sha256 =
-        "795ec65756bf87ec6ea4c92d85a25d0eb0d8cfa1df40685ddcf74b83099bba2f",
+        "758ccf8f017acc7c1c3cf7e1e603c79cf85827e0f807cd9bed82287308d95efc",
+    ),
+  "detour-via-sci":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "451e1194f7bf6a7dea02379679c790313cc20423271fd8e98f164c942e3d81e4",
+    ),
+  "df1":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "362409d7f47f69f9afc746b87c2380bc6d1536c1e9d1b8b77963b83504722fe3",
     ),
   "dhall":
     struct(
-      version = "1.8.2",
+      version = "1.15.1",
       sha256 =
-        "520184b58a70e4ac5dc3dc0b39bee64c279b5cdebd2b178aee6934cbb30899d2",
+        "ea3bb3b6a006b82e0286d72757ba9969f6ee292ef12eea2376939ba219c88e30",
     ),
   "dhall-bash":
     struct(
-      version = "1.0.6",
+      version = "1.0.14",
       sha256 =
-        "add8f2fe325589d6a1f31c935cff5e81f4925f90bfc8d8eb6d20b59def955cf2",
+        "8d20a586afffc2e1b1470168743ead24387e2cc5149e8f63e799220c6da5b8ff",
     ),
   "dhall-json":
     struct(
-      version = "1.0.9",
+      version = "1.2.1",
       sha256 =
-        "86a67f9eb51dc03b1ab97e7708a5bd540e4fb895e1c65603728ca98ab6deaf77",
-    ),
-  "dhall-nix":
-    struct(
-      version = "1.0.9",
-      sha256 =
-        "3eb773e87fc64ab5a09c4158393f634ff11c125f019ff6738e1bd95ac5e4d21a",
+        "999cd25e03d9c859a7df53b535ca59a1a2cdc1b728162c87d23f3b08fc45c87d",
     ),
   "dhall-text":
     struct(
-      version = "1.0.5",
+      version = "1.0.11",
       sha256 =
-        "47bcd70f33b471f717d0e5f3f241db478b954917fcea2a25aa079d79a973b6a4",
+        "61817e1b8c6c0e77a042cadc119c59b94c4577906d35e34738a332c86ac97a7d",
+    ),
+  "di":
+    struct(
+      version = "1.0.1",
+      sha256 =
+        "2913ed3a7b8db8d9160a6aec510a35e5f8199c962c0e115f84c0c88d8236ec40",
+    ),
+  "di-core":
+    struct(
+      version = "1.0",
+      sha256 =
+        "d2e872efbc661be995c220d7f3cf839438b045e86848e0ecaf0a61c1c27e8f6a",
+    ),
+  "di-df1":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "d0518d17165c6f9baa60772526f263b11128a17edd1f214c91f0e42aad11b3c6",
+    ),
+  "di-handle":
+    struct(
+      version = "1.0",
+      sha256 =
+        "cd081f53824a173b30550ae9dbea744a2e7ac8931092d1f1b246b9bd5bb092ec",
+    ),
+  "di-monad":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "b84d79e180778720b6aa31bf5e7f72db809378f92c97c391828639c876164ee8",
     ),
   "diagrams":
     struct(
@@ -3976,45 +3735,63 @@ packages = (
     ),
   "diagrams-builder":
     struct(
-      version = "0.8.0.2",
+      version = "0.8.0.3",
       sha256 =
-        "c2ca077cddf7e9d83714f098c93ac3492f47d1152e2de76bc21f2ea3be4629cb",
+        "3a80ac090b73838de3d2a9d006d128cb7903852b2f8df24db30855f729b30abd",
     ),
   "diagrams-cairo":
     struct(
-      version = "1.4",
+      version = "1.4.1",
       sha256 =
-        "a94ec8bfdba325cf317368355eaa282bef3c75ed78e153ef400b8627575cea81",
+        "df64fd41f4c8eb37e2edcc458c4d49c574d22cf7ca2ef7ceb5de4a79f6436658",
     ),
   "diagrams-canvas":
     struct(
-      version = "1.4",
+      version = "1.4.1",
       sha256 =
-        "30622ff2478391caf31dd8cc6842043f33409e97a3e5fd9f9ca6ee8264b576e9",
+        "92def277f039ab95428bb3339f66e6068dd6c1699f24a4c76ca8894004d915c6",
     ),
   "diagrams-contrib":
     struct(
-      version = "1.4.1",
+      version = "1.4.3",
       sha256 =
-        "5be8de1d66e06fc261808a920a9a7422ea637c54057228888c0a1fac587cebaa",
+        "65fba87bb7752b1053fb3ab8e4ae30d5920208ff48441c4d8969cdbe73402007",
     ),
   "diagrams-core":
     struct(
-      version = "1.4.0.1",
+      version = "1.4.1.1",
       sha256 =
-        "ce7919fe23d4232f6b7b8e33c10be762a3ca20a007552f171dc38a35e20a254d",
+        "a182e9f99e3664efdfa5e18f4b403703112fba33c5b877a91c9eabed1d8bb682",
     ),
-  "diagrams-lib":
-    struct(
-      version = "1.4.2",
-      sha256 =
-        "e9d41742ed3a92b9dff847c3936746e5a95cc4e187b7e4c35c3e3068c842afe5",
-    ),
-  "diagrams-postscript":
+  "diagrams-gtk":
     struct(
       version = "1.4",
       sha256 =
-        "fe58f0010520716f66802adb0c1f70f48e77e9c4fcea5441e5343f4c1a5f8db4",
+        "b66bde621a09b79b99185af50b2d1ed0b2bd3988c95ed27c7e92e5383917eae9",
+    ),
+  "diagrams-html5":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "e8eed3f8ae1176099c96806281262227618d9e9f40512a430fc9379af44ce96e",
+    ),
+  "diagrams-lib":
+    struct(
+      version = "1.4.2.3",
+      sha256 =
+        "25a7adccbe3175cdb081a3824413ba431e561026c6ddd9a647cd133e4bfcbe9c",
+    ),
+  "diagrams-postscript":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "a758191d99c30bd663dc0df2dedef13cd735a33c143e77906aa88baceb282c9c",
+    ),
+  "diagrams-rasterific":
+    struct(
+      version = "1.4.1",
+      sha256 =
+        "30c66148a7411f23067930a090431a91e5251043e5acf8ff644fa6635fad977e",
     ),
   "diagrams-solve":
     struct(
@@ -4024,27 +3801,15 @@ packages = (
     ),
   "diagrams-svg":
     struct(
-      version = "1.4.1.1",
+      version = "1.4.2",
       sha256 =
-        "c80668c6ac1bf62b108016d36bfe3e603897ca8e331522b0e80b77152915daaa",
+        "5455b68d92826a5405d51490976870cc0fa5b8b56aef0a8f56982b5f48efded2",
     ),
-  "dice":
+  "dictionary-sharing":
     struct(
-      version = "0.1",
+      version = "0.1.0.0",
       sha256 =
-        "e13fe7dec8394aeddb71fb0e0ac68d8750096bfcc198a80d7bc30d94e01edde5",
-    ),
-  "dictionaries":
-    struct(
-      version = "0.2.0.4",
-      sha256 =
-        "fde3c3d716af4eac7fd427c07a553473bafe0d97fd393f317f2fadea000fa8d4",
-    ),
-  "diff3":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8dc57a5f7070efe7227d3afaf5cf4d084c134e2cc0426e98421cdb720cacea25",
+        "8c3b5184d5d6056433d51a49c5402e4ab7b0260073d5342685b8e141d2be5a01",
     ),
   "digest":
     struct(
@@ -4060,21 +3825,15 @@ packages = (
     ),
   "dimensional":
     struct(
-      version = "1.0.1.3",
+      version = "1.1",
       sha256 =
-        "3bc566a59227115325caec0ea00a35e025e5ea471a3ab531cf595e5365aa93a7",
-    ),
-  "direct-rocksdb":
-    struct(
-      version = "0.0.3",
-      sha256 =
-        "84358de7e6b6202336ccb038123f0b95c4e57fab6d2fd8e98ba3deb3b582058a",
+        "3a25889c1c67966a2739a9c1ccd040278c89e10823a1b2463fbf571b74075e16",
     ),
   "direct-sqlite":
     struct(
-      version = "2.3.21",
+      version = "2.3.23",
       sha256 =
-        "da3bcd8eec00f051a326ddf91cfe3a9e838bafed80f27f9fdc6aafdfe8963780",
+        "1fdb6f6ea34ac978e72f61a845786e4b4b945014ccc64ddb07ddcafa1254937b",
     ),
   "directory-tree":
     struct(
@@ -4100,41 +3859,11 @@ packages = (
       sha256 =
         "f17a4f9c3b41083ccbb6c11b2debdbc705f86097b7459ff0f46cc01d2692381f",
     ),
-  "disposable":
-    struct(
-      version = "0.2.0.4",
-      sha256 =
-        "c23fe12dce0aef49bcd52206fe927ac6ae1aa4af5c32028d6ceb4bc52b1fc96a",
-    ),
-  "distance":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "007cfb1c56ff8e8f905dad7c1630630162ffb8520925f028cf82e93ba7cd4a58",
-    ),
   "distributed-closure":
     struct(
-      version = "0.3.5",
+      version = "0.4.0",
       sha256 =
-        "709017cd3a86d945c59e22724d1a8f2e9db57ad9530c995d5c34d96128e2a356",
-    ),
-  "distributed-process":
-    struct(
-      version = "0.7.3",
-      sha256 =
-        "e5e9185f37a112534bdc9e03140dde7c986f338e83f63b626079b7b1a30ee7d4",
-    ),
-  "distributed-process-simplelocalnet":
-    struct(
-      version = "0.2.4",
-      sha256 =
-        "2eea8b33398f06c5edd94dadabfb1a39e76a95a1ac385ff9597a4d8f0815df2b",
-    ),
-  "distributed-process-tests":
-    struct(
-      version = "0.4.11",
-      sha256 =
-        "07c255bc16f7ead7ee29dc389351cb6a438ee229739af7020e86aa35a8aff566",
+        "d56abae0390d30ca6adf9a2e84e770aa92e5b147e547d245fa3a56506dad5ee4",
     ),
   "distributed-static":
     struct(
@@ -4142,41 +3871,17 @@ packages = (
       sha256 =
         "954bf65722b662794990c81ba31a7fdbccd9d233af9212896443aa5ab9d4ffc2",
     ),
-  "distribution":
-    struct(
-      version = "1.1.1.0",
-      sha256 =
-        "fdd2f8eef65580e2248adab5a35e441180b0737ac14cb1307351a205043081b1",
-    ),
   "distribution-nixpkgs":
     struct(
-      version = "1.1",
+      version = "1.1.1",
       sha256 =
-        "1d072e1918a494bd476f666d9665b4e14a7551f5c57cd9640f0f5f986b40a896",
+        "55eb858a98995f4f2b2eec5fcbc44ba1901284e915ef5e18609e253a5a662499",
     ),
   "distributive":
     struct(
       version = "0.5.3",
       sha256 =
         "9173805b9c941bda1f37e5aeb68ae30f57a12df9b17bd2aa86db3b7d5236a678",
-    ),
-  "diversity":
-    struct(
-      version = "0.8.1.0",
-      sha256 =
-        "1bfb127ebd5c8cc9d5929222c7337d2eeecd66857875811ea9d9411227312832",
-    ),
-  "djinn-ghc":
-    struct(
-      version = "0.0.2.3",
-      sha256 =
-        "cb956aed69bc5c342b45ef1b1142b6555fd2865dde1a80ac6ab3ef86aca314a4",
-    ),
-  "djinn-lib":
-    struct(
-      version = "0.0.1.2",
-      sha256 =
-        "c0fe10b7aa5cb39f828e933925fc5bbf86c290bb7661021e4d9250ae8ed01011",
     ),
   "dlist":
     struct(
@@ -4198,9 +3903,9 @@ packages = (
     ),
   "dns":
     struct(
-      version = "3.0.1",
+      version = "3.0.4",
       sha256 =
-        "a6b5c741287c1d1dcfc24987612a7587df7978a4c167441d19a16ffa30b008ab",
+        "7b3433b536b7d225914d7b8495c7af1927d9554538d7d86c2644ccf9d3fa44a9",
     ),
   "do-list":
     struct(
@@ -4210,15 +3915,9 @@ packages = (
     ),
   "docker":
     struct(
-      version = "0.4.1.1",
+      version = "0.6.0.0",
       sha256 =
-        "6a5e0b8818306053d20e244d66bf55d682b48e9e83f72fabfc99bba518447280",
-    ),
-  "docker-build-cacher":
-    struct(
-      version = "1.8.2",
-      sha256 =
-        "f195024d031b6d8f79bf610be9476c93e46f9b25f10a27b2b16cf112c13ab94e",
+        "4d3a00300abc09c2f9214f03d2d16fb51aa5b2f182aa6c4de69a3017e4b42045",
     ),
   "dockerfile":
     struct(
@@ -4234,39 +3933,39 @@ packages = (
     ),
   "doctemplates":
     struct(
-      version = "0.2.1",
+      version = "0.2.2.1",
       sha256 =
-        "d71063c4607fde69caa0a1c0938b5956777091b1eb62e20517541559e814daad",
+        "6b0cfb565fc7fa90d71ac56b83aedecf670678e6f1441278877fbf399e9bccbf",
     ),
   "doctest":
     struct(
-      version = "0.13.0",
+      version = "0.16.0",
       sha256 =
-        "4bd80a88bd569091ada73b149c31085df1a51c9cb0985612eb73d9856fb5e321",
+        "bb49a6781b6deda4eaa9cc3e3b515f245e4b23c4eb403316b873e86220636c42",
     ),
   "doctest-discover":
     struct(
-      version = "0.1.0.7",
+      version = "0.1.0.9",
       sha256 =
-        "ac6a65da517db7f264e65607a50b080b54f008ba592746ac11b7bb40107fbd70",
+        "6790bb2df19b692131dca9f910a789884c2d4361a25f812f5bcb8803033799b2",
     ),
   "doctest-driver-gen":
     struct(
-      version = "0.1.0.1",
+      version = "0.2.0.3",
       sha256 =
-        "1ac3aa2f613197fa4d2f6626a08cd01bdd5895640bf8239a8e9ae48aee173b37",
+        "06b366890573c253a150eb11d782fa9bb91ec50f02cec7a739b439513dcfa9ee",
     ),
   "dom-parser":
     struct(
-      version = "3.0.0",
+      version = "3.1.0",
       sha256 =
-        "49d19767bafbf208380a7f1de6e5b266aa910ce40712a5801bb2b6103adb7490",
+        "d7e15cae0b27d708389160517b1616343da1911baf95f2c97e213732a0262ac3",
     ),
   "dotenv":
     struct(
-      version = "0.5.2.3",
+      version = "0.5.2.5",
       sha256 =
-        "ab48559e5bc7bff531d5ca50dc1d91c8bd14bd4daf51d55258a4e0408c938ca4",
+        "a197bf60643fc4dea5acd71b03b71cb89e8df91d55cc400b2ada5e79b4b6f4e1",
     ),
   "dotnet-timespan":
     struct(
@@ -4285,12 +3984,6 @@ packages = (
       version = "0.3.2.6",
       sha256 =
         "a06d401a2ca58b6ee494ce462c753939ef0a2d11b4d475ae40848884fb44eef2",
-    ),
-  "dpor":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "6efbcc42b845541148886ee92656bbfe6b90b1a0483180b9165d4b0b691ac8e2",
     ),
   "drawille":
     struct(
@@ -4318,15 +4011,21 @@ packages = (
     ),
   "dual-tree":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "2465247dab91c799a06feccc3598c4c25a15bb17e80da102e22a45caa9605f19",
+        "7412d70cf239da98b5a21df1cbbeab7319fd23d757427d4f5ce71b907dbaa9eb",
     ),
   "dublincore-xml-conduit":
     struct(
       version = "0.1.0.2",
       sha256 =
         "d47a8dcb21d1866f0229168d11d1da136da3028a2f4252bee61d219988f45f9e",
+    ),
+  "dunai":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "d6f48393ed9ed584eafe2393c848b78288fca1db5c504ed4749f9f0efe82b817",
     ),
   "dvorak":
     struct(
@@ -4336,9 +4035,9 @@ packages = (
     ),
   "dynamic-state":
     struct(
-      version = "0.3",
+      version = "0.3.1",
       sha256 =
-        "bb62799b08f981a1c8ddcbb349a2b87381439d574a9669cf0bbc829bb63f4929",
+        "c4d50bdf03e7b2af05ee2b78fdd5dd5d16e72ef5edf78cada60bf4cdc6a23537",
     ),
   "dyre":
     struct(
@@ -4348,9 +4047,15 @@ packages = (
     ),
   "easy-file":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "ff86e1b29284499bea5f1d0ff539b3ed64fa6d1a06c2243ca61f93be0202e56c",
+        "52f52e72ba48d60935932401c233a72bf45c582871238aecc5a18021ce67b47e",
+    ),
+  "easytest":
+    struct(
+      version = "0.2",
+      sha256 =
+        "0b486487a566f838cf448b46cc7215230f020fb4756bd362dfb5a66f6ee1a9e9",
     ),
   "echo":
     struct(
@@ -4363,12 +4068,6 @@ packages = (
       version = "0.0.5.0",
       sha256 =
         "d8a5958ebfa9309790efade64275dc5c441b568645c45ceed1b0c6ff36d6156d",
-    ),
-  "ede":
-    struct(
-      version = "0.2.8.7",
-      sha256 =
-        "8b6be46bb0ef2b6503124fb1ae63c26e377013686fbb19ddd0ffeec3d3365e0a",
     ),
   "edit-distance":
     struct(
@@ -4388,17 +4087,11 @@ packages = (
       sha256 =
         "2fc5d19bce2d477935202a5a4522671529d0352a0ee28be1307f8ab391065265",
     ),
-  "effect-handlers":
-    struct(
-      version = "0.1.0.8",
-      sha256 =
-        "2439a77b6ec8db236fc2809cb91219305a7071c72bfd68de795e01b3df9aa80c",
-    ),
   "either":
     struct(
-      version = "4.5",
+      version = "5.0.1",
       sha256 =
-        "ecfb0f4ba8594153db1329b5ca0de08b152dc4cc4326a20e1cfad1bbae41f2d7",
+        "6cb6eb3f60223f5ffedfcd749589e870a81d272e130cafd1d17fb6d3a8939018",
     ),
   "either-unwrap":
     struct(
@@ -4408,21 +4101,15 @@ packages = (
     ),
   "ekg":
     struct(
-      version = "0.4.0.14",
+      version = "0.4.0.15",
       sha256 =
-        "2d67d9e58dc72bc23d90efd1c38dc9f7d45545155774ceab4c96ce372f2d14d8",
-    ),
-  "ekg-cloudwatch":
-    struct(
-      version = "0.0.1.6",
-      sha256 =
-        "a9f8d9ae5b3b3336aae0db1249a9e7f0c4f373a5d9636ee4493b40644128140d",
+        "482ae3be495cfe4f03332ad1c79ce8b5ad4f9c8eec824980c664808ae32c6dcc",
     ),
   "ekg-core":
     struct(
-      version = "0.1.1.3",
+      version = "0.1.1.4",
       sha256 =
-        "ac56e2d0f6bf0b76aa3b69beddbb7d0811e8991c98a379bc24ec808049fb89e3",
+        "66d89acca05c1c91dc57a9c4b3f62d25ccd0c04bb2bfd46d5947f9b8cd8ee937",
     ),
   "ekg-json":
     struct(
@@ -4432,15 +4119,15 @@ packages = (
     ),
   "ekg-statsd":
     struct(
-      version = "0.2.2.0",
+      version = "0.2.3.0",
       sha256 =
-        "c2a0f4270e2e1daa2847944c8b3bf948df8c6efd4893063b069857fa7e893afc",
+        "aeead4a98b467a5fcdbd0646db583843ec14a8985f1a1fbf45cf5c0d969f8a16",
     ),
   "ekg-wai":
     struct(
-      version = "0.1.0.2",
+      version = "0.1.0.3",
       sha256 =
-        "dc42eb0c0c7be06595382dc2858cc926825fff87ab617aa47cc8513092652de6",
+        "bfd35917b663da0c1354339dd30837eee6ddf0d42cf57442fd916a42c977a2e9",
     ),
   "elerea":
     struct(
@@ -4448,11 +4135,17 @@ packages = (
       sha256 =
         "901221660b32597803b20fe2e78bb6f1f60f064d04671fb3f0baa05c87446681",
     ),
+  "elf":
+    struct(
+      version = "0.29",
+      sha256 =
+        "426509f12279bdc5a0228f74edef86997dbb47fddc19d83e9815dd301d4a8fac",
+    ),
   "eliminators":
     struct(
-      version = "0.3",
+      version = "0.4.1",
       sha256 =
-        "b6a2352a9a0d388618c220b627484385535b6a6a8fcdabc0a785028cdba8a2f4",
+        "3becae7b9634055dd02c3908d800dd12b3335b524299e033215a38cfe51b1d00",
     ),
   "elm-core-sources":
     struct(
@@ -4466,47 +4159,41 @@ packages = (
       sha256 =
         "bf9862015918c72b54b421efcd9d858969dcd94ef0a3d0cb92d9bc0c4363f9d5",
     ),
-  "elm-export-persistent":
-    struct(
-      version = "0.1.2",
-      sha256 =
-        "bc45ef54b7538b0c8223a1b966cbd10a69dac3879897d2a75b148dcdc7d8de9d",
-    ),
   "email-validate":
     struct(
-      version = "2.3.2.1",
+      version = "2.3.2.6",
       sha256 =
-        "5b51f0e9dfbfaa75fd322848fe5cc7b1998dd3d4b638d747ac248faba2f67d63",
-    ),
-  "emailaddress":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "390b0aaf8fa2d3a694b812ad83fc0f26ed5c7172cc318a7d46c1fc3456d9c15c",
+        "45dd526e69abfe166e046e4d03c5f3c793adcbbb75b53c46bab076c436f50f32",
     ),
   "enclosed-exceptions":
     struct(
-      version = "1.0.2",
+      version = "1.0.3",
       sha256 =
-        "7b9beab82d219c0dd879dfdef70fb74a4a7595b4dbd0baf7adb12cdbbe8189f1",
+        "af6d93f113ac92b89a32af1fed52f445f492afcc0be93980cbadc5698f94f0b9",
     ),
   "entropy":
     struct(
-      version = "0.3.8",
+      version = "0.4.1.1",
       sha256 =
-        "743a49d5e17ae9d6118ff077f2cd2d5944c0ea6cff501efeec95b68d5f7474d0",
+        "8efd7084237dcda2a444a6c7be0e4b298e5084b20514df4657da5044c22b1faa",
+    ),
+  "enum-subset-generate":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "dd07c2089495ee5b07bdb371bc10004341edb58cbc287d4862ee96b797b14581",
     ),
   "enummapset":
     struct(
-      version = "0.5.2.1",
+      version = "0.5.2.2",
       sha256 =
-        "0f77b5235f1ebdb423e5be2df9390edd7173f0a6531dd368b86c998ac3023805",
+        "792fdbdf387de02580accb3ad49a6f5191b24eb2283ef141355eacfd328cce74",
     ),
   "enumset":
     struct(
-      version = "0.0.4",
+      version = "0.0.4.1",
       sha256 =
-        "bc00048a2908f3ee31af810d1eca9be805cb1bb2e0908d8c6bff94134fecfcb7",
+        "5f9d115f7f2b2d4dba290f9d62cd7e9f52f6f6f8235ac5ed9bbf6e982a51d054",
     ),
   "envelope":
     struct(
@@ -4514,17 +4201,11 @@ packages = (
       sha256 =
         "cf4d6fe3f906e859ec3c16684a8dafb349e77f0fa4f21b7090ca33e707867ef9",
     ),
-  "envparse":
-    struct(
-      version = "0.4",
-      sha256 =
-        "bf9dd7cd0ed3c38f63ea45cbb496b58ad3d83022b5eab5a66bfeebec5982803d",
-    ),
   "envy":
     struct(
-      version = "1.3.0.2",
+      version = "1.5.0.0",
       sha256 =
-        "4ca0af8de7d089cf9f1e16e46a6a1300e901907f4edb3a8d393e5af11868899b",
+        "cdc099b3ae0c61007d07642c8e4811d29dfe3977b49595e21e03a1e29f741fbf",
     ),
   "epub-metadata":
     struct(
@@ -4534,9 +4215,9 @@ packages = (
     ),
   "eq":
     struct(
-      version = "4.0.4",
+      version = "4.2",
       sha256 =
-        "042f4c1e9eeb25a52c20623fc482cc00e3235198089c5b60bc36fa47ebacbde5",
+        "4160703a06af1c7518b8ff3244a04013fc7c04a012637dd26be31308e23970e8",
     ),
   "equal-files":
     struct(
@@ -4564,9 +4245,9 @@ packages = (
     ),
   "errors":
     struct(
-      version = "2.2.2",
+      version = "2.3.0",
       sha256 =
-        "f6322b61bf631c008410ef131f9b3f9db5a94de20e91d5339fba54461fa44e8f",
+        "6772e5689f07e82077ffe3339bc672934d83d83a97a7d4f1349de1302cb71f75",
     ),
   "errors-ext":
     struct(
@@ -4576,27 +4257,15 @@ packages = (
     ),
   "ersatz":
     struct(
-      version = "0.4.2",
+      version = "0.4.3",
       sha256 =
-        "aecf2d0c0dc413b52b2eadf4f75de76f72367db699086222787f65f0b93224e7",
+        "d6c9672ec9a05bc8e7546d1479404b9028ff00e3bd78780f9902194106cc1e30",
     ),
-  "esqueleto":
+  "etc":
     struct(
-      version = "2.5.3",
+      version = "0.4.0.3",
       sha256 =
-        "3d997551fe9e42b39b5eb8215d5daf4c59e33d55da5bc9eff193ae8a7f4ec482",
-    ),
-  "etcd":
-    struct(
-      version = "1.0.5",
-      sha256 =
-        "916fc01e40cc5488f54fea8c623b31087b364432a78acffd95825f5bd1311f2f",
-    ),
-  "ether":
-    struct(
-      version = "0.5.1.0",
-      sha256 =
-        "36980c9598c5e8e804695da3b966416a2221296022b39be437ec35263ea10085",
+        "834fdec224481159f13dc6c177534978bbf245d2d4dc9ed94c808096772dd576",
     ),
   "event":
     struct(
@@ -4606,9 +4275,9 @@ packages = (
     ),
   "event-list":
     struct(
-      version = "0.1.1.3",
+      version = "0.1.2",
       sha256 =
-        "f58250c839eab441221fdfcc82795f4a4bddd397cd08dc02729ebe3bb05e8416",
+        "624e30b876e0acdaea895efbb2000bbbec2d5be0743ecac9805655ae634af89c",
     ),
   "eventful-core":
     struct(
@@ -4616,23 +4285,11 @@ packages = (
       sha256 =
         "e0f55e7498d8e48232ce2d5194c69f635beaeb322cb64753766076d7b35c9019",
     ),
-  "eventful-dynamodb":
-    struct(
-      version = "0.2.0",
-      sha256 =
-        "6b1cd246ef078fe63ae57a3129c052fa4d8c14d956faf220f03f6319720b379e",
-    ),
   "eventful-memory":
     struct(
       version = "0.2.0",
       sha256 =
         "6a7c3e0a12e3c4e572927929020ad92075933e5d3c66ea61ff615a3ac217adb9",
-    ),
-  "eventful-postgresql":
-    struct(
-      version = "0.2.0",
-      sha256 =
-        "6be868f5b2aabd02c33ae90e463c1a5c938b2db14e0d1c30a1de32c83c725e17",
     ),
   "eventful-sql-common":
     struct(
@@ -4652,35 +4309,11 @@ packages = (
       sha256 =
         "a99f9d0cde3926add542c4fc59e079da7d71f2b40e2251b7d79777585c4ebfe0",
     ),
-  "eventsource-api":
-    struct(
-      version = "1.1.1",
-      sha256 =
-        "308037d5ecec8c3df2604c83db2197799fe950927b9640092b9e771e4f4dc57f",
-    ),
-  "eventsource-geteventstore-store":
-    struct(
-      version = "1.0.4",
-      sha256 =
-        "b776985bf8f72ae584a643de8d9ff8225b1e7c36219e4d95cc56c2ac382cc73a",
-    ),
-  "eventsource-store-specs":
-    struct(
-      version = "1.0.1",
-      sha256 =
-        "2d96281eace300332b950388724c82a33bbc2366ecf591648ce36e0154cde639",
-    ),
-  "eventsource-stub-store":
-    struct(
-      version = "1.0.2",
-      sha256 =
-        "b9458d0b398347e833db1f4e0e55c850dcc8f4e8fde32505612fa499e2288881",
-    ),
   "eventstore":
     struct(
-      version = "0.15.0.2",
+      version = "1.1.5",
       sha256 =
-        "9dcbf5189b86c9f3a1ff02d0b81a244bd45583847af7fba26e8305111cadaa02",
+        "a8cf2f7063970532ffb26cd72696b610f92f1df3eecaed0b6cb4ea41128e11b1",
     ),
   "every":
     struct(
@@ -4700,6 +4333,12 @@ packages = (
       sha256 =
         "4e9e87c653aa619b92e0f7c8e7d737cdc2610f0804bf619b47786165be972ce4",
     ),
+  "exception-hierarchy":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "a9424dc79f08bc98bf49353550101495c9a72ad67ba7c302388f64eed03760fe",
+    ),
   "exception-mtl":
     struct(
       version = "0.4.0.1",
@@ -4708,9 +4347,9 @@ packages = (
     ),
   "exception-transformers":
     struct(
-      version = "0.4.0.5",
+      version = "0.4.0.7",
       sha256 =
-        "564caaaac6c2d1759a13d2c2c8a1d7a4b0109035558c4641fa7a8a378961088b",
+        "925b61eb3d19148a521e79f8b4c8ac097f6e0dea6a09cc2f533279f3abf1f2ef",
     ),
   "exceptional":
     struct(
@@ -4720,9 +4359,9 @@ packages = (
     ),
   "exceptions":
     struct(
-      version = "0.8.3",
+      version = "0.10.0",
       sha256 =
-        "4d6ad97e8e3d5dc6ce9ae68a469dc2fd3f66e9d312bc6faa7ab162eddcef87be",
+        "1edd912e5ea5cbda37941b06738597d35214dc247d332b1bfffc82adadfa49d7",
     ),
   "executable-hash":
     struct(
@@ -4736,17 +4375,23 @@ packages = (
       sha256 =
         "9cc742b6d40a487b3af38dca6852ca3b50a0db94d42fe819576c84beb5adbc6f",
     ),
-  "exhaustive":
+  "exinst":
     struct(
-      version = "1.1.5",
+      version = "0.6",
       sha256 =
-        "09e67dedf95c917103b445e32dab56412fbe9c1fbec3764a844781db56347be2",
+        "e906a149bfe195c16c25a5ab9ec2116e2577e5a10de134c17dff2be2c17c925e",
+    ),
+  "exomizer":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "94c24d436d12666d16cb7171c83cedec449b992dc3aeaaa6decdc0faf8e2cfd2",
     ),
   "exp-pairs":
     struct(
-      version = "0.1.5.2",
+      version = "0.1.6.0",
       sha256 =
-        "8dadc2dc4b4f666c9fe70068634a1eb07598943d6ace86560878ed8ec0aeac9d",
+        "e63ad90fcd292a9a31bd42b94408930c7cdf06700c9879453e61423a89a75be3",
     ),
   "expiring-cache-map":
     struct(
@@ -4756,21 +4401,15 @@ packages = (
     ),
   "explicit-exception":
     struct(
-      version = "0.1.9",
+      version = "0.1.9.2",
       sha256 =
-        "1f8a6ac6f3fa078ceaeb519e913aa443fb932f5dde9473a2ac208ffaa720bdcf",
+        "60f6029777f80ec958e28cef19a15723242987a01f09f6bfef252f24207649f6",
     ),
   "extensible":
     struct(
-      version = "0.4.7.1",
+      version = "0.4.9",
       sha256 =
-        "aae40dc52f3af16f9c62bda7f65e62396424345e3be5c667352256b5150ceb11",
-    ),
-  "extensible-effects":
-    struct(
-      version = "2.1.0.0",
-      sha256 =
-        "2c7bb9a3b8a7cad0238c80e58c3870e60dae1f6fc15fb5b4b5baa632283e3b19",
+        "b752ea6f45ff57e2994e12af911c92977b54246756c5181e376e09fd28f93e86",
     ),
   "extensible-exceptions":
     struct(
@@ -4780,9 +4419,9 @@ packages = (
     ),
   "extra":
     struct(
-      version = "1.6.3",
+      version = "1.6.9",
       sha256 =
-        "35a898a41d7eced847c529a613b3b635a9f8172625d0615ce3926ad3a904ba19",
+        "2bc8cf7bd00e08f99cd6e55f7405f1b9d3950d84ef28e32b4b91bf0bc0baac77",
     ),
   "extractable-singleton":
     struct(
@@ -4796,6 +4435,12 @@ packages = (
       sha256 =
         "c4aea5df7abd2d267e012e8e4fde00eb0e7fc3aa18670ff196c433ad5a1de0c3",
     ),
+  "facts":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "dde59212abc383920c5ac5c5a0b5253f4a309d14ebbb21b45310d5b78d922e8a",
+    ),
   "fail":
     struct(
       version = "4.9.0.0",
@@ -4807,12 +4452,6 @@ packages = (
       version = "0.1.0.5",
       sha256 =
         "0e685a5445f7bce88682d209bccb47d03f06065a627475df44a8e2af8bc20fa1",
-    ),
-  "fast-builder":
-    struct(
-      version = "0.0.1.0",
-      sha256 =
-        "c18abb40d416e46e7f69e609188c99f1f0646b2db62bc7df6208b2b0a3974027",
     ),
   "fast-digits":
     struct(
@@ -4832,29 +4471,35 @@ packages = (
       sha256 =
         "45101ddc8b86402e866ec029bcfbc2662779e578e43b40acd971a9f411e2be95",
     ),
-  "fasta":
+  "fay":
     struct(
-      version = "0.10.4.2",
+      version = "0.24.0.1",
       sha256 =
-        "2b760dfd5029dee94d56010f8125f4317d6fa675a84817c352311d308d1897be",
+        "a26ef27237670a6dccbc566a649fb9e137dc736a61e65c05814b381fb86fe817",
+    ),
+  "fay-base":
+    struct(
+      version = "0.21.1.0",
+      sha256 =
+        "5f94e3657276c5d15fcec039e8fa28f4f0d923aab17069518f6a7ca208c029c4",
+    ),
+  "fay-dom":
+    struct(
+      version = "0.5.0.1",
+      sha256 =
+        "e0f2e4dc11a13c4a9c43d707a3cf24bc1badb585540d24b29e8a6bc6ace1a6fe",
     ),
   "fb":
     struct(
-      version = "1.1.1",
+      version = "1.2.1",
       sha256 =
-        "c8d23435144e58af8ee64dde629f072043e4800daecce1bddb0670069a657f65",
+        "a9d670a763e2ccf3e457e6b310769d5d8977cb1c00a78c8825861999da055d15",
     ),
   "fclabels":
     struct(
-      version = "2.0.3.2",
+      version = "2.0.3.3",
       sha256 =
-        "4d5d83ffc3c8bc610e9c42e19c2e07a1ca68666310261de15703c605047182b0",
-    ),
-  "fdo-notify":
-    struct(
-      version = "0.3.1",
-      sha256 =
-        "7083414bb25e3057f6444722288cebf4ad3e4c2616f95f26079c8c7762989fd8",
+        "9a9472a46dc23b5acc0545d345ecd708f7b003f72ab212e2d12125b902b9c2e0",
     ),
   "feature-flags":
     struct(
@@ -4864,9 +4509,9 @@ packages = (
     ),
   "fedora-haskell-tools":
     struct(
-      version = "0.4",
+      version = "0.5.1",
       sha256 =
-        "e0e805970b15a2d50153ed9270797475d4ecd60ddbbb84d9032ee84967880504",
+        "b9a9119aace941ff5860c02462bf340c6f3cce29f7bdcb42af98dedfa9888394",
     ),
   "feed":
     struct(
@@ -4882,15 +4527,21 @@ packages = (
     ),
   "fgl":
     struct(
-      version = "5.5.4.0",
+      version = "5.6.0.0",
       sha256 =
-        "5176891dc0a898a87df53e1b27db5eba7474f08207405a1ea06c988c09a97211",
+        "94722e1eb3dca66069e26a2d4b072c558bc896816ee016fc99521f3e16b9ccc4",
     ),
   "file-embed":
     struct(
       version = "0.0.10.1",
       sha256 =
         "33cdeb44e8fa1ca8ade64e2b8d0924ea8c70b2b521455a0f22cde36f19314152",
+    ),
+  "file-embed-lzma":
+    struct(
+      version = "0",
+      sha256 =
+        "e86cf44f747cf403898158e9fdf9342871e293097a29679fcf587aed497f0c77",
     ),
   "file-modules":
     struct(
@@ -4900,9 +4551,9 @@ packages = (
     ),
   "filecache":
     struct(
-      version = "0.2.9",
+      version = "0.4.0",
       sha256 =
-        "02e6cd64adeeab38b7f6425905332deb8f03824cb4f47a8b8855b846e195dd81",
+        "cd088db62e75138e877a88b31cf44dfa8773dc30c4a431e6b0663b6e3a764e74",
     ),
   "filelock":
     struct(
@@ -4928,6 +4579,18 @@ packages = (
       sha256 =
         "7884124056950a7f7ff393ebb7d1622695f9b66f898c60aeb8bc991c73642f21",
     ),
+  "filtrable":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "d6a53889a7d114a7ea411026b994c9f73ebfeffe68ea338ce2abf9dc977e363c",
+    ),
+  "fin":
+    struct(
+      version = "0.0.1",
+      sha256 =
+        "34d28a951f2899f1d27bfb75d53818204d6d7e5aeaaef1a326c50ae915361a57",
+    ),
   "find-clumpiness":
     struct(
       version = "0.2.3.1",
@@ -4936,27 +4599,21 @@ packages = (
     ),
   "fingertree":
     struct(
-      version = "0.1.3.1",
+      version = "0.1.4.1",
       sha256 =
-        "974c35da68a4f2c3bf6fe7514b8057ff34c2894999071ae7d6a735db64fe9823",
-    ),
-  "fingertree-psqueue":
-    struct(
-      version = "0.3",
-      sha256 =
-        "9f8c2f1965ea7a618d969db6506c8f373c95e09072b2182de40713d265046c92",
+        "9778dc162963c376f02239183e782673729d01a2e1e1dbf81924d80bf6f74ea4",
     ),
   "finite-typelits":
     struct(
-      version = "0.1.3.0",
+      version = "0.1.4.2",
       sha256 =
-        "db733336de7ba5a2650f33f0b6a82dfe6699124f673b4506ffedaa4b6513489d",
+        "d207a46c911b69ecc1f7c50d9d65ea1aca6c6efacec6342bc3294ed1bc4bd747",
     ),
-  "fitspec":
+  "first-class-patterns":
     struct(
-      version = "0.4.4",
+      version = "0.3.2.4",
       sha256 =
-        "d9f3b682edb7c12f2a1cbd9e522e093e2e092070dc07263ae9e6dfc16f6c7597",
+        "3bf42829097277a89043021d02b82bde24950de9c30d19b33c0ffa5e1f2482b5",
     ),
   "fixed":
     struct(
@@ -4972,15 +4629,15 @@ packages = (
     ),
   "fixed-vector":
     struct(
-      version = "1.0.0.0",
+      version = "1.1.0.0",
       sha256 =
-        "6ff473451a7f0e7fc7b33c66a5905da937e960a51aa77b2528a7af9f1d2842f8",
+        "1ed0bef94b0fead859ad2aea0b73bf1bd3686a6c1faafc75e321fbd9c3ae94c5",
     ),
   "fixed-vector-hetero":
     struct(
-      version = "0.4.0.0",
+      version = "0.5.0.0",
       sha256 =
-        "36b6487551dc4c93e22c8f5e6e38de75ed0b12884b677b2a92bda47c781f26f4",
+        "a3f25968b260c953c6ad4ec75ba5211238b2bb07185fe1f33fb98301a4ee8690",
     ),
   "flac":
     struct(
@@ -4994,23 +4651,23 @@ packages = (
       sha256 =
         "3c1cf80c48521370ce6351d4b544c14891442bfe47c65e5bf436fe58f6fec1ce",
     ),
-  "flat":
-    struct(
-      version = "0.3",
-      sha256 =
-        "7cfa8450652c16ceb58ce630512ca4019d880e716548d0df9aaef6e631407682",
-    ),
   "flat-mcmc":
     struct(
       version = "1.5.0",
       sha256 =
         "87cea9deac6e2d32d9984741ba222ccb2fb0d5f8c58e843684476bfe7632f1fd",
     ),
+  "flay":
+    struct(
+      version = "0.4",
+      sha256 =
+        "01ff3e642eab48807e4369fd8c1336e22d7abdcf4374cd1322b1fe259c9413ef",
+    ),
   "flexible-defaults":
     struct(
-      version = "0.0.1.2",
+      version = "0.0.2",
       sha256 =
-        "827032cecf5e937d673f3a0b84fbbaba7c03fce6a567c15faf36865da9b76dc2",
+        "f3d5d41a6dd69dbb585dd10fe6b7fe9023bc4308bac1320a55b62758acc18a64",
     ),
   "floatshow":
     struct(
@@ -5020,21 +4677,15 @@ packages = (
     ),
   "flow":
     struct(
-      version = "1.0.10",
+      version = "1.0.14",
       sha256 =
-        "d28543eddbeb9d05e33fa523df0a2346685adf284e9a2108b6059150cb2117cd",
+        "08cc6d05a0b27941ca2a0e0f8e7e7a623cbbfc53814aa1e5be4e643a6005d24c",
     ),
   "fmlist":
     struct(
       version = "0.9.2",
       sha256 =
         "8fc4b55d04e7f216740a01acd2f38293e3bd9409a9495e6042a162580c420609",
-    ),
-  "fmt":
-    struct(
-      version = "0.5.0.0",
-      sha256 =
-        "ce3e15e87c04b1dcafcea8d65f894de9427a89d296e1c26a358c625558d9d194",
     ),
   "fn":
     struct(
@@ -5050,33 +4701,27 @@ packages = (
     ),
   "fold-debounce":
     struct(
-      version = "0.2.0.6",
+      version = "0.2.0.7",
       sha256 =
-        "f3652bfca100e8a499722426f7b72bcb285dee9ebcec3fecfb66ee675840788c",
+        "ff7ec4537a04beaae6926387f49dbfd98b6b6e5344e9d435503be7f2aca1c68f",
     ),
   "fold-debounce-conduit":
     struct(
-      version = "0.1.0.5",
+      version = "0.2.0.1",
       sha256 =
-        "253e73bcf6e1cb281acce2c9e39b00b2419032e4f1e0234bd19a473d210f84cc",
+        "5f98432d8d0a193ec1287c438fe53f8bd1ec4d5446aa64914f2f353f44e8500b",
     ),
   "foldl":
     struct(
-      version = "1.3.7",
+      version = "1.4.2",
       sha256 =
-        "76225f77e5a63891ca9f50fdc053be1506b6508feec73003455286e9bf316984",
+        "89c1479e075cfe692ffbf87bdde76ca10bbe9644b36677e33e7b987db5608c91",
     ),
   "folds":
     struct(
       version = "0.7.4",
       sha256 =
         "5c6e6f7c9c852cbe3d5372f93ed99f82400d15ae99ecf8e9e005481647734572",
-    ),
-  "follow-file":
-    struct(
-      version = "0.0.2",
-      sha256 =
-        "13922046769351aaeee80cce67d2fce07eca94a3a762033859fe15f7ce75c118",
     ),
   "force-layout":
     struct(
@@ -5090,11 +4735,17 @@ packages = (
       sha256 =
         "06718a214d068eaa494cc82376f23b2059a141b01048cd7efcf2176a6c3383dc",
     ),
+  "forkable-monad":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "571e33effa5baaef4e2dc910010e2b02c01d8b8e06f051e96906f288f71ad462",
+    ),
   "forma":
     struct(
-      version = "0.2.0",
+      version = "1.1.0",
       sha256 =
-        "00d0a75fb7706bd06f4e47eaafbc07e92461582d8b8e5aee76b44604d2062d17",
+        "b7dc7270e0a294cdaf40e99f067928411d82ed50af4dad51a6088830d539c325",
     ),
   "format-numbers":
     struct(
@@ -5104,21 +4755,21 @@ packages = (
     ),
   "formatting":
     struct(
-      version = "6.2.5",
+      version = "6.3.6",
       sha256 =
-        "d0a3fafe5a3e733cefc12a1031dcd76d7b9cc3552f757ae720a286d4d3429f4c",
+        "6a28db7625f912dfa0075d4376b6f1b7f84d139defda53c90e440dcf74aad31a",
     ),
   "foundation":
     struct(
-      version = "0.0.17",
+      version = "0.0.21",
       sha256 =
-        "04d1a273c5575ffd12c822995bbe4e93bfa92571b4eb9bc792ae84030fb9c201",
+        "4ed3a0e7f8052b52d27c9806eff3bea51acc2587f74f81db4b8e03e938f283e0",
     ),
   "free":
     struct(
-      version = "4.12.4",
+      version = "5.0.2",
       sha256 =
-        "c9fe45aae387855626ecb5a0fea6afdb207143cb00af3b1f715d1032d2d08784",
+        "ef05eb1c8e69742a4f962c573ef362e44ad48772940f1ef69fe39f0f77b2a396",
     ),
   "free-vl":
     struct(
@@ -5134,9 +4785,9 @@ packages = (
     ),
   "freer-simple":
     struct(
-      version = "1.0.1.1",
+      version = "1.1.0.0",
       sha256 =
-        "4b0645811635f3a9801b414229f3e7384cbadfc9a1d40c9f155422e86390bdb9",
+        "2198cdb1f6206b192bed553757cfc145485ee86be7261878bf44bc0e84b1bb01",
     ),
   "freetype2":
     struct(
@@ -5149,6 +4800,12 @@ packages = (
       version = "0.2.3.1",
       sha256 =
         "0827492c1a6116baa5c4866539a4cfa0f6d81bf31f6573616bf5ac4484199613",
+    ),
+  "friday-juicypixels":
+    struct(
+      version = "0.1.2.4",
+      sha256 =
+        "6d59828fe700ddd0777d180551c5f62444c18fd0b27ae3a675ad185efa90ae3f",
     ),
   "friendly-time":
     struct(
@@ -5176,27 +4833,21 @@ packages = (
     ),
   "fsnotify":
     struct(
-      version = "0.2.1.1",
+      version = "0.3.0.1",
       sha256 =
-        "175a75962ad07c30c031fa8931f8d3e32abc06a96676e73e65cb7207e9d2dc90",
+        "ded2165f72a2b4971f941cb83ef7f58b200e3e04159be78da55ba6c5d35f6da5",
     ),
   "fsnotify-conduit":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.1.1",
       sha256 =
-        "925bd952deddc9728461c8b5e32b36be57b64693757c4d2ce03a58bdca090e9f",
-    ),
-  "fswatch":
-    struct(
-      version = "0.1.0.2",
-      sha256 =
-        "f78699b2f3ffc673df385ea2044e3ff4af1df898c460f1b04264f8e8ac4865cc",
+        "03990f311f7d66a6996b88722602b6058fbae7ad33e74073875ef0466ef001ce",
     ),
   "funcmp":
     struct(
-      version = "1.8",
+      version = "1.9",
       sha256 =
-        "33fc37e8c05d665bc6a7a5b4406e433e19fe2c58421a034b76e1b412e8737526",
+        "08b2b982fc301af160ae5f2ab5d01e850b4ed177963fb19b4d4b2a28e7bdaab4",
     ),
   "functor-classes-compat":
     struct(
@@ -5210,6 +4861,12 @@ packages = (
       sha256 =
         "ecd664796e9cf5c608ca904897dd9ec18b471a86fcfb4216328382b28023d961",
     ),
+  "fuzzy-dates":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "e33406933fbb45172f5ee9b10194397333effecc3ce5f1495521bc903faf56c1",
+    ),
   "fuzzyset":
     struct(
       version = "0.1.0.6",
@@ -5218,9 +4875,15 @@ packages = (
     ),
   "gauge":
     struct(
-      version = "0.1.3",
+      version = "0.2.3",
       sha256 =
-        "807986c6ec1a028027b61bb2fa3c29cade9602c6766525b418884805017027c5",
+        "5a4edf8971eda80524cad65c5ecc0d4dbe65a4f38d0bdfa7823ed92f768d9a6a",
+    ),
+  "gc":
+    struct(
+      version = "0.0.2",
+      sha256 =
+        "39cc5ac887319aeb184ee0d6ddb5b5a34e3f3d38c3fdf3ecc60bdf31a53dc30c",
     ),
   "gd":
     struct(
@@ -5234,11 +4897,17 @@ packages = (
       sha256 =
         "deb8efce5e4deb5b45c0d66d23eac65224c3d560d7ac67da6d3616cd5a916721",
     ),
+  "gdp":
+    struct(
+      version = "0.0.0.2",
+      sha256 =
+        "214fff5ae2e4952cb8f15e7209be125e760b6d97fac4cd99b2e0592f790a1abf",
+    ),
   "general-games":
     struct(
-      version = "1.0.5",
+      version = "1.1.1",
       sha256 =
-        "427d0319c4aa99d8071d25bc4df7e7f1eff341b05d8f5ed85a735b1b6c032a53",
+        "8b8e9e3546738b55a74589cf76ebe46c3a2f2fd346a853f9dbbf8bd0563350c0",
     ),
   "generic-aeson":
     struct(
@@ -5254,21 +4923,21 @@ packages = (
     ),
   "generic-deriving":
     struct(
-      version = "1.12.1",
+      version = "1.12.2",
       sha256 =
-        "f5fd3f733a20deee5a6e752969edac1e04a90e2ee34e005fccb5d35a5c129473",
+        "5688b85ff1e3484e3f6073a52f99624a41c8b01ddaab9fcec20afa242f33edc4",
     ),
   "generic-lens":
     struct(
-      version = "0.5.1.0",
+      version = "1.0.0.1",
       sha256 =
-        "87d02379ba33a8039e641f3dc069877b84003541981e96b8f06f02b0ba1a0127",
+        "08a1fa26ee3f784b9fa4a107995aec119fe254a27252335eba5d39fc9ef50349",
     ),
   "generic-random":
     struct(
-      version = "1.0.0.0",
+      version = "1.2.0.0",
       sha256 =
-        "e71da0dc9af559bd5dfa94c37af0fca569ce13567faef09422a4145d5d75949b",
+        "9b1e00d2f06b582695a34cfdb2d8b62b32f64152c6ed43f5c2d776e6e9aa148c",
     ),
   "generic-xmlpickler":
     struct(
@@ -5278,9 +4947,9 @@ packages = (
     ),
   "generics-eot":
     struct(
-      version = "0.2.1.1",
+      version = "0.4",
       sha256 =
-        "89af298dd2ad37bc86ab240f3309451a6e66dd13dbf79227eb01832c3748d0d8",
+        "5abedc86df738c8ff7a8c6ca9ee97605406a1b6fadd4924fa93f7aacd2fece9b",
     ),
   "generics-sop":
     struct(
@@ -5302,117 +4971,117 @@ packages = (
     ),
   "genvalidity":
     struct(
-      version = "0.4.0.4",
+      version = "0.5.1.0",
       sha256 =
-        "fca452fe3735be8b4fffdf1e9f9761f5220ed5582a6543a6af4d48a2b56cd63d",
+        "402ad5193fefdec24c7a0c62386f764a356bfc93e5e36672fc54a824d1c0d39f",
     ),
   "genvalidity-aeson":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "4f8798118961f2c5f7986b02df2b91a1f9daa663990c70d3e1a28c9988863390",
+        "d1244fea0a0a7cad4f783a72b9ff98c606131445a3f2fe9bced5194ff8a2e7b0",
     ),
   "genvalidity-bytestring":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "4b8aa18a173740aad49964b802a150f866238973caa36549035009c7dc949cae",
+        "43b9051401d59714766d96d48435ee01016454e524af54be51427dcf804cc1e3",
     ),
   "genvalidity-containers":
     struct(
-      version = "0.3.0.0",
+      version = "0.5.0.0",
       sha256 =
-        "0c79575e61974b3bac1e294fa43e2369c76b10e3d64dafeecb35cf29c293e027",
+        "798592f343e6f0727e11dab07946adaf0fcc276380d4d1b8239c73d6aae658e2",
     ),
   "genvalidity-hspec":
     struct(
-      version = "0.5.0.0",
+      version = "0.6.1.1",
       sha256 =
-        "b50fcae1425a5da8666d0c6f439c844f87d4406711664166b083573f2b8b0cbc",
+        "7a93a3c060bb8754d633bdfd29128dbb693adb5099c6f25322ff9ba7a8d60d4b",
     ),
   "genvalidity-hspec-aeson":
     struct(
-      version = "0.1.0.1",
+      version = "0.3.0.0",
       sha256 =
-        "224f77428f59159a45a208a5531e60b70d77894bea5cdd9dc4ef285fd91d8473",
+        "b0e772bf802a4a70c7e52947d8fe301622cc7ffccf465f780042c8671075122f",
     ),
   "genvalidity-hspec-binary":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "d4f65a560e2ba34ba9fe36a08241407c235372ed830e8b5842757b9e1a1ca595",
+        "210868b5ce59fc20c406c452970003f332298bcdf900ed736975e0592a5824c0",
     ),
   "genvalidity-hspec-cereal":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "f330fca068308cfd1606e6438282c3c73c849d9d65618fff4fe044361e9aed05",
+        "e150f686eb9c161b4386d1515bd0dd12724b8d5593dbe2ebda2eca9c667a249b",
     ),
   "genvalidity-hspec-hashable":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "ce8e6131b8c793a4fcf1cf7bedc461817a91ba1ecc5d80de3641384283ae4600",
+        "3c1e48c842ced9e86c3978c61062f6afcfada9d08786e0a7368c745fc92c9f68",
     ),
   "genvalidity-path":
     struct(
-      version = "0.2.0.2",
+      version = "0.3.0.2",
       sha256 =
-        "900c6339e8057cce0a13c0342e09a548d238c6eb7eb69eeb20b82a6174f71590",
+        "00fc6d2f4d54cda700ad4af04efea62db002cab4fbb3ca8da4d20b1a03a340ba",
     ),
   "genvalidity-property":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.1.0",
       sha256 =
-        "dfd734fe9020f182c735ac0779f7f76e7d4d8e1294eabfb2f453e39259896af5",
+        "35b7401c1c8bb0a715e22cfd7172bf546f8d74efca256523a5acd39e2d179877",
     ),
   "genvalidity-scientific":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.1",
       sha256 =
-        "f231bb6a208e4b941803669f60d3121a2122f22c5686d82a027ec0f9bd3666a1",
+        "f67d54a949756d64f04c14b62a65d16dbe0b0f0656fee2f0a7332e06eb65b9f3",
     ),
   "genvalidity-text":
     struct(
-      version = "0.4.0.0",
+      version = "0.5.0.2",
       sha256 =
-        "769b3633d8770374551b49df01b29e8ef9cce1d8275715ab1cee5868430faced",
+        "1db3f2a225ab60f3b6afc92984deb1725a1f85313144a98a12a2148f8e2825b5",
     ),
   "genvalidity-time":
     struct(
-      version = "0.1.0.1",
+      version = "0.2.1.0",
       sha256 =
-        "2fb7399591faf6d53426d89f3c97a87410042269aa3e2bc9ec7f0eb4993632b5",
+        "fa3ca51cd13fd54b7ef7f8e11ac77020d36e545220c2e6d887a153aed29348e4",
     ),
   "genvalidity-unordered-containers":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.3",
       sha256 =
-        "e8fac31236806e21681fa7121a513812e54ff42133c7f82601d1af6082e7f38a",
+        "ada97e40d4a68fcfa7fe90b431ba9684bdc34fa7c7c566dc06f528b375bc0965",
     ),
   "genvalidity-uuid":
     struct(
-      version = "0.0.0.0",
+      version = "0.1.0.2",
       sha256 =
-        "ab784b9bb0465fbfaa16ae9181dc1a0e6dc7000ebde7dd366f659151aa07a9b5",
+        "d1354bdfc0a75a1f228cfed22cd0edb0cc13a925e4b2514a634d56eb5b53f412",
     ),
   "genvalidity-vector":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "990ec4f09d5baa30eaf76081db5247f95c2659ac213a185f3bab48d0b93f20c6",
+        "11d2988f3256eeedef0d5be4e5e9c7883fd4f86fde08eda6e2559ab86f673e38",
+    ),
+  "geodetics":
+    struct(
+      version = "0.0.6",
+      sha256 =
+        "e21dbbd01fac330a542fba24d6dedc6c3b46a4bf43e7fa6181417e6daab9e542",
     ),
   "getopt-generics":
     struct(
-      version = "0.13.0.1",
+      version = "0.13.0.2",
       sha256 =
-        "6902d7e366dea566f533be6b40ce219b010f1e9fcbc089285da3d4ecca524e83",
-    ),
-  "ghc-compact":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "50bc40e5e5b3a17b267250136af0c04027a9d9eb699e9fee8a5a321bae424e0f",
+        "e604aa25d7843a175ec8803e2d60eb6c959fbb4cc7fb0d8321f315ff8671600c",
     ),
   "ghc-core":
     struct(
@@ -5420,17 +5089,17 @@ packages = (
       sha256 =
         "ec34f3e5892be7c2b52945875cd330397eca3904ae1d9574559855817b8b7e85",
     ),
-  "ghc-events":
-    struct(
-      version = "0.7.0",
-      sha256 =
-        "86249a6e6d40ea645746ebc9d97aa12da5d1b478571d1b6648239914ef0e7a8b",
-    ),
   "ghc-exactprint":
     struct(
-      version = "0.5.6.0",
+      version = "0.5.6.1",
       sha256 =
-        "4f2ffa9931dae98e6f01eaee1f567fb9dd21f3028d56e0fe15184f3fc53d7839",
+        "07fd206d597631d7d8a78fb34423eb436f434a2477c69317c9a002ed23363390",
+    ),
+  "ghc-parser":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "bb74cc64ff8fd3d10447075d5982c7c684210762faa15226415d0ed7da756084",
     ),
   "ghc-paths":
     struct(
@@ -5440,75 +5109,57 @@ packages = (
     ),
   "ghc-prof":
     struct(
-      version = "1.4.1",
+      version = "1.4.1.3",
       sha256 =
-        "24a31e361ba788304534ab80d1d2ec0b9f96747a299daa2dc3fced33ec15eeca",
+        "99361f883b9942a8593d3593347877367fc5f2b313d6a2269c07cfdb28999399",
     ),
-  "ghc-syb-utils":
+  "ghc-syntax-highlighter":
     struct(
-      version = "0.2.3.3",
+      version = "0.0.2.0",
       sha256 =
-        "5f4276c987883b487e687a596bb2ecb67a76027b4b1817b55b53acd92666473a",
+        "cf335c2d5c789dd6dac948edba4cef89b3b8595b5150c21ee735c82b97868dbd",
     ),
   "ghc-tcplugins-extra":
     struct(
-      version = "0.2.2",
+      version = "0.3",
       sha256 =
-        "9807d578a57a376d7a32a0a34ad1c0014d66cd492080e89a2f57c3d520caa2cc",
+        "30acfd21d590809c16d990512fc8fcb98361ec540a76438233bd8aa23e82374c",
     ),
   "ghc-typelits-extra":
     struct(
-      version = "0.2.4",
+      version = "0.2.6",
       sha256 =
-        "afdd095ff413a40bc060c132bf298f967a393100b790d4f232040540cc39d246",
+        "958d3c44543c75fabfe2f0a0db9d9cd3182bb748af9223e9c498ce4bcdcca637",
     ),
   "ghc-typelits-knownnat":
     struct(
-      version = "0.4",
+      version = "0.5.1",
       sha256 =
-        "dbfa82c3939af306d05cbd5f88563ab25d6f71dc7e4410f3cb4ba27b25219763",
+        "5b94c42dac0ae7fe381019d77afa9fe9b290b0ab7a2d9d6e20357381fc586d7b",
     ),
   "ghc-typelits-natnormalise":
     struct(
-      version = "0.5.8",
+      version = "0.6.2",
       sha256 =
-        "21024606874541db26e965609960c9fd12a4fbfac6d8ff2053491e3527907076",
+        "801ceb41442dfa992fad04c64f2989d1d701bcfe0874a55aa8d250e63c1a4311",
     ),
   "ghcid":
     struct(
-      version = "0.6.10",
+      version = "0.7",
       sha256 =
-        "92abe44d24072573d08a65a84c500974169502c69a2bf7e6ee8c367e53300de3",
+        "0f4bda82d39bc62b7a8906439a3dd281b7859cba1efd45ae0dbc7039b7089db5",
     ),
   "ghcjs-base-stub":
     struct(
-      version = "0.1.0.4",
+      version = "0.2.0.0",
       sha256 =
-        "27ab2b99bb677b6c19813d713a22f5818b2e53062bc45d0f34648cbf26ab12a8",
+        "67bb7c931d1dc6cf2023fd8b7db126e3cd52772e5039bc3fd24585278d4a6516",
     ),
   "ghcjs-codemirror":
     struct(
-      version = "0.0.0.1",
+      version = "0.0.0.2",
       sha256 =
-        "dcd9f5288d7624c8a2a5bf8440d9de6ab8400707d366180b13cc3f472280a513",
-    ),
-  "ghcjs-dom":
-    struct(
-      version = "0.9.2.0",
-      sha256 =
-        "4a01996bb07fea34deb1ddfd049e0fd92fc2fe36ef9b3ae0182c230373b71b7a",
-    ),
-  "ghcjs-dom-jsaddle":
-    struct(
-      version = "0.9.2.0",
-      sha256 =
-        "d4c8d989ed17afae5af35e98cfc253f612f87d10fa04951eb78f7e61877e3616",
-    ),
-  "ghcjs-perch":
-    struct(
-      version = "0.3.3.2",
-      sha256 =
-        "a7cee1699b51af9e0aa62dec2ab4a04f68250106da02c77bed19dd69fae5e6d9",
+        "6cbb2c649f6d4a874eb7486a2dd33db2ed0f138f1f8289a6447460d39b4b2097",
     ),
   "ghost-buster":
     struct(
@@ -5518,69 +5169,105 @@ packages = (
     ),
   "gi-atk":
     struct(
-      version = "2.0.14",
+      version = "2.0.15",
       sha256 =
-        "f530c062127cb6f744a67b54ce427c620de23e146c7d9a098f9f46281cd4e53a",
+        "89753b4517e77ea956dcfd1294b4b98032c6e50df912e28c9a796d2b825fbfee",
     ),
   "gi-cairo":
     struct(
-      version = "1.0.14",
+      version = "1.0.17",
       sha256 =
-        "abbb705fe4c6d0616cb625438bf3f4653005d1ebd3b29cfbdc9724f824c42410",
+        "5dbda70a038a93cb07130597407de9cde1436603beca3f2a0a6b43953c55a7ab",
+    ),
+  "gi-gdk":
+    struct(
+      version = "3.0.16",
+      sha256 =
+        "7eb0aa493d268cd040c7ff70ad09d7bf7787e0e7619617ba220b88eafe68e34a",
+    ),
+  "gi-gdkpixbuf":
+    struct(
+      version = "2.0.16",
+      sha256 =
+        "fdbb5f12ecd3a419a345919913e659f90000b38b973ce79fb6e9ba05f5d4166f",
+    ),
+  "gi-gio":
+    struct(
+      version = "2.0.18",
+      sha256 =
+        "13ebcd9c5d804de97db1f0ce7de520a73ba2eed950cbf5be84950fe33a8ef440",
     ),
   "gi-glib":
     struct(
-      version = "2.0.15",
+      version = "2.0.17",
       sha256 =
-        "9f19b508035445676d9ba86bc001d228b38e79a063f8c1d26325962af8c6d3bd",
+        "9d7abe0a9d66689c5102629edb43a2336d1bb8dc805f0cbe214e5a4e799eab67",
     ),
   "gi-gobject":
     struct(
-      version = "2.0.15",
+      version = "2.0.16",
       sha256 =
-        "34675989537af44b804926ef6a8d97aaf312b81c0331a00f5f0d36611aa52841",
+        "c57844d5b9566834ece584bfbbdff1c3ef2de5aa67c711c406fe92d4b927f6ad",
+    ),
+  "gi-gtk":
+    struct(
+      version = "3.0.23",
+      sha256 =
+        "93e8211564ebd62e580ac8ce6c224c8e1f489965cd31cc2f6c193675d0443152",
+    ),
+  "gi-gtk-hs":
+    struct(
+      version = "0.3.6.1",
+      sha256 =
+        "9cb25b6585f20ab8593fd3ca544c0193d1c86d1e1bd8d8d43ae412f2c78b4161",
+    ),
+  "gi-gtksource":
+    struct(
+      version = "3.0.16",
+      sha256 =
+        "97b91b9f48b9e0c65a3936beb6e814ac5a55ab20aefbd9a167313982bd5da53a",
     ),
   "gi-javascriptcore":
     struct(
-      version = "4.0.14",
+      version = "4.0.15",
       sha256 =
-        "242477e291bf7eb768f06343c99f1854f725861ebf03419bf1ca6b13dbb7b402",
+        "03ea9ef17c74bbb57d2b6260a8f46b6e91b22de20788c53de823e9a8e32cbf1d",
     ),
-  "ginger":
+  "gi-pango":
     struct(
-      version = "0.7.3.0",
+      version = "1.0.16",
       sha256 =
-        "fa1d71fa484e2a96b46bc71669b2d6e8f8233e12c0b29e550867b5797b0493b0",
+        "a7bcc68413d7f7479e9b746eacf08b0c29a93b7c8af17005d96607ce090e78f4",
+    ),
+  "gio":
+    struct(
+      version = "0.13.5.0",
+      sha256 =
+        "5c761423e947c02181721bdac7c11293d1bd31515fabe969e7e4ac9fd7e7355c",
     ),
   "giphy-api":
     struct(
-      version = "0.5.2.0",
+      version = "0.6.0.1",
       sha256 =
-        "447111d3fa32a76ffc50b26fbec59d9e9a097d7e2facb04a7a272cb9abd97ce9",
+        "8ddfb5005bc26553850366c527c0a1a93e6b1efaf4334f195a4f5ab647408604",
     ),
-  "git":
+  "git-vogue":
     struct(
-      version = "0.2.1",
+      version = "0.3.0.2",
       sha256 =
-        "5fb7d86687262fc92faedfdb51fd99d02ef3d4bd09bc151dc2e0a1b23afd1048",
-    ),
-  "git-annex":
-    struct(
-      version = "6.20171214",
-      sha256 =
-        "30ce0b6f7314b5e138643d6342427bfaa25d27bfbab9f95001cf867557d4d51a",
+        "b41669f86776dd8fc56bec61f96f14b1fa0fc6720eaf3ed0559db97b4020705c",
     ),
   "github":
     struct(
-      version = "0.18",
+      version = "0.19",
       sha256 =
-        "31dc02d345e46b09bbc7ae7b898102630b2861b50814a13f6265c6929ad18c44",
+        "f0ea9b57cd21645bba40e37e5e7c83ad78469cc3e32526b15e9a4bb2b3b84394",
     ),
   "github-release":
     struct(
-      version = "1.1.3",
+      version = "1.2.2",
       sha256 =
-        "c0d1a541021c38d94fa68b971a242e4a63d3d30d916c47a0eba46c792d6a1e10",
+        "0684e7279625b654221e61ec0a95128e0aec0be810181699e1ca46902e92d356",
     ),
   "github-types":
     struct(
@@ -5588,35 +5275,11 @@ packages = (
       sha256 =
         "cce4ea461b3ea7c92d130181244cfe7f29c10aecc7e7a980ee6722b6d6af7867",
     ),
-  "github-webhook-handler":
+  "github-webhooks":
     struct(
-      version = "0.0.8",
+      version = "0.10.0",
       sha256 =
-        "1d908854606683c236720c2de3988ae723591be02b1c668bd8ba0ffa03b34fea",
-    ),
-  "github-webhook-handler-snap":
-    struct(
-      version = "0.0.7",
-      sha256 =
-        "d4f526f4027a0c1cd9bdf455fbfb0c1742539eb3379b22ba59f1647133202c91",
-    ),
-  "gitlib":
-    struct(
-      version = "3.1.1",
-      sha256 =
-        "dd68758b62fb0ca52f3ed851d2e68779770b1d83f2dd846528c3538aabf395ef",
-    ),
-  "gitlib-libgit2":
-    struct(
-      version = "3.1.1",
-      sha256 =
-        "fc2806ebc1bb51f5043a0d5091c5045be40bf82cae3296213b353507b8c868bb",
-    ),
-  "gitlib-test":
-    struct(
-      version = "3.1.0.3",
-      sha256 =
-        "fe0abfa269dabd63d60f856db0a82c88d6bd059de1d4d84dccaf846a1a38291f",
+        "084a8aa9cc71f89a47a0c8cdb1d0f9eac79fb7d4360ed224efd8443f0c7271df",
     ),
   "gitrev":
     struct(
@@ -5632,9 +5295,9 @@ packages = (
     ),
   "glabrous":
     struct(
-      version = "0.3.4",
+      version = "0.3.6",
       sha256 =
-        "82e0efbd130a686c97897e78f33272557a22ae5742790bf2325abc0268a7bc01",
+        "3113326be49f4e1276ad6e61d47cac07768985d7203cb718c7dd60f76cd541ad",
     ),
   "glaze":
     struct(
@@ -5644,681 +5307,51 @@ packages = (
     ),
   "glazier":
     struct(
-      version = "0.11.0.1",
+      version = "1.0.0.0",
       sha256 =
-        "1151031c7943140b19fc3b319f6e1c648cc75fa0fd619f17d64dfe7857b60b46",
-    ),
-  "glazier-pipes":
-    struct(
-      version = "0.1.5.1",
-      sha256 =
-        "9d1d044a4d8641a0da09d6447298530a8a785bb3e29c0177a0b682f9bbf4d1ac",
+        "e9c56250e48b99bfe6280c58d1458c5d35203bf3676705355a4d0bd89c7b71a4",
     ),
   "glib":
     struct(
-      version = "0.13.5.0",
+      version = "0.13.6.0",
       sha256 =
-        "72bdde540d09c75307e422dac63cdc084e41fd5dc24f9e1e121a018aa8a3a6ad",
-    ),
-  "glob-posix":
-    struct(
-      version = "0.1.0.1",
-      sha256 =
-        "3245382c77ebaceea958ef62510d073b96e10a43bf69536cf9079d69da363caf",
+        "4e71062c6a458440294d820e21449aa4666deed2ea233ef5915da7c1d4aee8eb",
     ),
   "gloss":
     struct(
-      version = "1.11.1.1",
+      version = "1.12.0.0",
       sha256 =
-        "14e09540ba120c4d0d9153655c35602de4657aa40ad2add693ca12f825d1d653",
-    ),
-  "gloss-accelerate":
-    struct(
-      version = "2.0.0.0",
-      sha256 =
-        "2ea628c30c52a6a9600f6fd782b1aa65266a7253b6fca9968e1e1474a4f0d1c1",
-    ),
-  "gloss-algorithms":
-    struct(
-      version = "1.11.1.1",
-      sha256 =
-        "e1a7561c87a2d105054017d1c4fd393f597ddfcf0409aad097ba7e8e7aae23f2",
+        "6906d8ad72f094f16c27f19a4836e770cdae08dd90537239b067d5ddebdeac4b",
     ),
   "gloss-raster":
     struct(
-      version = "1.11.1.1",
+      version = "1.12.0.0",
       sha256 =
-        "277897eb2646fb66e23391796ed9e92360467ddf3acac196f658203cd9787c46",
-    ),
-  "gloss-raster-accelerate":
-    struct(
-      version = "2.0.0.0",
-      sha256 =
-        "2db125ba6435ee4c20ac4210a66899a063f34554e80e4b7a88c6e4e579ea18c4",
+        "c89f496a397f168f020ad69742da21a7c54265e0b5144f3224d7912a15c34191",
     ),
   "gloss-rendering":
     struct(
-      version = "1.11.1.1",
+      version = "1.12.0.0",
       sha256 =
-        "1f0a9a6d2124d4cbfb30821f1654d2cd9d7c1766310cf7f9009ccc9808474af4",
-    ),
-  "gluturtle":
-    struct(
-      version = "0.0.58.1",
-      sha256 =
-        "178658ce4f76ac0a855ca9123cdc8bda0ecc5531356551c00ba6de98dcbd934b",
+        "60d90b9729b8f6c8715d621aec8a9ded3f8f95bcb0877391d39a8e303de5c4bc",
     ),
   "gnuplot":
     struct(
-      version = "0.5.5",
+      version = "0.5.5.2",
       sha256 =
-        "286d49fac2c8864ed9c7c0b9437dfd11f2d2ceb2f3a308e584051bb6bf2947cd",
+        "b69a2c3173f6c495937b8e73d9c7f265f8cd89f6cd376a5cfdf2f91198bd97d6",
     ),
   "goggles":
     struct(
-      version = "0.1.0.3",
+      version = "0.3.2",
       sha256 =
-        "5f42635dff7597a37282482b0df0e164092f1924118a0e43d2ba87da7521c045",
-    ),
-  "gogol":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "6273f96e5936a660a5d629ce210a0ef1b4a5642910f1c90144cd3fc4db9a6431",
-    ),
-  "gogol-adexchange-buyer":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "a83e37a494957cb45627ef0793a49044db6cd95470600cfcdd78ca738765c2c2",
-    ),
-  "gogol-adexchange-seller":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "29d9b297d772fd0fd4bd1b1272c95174a000a4d5d13d0508d84de2009ada17e5",
-    ),
-  "gogol-admin-datatransfer":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "09072765af2d11e3ed49805a5235234ef92b61db3b7e2b681ec9bb37c98354e2",
-    ),
-  "gogol-admin-directory":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "f3d63b51daf3c02b438206138ea6e4b2ce7af6276c671e43348443d377f5635d",
-    ),
-  "gogol-admin-emailmigration":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8a557ffd73be13583a76a478fae4b472c1a06b122ea3ee8f9295944db623fcb4",
-    ),
-  "gogol-admin-reports":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "72ecbe342560f513873a5c88e47b08a164e14e1f459697e71cd6efb31630ba3a",
-    ),
-  "gogol-adsense":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "a3ecac82d34094764af2664249a1c5947c790a7584b804c88ba396c4f4bc3a36",
-    ),
-  "gogol-adsense-host":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3cb3bc1c00b93df70065fc4ef3852d77b67788068aca96eda4910a45f2a76fe7",
-    ),
-  "gogol-affiliates":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "6eefbc1a2739ff5d30bd3d9e5a70d2e70048c88d456ec9f6bbe86fa072e8f3c0",
-    ),
-  "gogol-analytics":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "dab773333e4a936eae02ed2789a75c3e57067fd9852f1df4c008e1cec27fcf57",
-    ),
-  "gogol-android-enterprise":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "95adec006e8057bf7a40b40d1ae461b9cc4f536271908732fdb14e2f088ed452",
-    ),
-  "gogol-android-publisher":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3b6fa3d1e7f2b32d2c241c328217ec21c022f32a4261178ec2162af37f22c4b1",
-    ),
-  "gogol-appengine":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "198a22d5ae3fb7662f4076d3c17d5f9a701e4bbafaae26bbc84412e43024358c",
-    ),
-  "gogol-apps-activity":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "a221bab93f0086c86619cb190b28ddf38fc4750fcb3acf3a9f526a40ab2f2832",
-    ),
-  "gogol-apps-calendar":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "7ddce2ee87d66c9ed038ab556f6067dfd48c968ec62b100b1a17ce0611a5513e",
-    ),
-  "gogol-apps-licensing":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "17ca7845a9d16a0c468cf491269106cb3e008d22a060831480583072a99dfe50",
-    ),
-  "gogol-apps-reseller":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "c4de2625b6124caffe1fea0af87e8949072d6aea1156f66eaabe766f72a73585",
-    ),
-  "gogol-apps-tasks":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9b9cce5138ef44469630090d25cc609e25cbfc1bf45f4f2f8e59561fb1f89655",
-    ),
-  "gogol-appstate":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "7cca025e8c02e5dc272d731f8cc89512548159f8ad99d74c6ceb151cdb2b2e89",
-    ),
-  "gogol-autoscaler":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "e0c22ad86d45cc0d1e039e9f3f234cb2752b7f754c9beab047c9dacc0972da46",
-    ),
-  "gogol-bigquery":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3f6d7c35e18ec32aea9b639353bd09126b0ee25e023cba603ea85dd6ef4944ff",
-    ),
-  "gogol-billing":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "6e61e758d8b880d83ca58d0baf0bf4a33d2166241ebcf04906390bc990704c8b",
-    ),
-  "gogol-blogger":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8732fd8df6527da1e24002f2f4c4b057f1104fcef3c896d6da55f724aa84e122",
-    ),
-  "gogol-books":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "1a16af340135b961b33d6a12152efe078e95da673c5c41d5366a4c670654e221",
-    ),
-  "gogol-civicinfo":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "4d64778d78d90c6125002e5ae22c46b9fb2a1e725bbd989eaf96c4c99f14fc69",
-    ),
-  "gogol-classroom":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b6090b9d4cb55ea13e1a98c283ad73205097d1148714dad1778cf6dcbe4632ae",
-    ),
-  "gogol-cloudmonitoring":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9d3e7440779bbfae0b2291ddc2ba1fe82133958de03872532276d06d1c62ae06",
-    ),
-  "gogol-cloudtrace":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "66b14d70e6f6da1e0ee172e2d39cd7ea42be14bb38f1ad5a7a90b7a249855ce4",
-    ),
-  "gogol-compute":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "fa2476f62d7d8c241db9aaf3a3a0b697e97453097982d804711f022b5f13206d",
-    ),
-  "gogol-container":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "11d135532c91ad9bb698e63f95de76178c2de7abb9344a6d1ed6b58ac81cb4ef",
-    ),
-  "gogol-core":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "ffa84f391ae20af77fae17c742787b0c439ee36108a40bfc89bf8ce5c0840c90",
-    ),
-  "gogol-customsearch":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "f21fc206af0456ac283198577c7bbad90fb19a1d38db0f0d5f32c4f4893cb91c",
-    ),
-  "gogol-dataflow":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9de12084a7b529d24d386936d7d851d3cfac7be22d0bfe60befbca1bdd867fb3",
-    ),
-  "gogol-dataproc":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "c07f74b76ce02e6205e4b6b9a7dd70854d53a38b0ff4cc561ce253dd11093aac",
-    ),
-  "gogol-datastore":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "45681c1c06cf5eb4dfb8bde7e4a2bbb23f12b6426863c42da80eba1aa9debd71",
-    ),
-  "gogol-debugger":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "fbe833cb6ff9e5dc123edc29c58099178366a647c932ef8d2fac0bf3e8a11217",
-    ),
-  "gogol-deploymentmanager":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3a2d4a05cab1a044384df7644709ec0e8c46a12158fba2b94b3e3f71fb118c06",
-    ),
-  "gogol-dfareporting":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "27ea407b608a3a21b04d511db036e172b7715f988fbafec6914b5e1279f70a36",
-    ),
-  "gogol-discovery":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "c8b57e687a2278182cb4a851f82877c1f4318cf55bf3c64069ac248cfb1f52c8",
-    ),
-  "gogol-dns":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b4d4fc7228a5eb575ff440245269cf20e6eddd81d131151d5b1ef0d39d194ea1",
-    ),
-  "gogol-doubleclick-bids":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "0c985e054319520307981d3459d3a443dc01d9880fb4fd996a180ad76deb143f",
-    ),
-  "gogol-doubleclick-search":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8d94967b535ef3f8a437a4d16e3987403ce761da12dff36b374d32bc1ed89af3",
-    ),
-  "gogol-drive":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9fae145cf1bf4be57b9f53aba11b26f82b1ae36b4d3e2bf61d2af009f91a65d0",
-    ),
-  "gogol-firebase-rules":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "185f71924141bdcf286a1207e8b0563374879e11c17fca97a7e01c3dee0b3857",
-    ),
-  "gogol-fitness":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "bb866b003882fc932082e60898f4d6261f4ffd26833f6e1682972df2030b94ab",
-    ),
-  "gogol-fonts":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "bb96e0afcc5cf0ae7285f49e3bf8b9d30274f1f315d0632e96f3b56c999d4c5c",
-    ),
-  "gogol-freebasesearch":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "6c0b7d61a05f6ece6e9e7ca9e2653cfeb18127dc70cb37ea146d3769dc65a20a",
-    ),
-  "gogol-fusiontables":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "47cf0cf75946f5ed25bf812e4cd677a946e79c231c70fe000afad1d5fe518a45",
-    ),
-  "gogol-games":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "bf99505fd85be3943ed32f71b0eec554baeb109dbc143321b1dbe0c9d10b1d64",
-    ),
-  "gogol-games-configuration":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "cf93351629177224c8615b2a0f63ec5f3b4e02fd0f116368ffcc5bf87d9ce211",
-    ),
-  "gogol-games-management":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "97acc96a19a038bcd3b232645480fbd36eea741b5a1ff706b6ca6a0b338757a4",
-    ),
-  "gogol-genomics":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "6ef65fc936a005edfbd8ddb0544b3452b9d1ebbcbe696c7c26cc25b0a9243135",
-    ),
-  "gogol-gmail":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "03bd9cc7bd8147901e870dbd5b8e15df85b31392bcec2f8156e0fac656293f41",
-    ),
-  "gogol-groups-migration":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b3b65424c086c42ee8e77fc90f0c18699fc662989aa36cd16e4b987e6633c730",
-    ),
-  "gogol-groups-settings":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "681cc39a36e82ea2fdc7f084c75ad50f1ee25961f6bae3983e71b19eba31c4f7",
-    ),
-  "gogol-identity-toolkit":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9f4f3a7cf728eb5d1abb237192ebbcdfc37712d58e00698b53d4a2f54afbb3d5",
-    ),
-  "gogol-kgsearch":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "566c71568fdfdd8f83e263e41511eb36ca315da777b9e62a82e80ae788e18d4e",
-    ),
-  "gogol-latencytest":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "d329a3c92505dfeb97225ae86cb5cf13ef35707782f6910071f96873d9a6b4bd",
-    ),
-  "gogol-logging":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8f0058d85ebd8eaa459ea9c7ac4ff8abc5033e00c3285488ed3810903116b8c4",
-    ),
-  "gogol-maps-coordinate":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "76734dcea7ce6536bfd5538c3066e1da59e05ec460a1ab20ffa6299f9e704faa",
-    ),
-  "gogol-maps-engine":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "7bb71e90c975d025ede3d6d185d10553f3f56ba498cf1b32f5a3a9dde7f94695",
-    ),
-  "gogol-mirror":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "15bab1544b8beb41e5ecd3cd70c8ad337d601f2f49302fd8f287a126e7127032",
-    ),
-  "gogol-monitoring":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "ea9d36d17913aa98c9acc088a5211a03f38dc85abe79eab37ad66656c2a35a0e",
-    ),
-  "gogol-oauth2":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b674d7211638a76305d1ea0995f9ce17ef12657dca929744d48c00b8a7c1b239",
-    ),
-  "gogol-pagespeed":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3d431c1dc6bcefc3b4a4a38e7296fb2091fcda424b69bb8af7ee9c4f3830d6cc",
-    ),
-  "gogol-partners":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "dbb506a04bc7a866364b7c9cce30503dd2f1ffbf2f4f0d0c8ababa4dafae1076",
-    ),
-  "gogol-people":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "dbe9523e3a7b5d0a2128b56a2f5a948c87c2e9bbf5ae4439d859ce940ace4e48",
-    ),
-  "gogol-play-moviespartner":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "ec03c3465bd8435357f231ab227d7312b01aa6b156591288aaa492e483d02c6c",
-    ),
-  "gogol-plus":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "1b6d98a0b9d1498153fc599b37599ba30e3266f6a9b6e387a82882cde4e49a63",
-    ),
-  "gogol-plus-domains":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "71ef298c3ec48cc9f92fcc0a7a254ddf345278ccd8686c76bee90bdab68c0a34",
-    ),
-  "gogol-prediction":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "cfc088e8e8837d65f4f3b3e3c2aea7491e1ae40aac30445924ff79ce29cfd28c",
-    ),
-  "gogol-proximitybeacon":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "5b540108ac241848a83766ee5ce8100d805d368f7f6f11aea1f1d5b4499da4b8",
-    ),
-  "gogol-pubsub":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "335adc19c913d446c226c16c9107ee7e69d85cf7fe4e2146634eae812be658b0",
-    ),
-  "gogol-qpxexpress":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "a00c993c43ca00d141590c203162b923443d9f9a3a1dfc100791d8b984136883",
-    ),
-  "gogol-replicapool":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "54861dacc5e2c299433d784bd0c8a8a6e8e6f8f7001ed9ece7e5d7e9d77153ce",
-    ),
-  "gogol-replicapool-updater":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8260d9fd9284f5aee5691118c60468177ded3a97cca561613aa015af1c2ff591",
-    ),
-  "gogol-resourcemanager":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "cb50c3f678c5a93d3db6a68dd2b9e06f2da8a0f802e7faa913ed97ce234d5258",
-    ),
-  "gogol-resourceviews":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "77aa60901029f7d9be3e93acbf92a6e9d6fdc7f1bf8931571c7892fa7b938f84",
-    ),
-  "gogol-script":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "01cd14a58d60422083fffe8a1ff7401808f0d930f87924fc27b136fb476a4bd0",
-    ),
-  "gogol-sheets":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "2dd5593fb556dc62237dbec27eef6f195cc3661201df019b504d5161443a41ce",
-    ),
-  "gogol-shopping-content":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "a5c4728c17ee78d63c39770d503115d13e7931fc711d7724d816be3c45470617",
-    ),
-  "gogol-siteverification":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b0853d9a5cc5d1a6e18966b8b4e525487c8cac9e30a51b0297bd5c20b6a4245e",
-    ),
-  "gogol-spectrum":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "ab387e91fbfb6aa4695f2785383df1991891d900d072432812f01adfa532a92c",
-    ),
-  "gogol-sqladmin":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "7964b65fa87ef3540dc96a9e09ea13f210e361cc7e1213b76ea196e3b1069c98",
-    ),
-  "gogol-storage":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "3b95f472a42d714031d5b553707c403dedc31b86d8dc0760f5e071be567ec4a2",
-    ),
-  "gogol-storage-transfer":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "eb13d8452cff8e356ef40fec0d0333851a367c3a5a76c1db7a242849b5a18a47",
-    ),
-  "gogol-tagmanager":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "f7511a169acb4d04f86f6e7bad9a1a026a66d8642cd18bc6a6afcdedc7a45743",
-    ),
-  "gogol-taskqueue":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "03cbed41c2add112dbddf606cd3d7ea1bc857bd93e6742c296c40a0cd0f63f47",
-    ),
-  "gogol-translate":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "73b3fcc645c6bc55303dd4f5877c289815298eda93feee5c160cf2f063f5952f",
-    ),
-  "gogol-urlshortener":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "9bb9444e5b0a60494751ffba65b1bd887a71d8d1558e613b04dbffeeee98bcc2",
-    ),
-  "gogol-useraccounts":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "298efe783f4dcdab3c181ec1ca12ae3f6e9bf758b05fc010ad7b832e10c0f53b",
-    ),
-  "gogol-vision":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "c99525ab5beec654bbcdbf0d751869971aa915d9b28d4a04f870ecb1d9f94deb",
-    ),
-  "gogol-webmaster-tools":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "b747ffd277b136153717309d97b149c55beba77d0803698a389118b02c977766",
-    ),
-  "gogol-youtube":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "32e812a1d9fd447b23b6dfb3e6f93db64f62fef7ccf6c5001f769c2eb26c67eb",
-    ),
-  "gogol-youtube-analytics":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "70b5a5eac8da50986b23a1e2dcd44ebe0adb6ba394696db5e1579a1295440881",
-    ),
-  "gogol-youtube-reporting":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "8edc2c9f8bcc854e61a89f6dc92732dc92a197d109808f56df79c01733551d49",
-    ),
-  "google-cloud":
-    struct(
-      version = "0.0.4",
-      sha256 =
-        "09a77ce6846ea0c5f9d7e5578dcddcbaf4905437445edb45c2da35456324fb9a",
+        "a64d25c6506b172ec6f3b8a55f7934c23ccedc66c1acfb62432063dff743e93c",
     ),
   "google-oauth2-jwt":
     struct(
-      version = "0.2.2",
+      version = "0.3.0",
       sha256 =
-        "38dc52d516d085c50c4c1771a0364417d6b79aef1caa7558af21feda35c09b2a",
-    ),
-  "google-translate":
-    struct(
-      version = "0.4.1",
-      sha256 =
-        "b663f7fd7c72cac2b630b234074b5acf3d1dcdfccef1f87a03db32a1351ef176",
+        "72fd0f2fa82b734bc099c108ab0f168b1faaf6fb855d4dfb1df6348167ab27d6",
     ),
   "gpolyline":
     struct(
@@ -6340,15 +5373,15 @@ packages = (
     ),
   "graphs":
     struct(
-      version = "0.7",
+      version = "0.7.1",
       sha256 =
-        "eea656ac6092eac99bafc0b7817efa34529b895408fc1267a5b573fb332f6f4c",
+        "acd37a7ba5dd02f24131ac8971a5f8639cc0e9db687e7d6790a84af4af0ce209",
     ),
   "graphviz":
     struct(
-      version = "2999.19.0.0",
+      version = "2999.20.0.2",
       sha256 =
-        "af0a7ff197c9de3f23e6653541446f755c824083ced04b629df6d19523fe04ea",
+        "e7662eb82d1e5b22b467fb6e9094b65731036ae04c5374058e3b52fbc055474e",
     ),
   "gravatar":
     struct(
@@ -6362,65 +5395,29 @@ packages = (
       sha256 =
         "2d8173e61da8d02c39cb95e6ccea8a167c792f682a496aed5fe4edfd0e6a0082",
     ),
+  "greskell":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "70c45b76aa802d0cd567f026bf2ceb5bb360fc7e2fd9180fba445207a6c7df06",
+    ),
+  "greskell-core":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "1a1664043ceafdc6b6bc0a64eb104e9f03740cb9ea9249c6d9c2b496e7fb79f0",
+    ),
+  "greskell-websocket":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "b806936a188fceff94e37c43f015761a3da20c6bc0642c81ac736bda0ec8379c",
+    ),
   "groom":
     struct(
       version = "0.1.2.1",
       sha256 =
         "a6b4a4d3af1b26f63039f04bd4176493f8dd4f6a9ab281f0e33c0151c20de59d",
-    ),
-  "groundhog":
-    struct(
-      version = "0.8",
-      sha256 =
-        "16955dfe46737481400b1accd9e2b4ef3e7318e296c8b4838ba0651f7d51af1c",
-    ),
-  "groundhog-inspector":
-    struct(
-      version = "0.8.0.2",
-      sha256 =
-        "bfbad62b62174e24f8fe29ce7d3d232392a23221107a32397d91c22531e87af1",
-    ),
-  "groundhog-mysql":
-    struct(
-      version = "0.8",
-      sha256 =
-        "51ad8be513110081fff4333ae532b35e7ac5b35c4673e4c982bc0eca6c485666",
-    ),
-  "groundhog-postgresql":
-    struct(
-      version = "0.8.0.1",
-      sha256 =
-        "ad8ef33fb170dc63f97ef2add891d2e20f279f12495a2f56c7086d49c20b95e8",
-    ),
-  "groundhog-sqlite":
-    struct(
-      version = "0.8",
-      sha256 =
-        "7dcbbd4bcf9b38408bc29608a514a2b535c85490e4649090c342603c91283092",
-    ),
-  "groundhog-th":
-    struct(
-      version = "0.8.0.2",
-      sha256 =
-        "26958d982f2dd17aeacdf22386fd87bf81a5acdc93b28e80b93beaba6c6d3d8f",
-    ),
-  "group-by-date":
-    struct(
-      version = "0.1.0.2",
-      sha256 =
-        "b0b863add81e83c817dba93a8ab22c0f4b7e57643fafc630ac73190d9ee2a527",
-    ),
-  "grouped-list":
-    struct(
-      version = "0.2.1.4",
-      sha256 =
-        "309d8b5409ef785bd8720658e4fecc233c65f56002741f1e9b5d0f7f584d369c",
-    ),
-  "groupoids":
-    struct(
-      version = "4.0",
-      sha256 =
-        "6671953fa0970c13ac8014278fcd6227b4c07e1a69d5a23965e2df1418218a22",
     ),
   "groups":
     struct(
@@ -6428,17 +5425,29 @@ packages = (
       sha256 =
         "dd4588b71dfff42b9a30cb40304912742b95db964b20f51951aff0eee7f3f33d",
     ),
+  "gtk":
+    struct(
+      version = "0.14.10",
+      sha256 =
+        "28e1671eeb216335c7615513ba285a0c538d6747e38eb9acb64a5641f2650633",
+    ),
   "gtk2hs-buildtools":
     struct(
-      version = "0.13.3.1",
+      version = "0.13.4.0",
       sha256 =
-        "220f2f4aa1e01b8585fddf35bfc9f3a9dd300f2308d3c2b800c621cdd2ce7154",
+        "0f3e6ba90839efd43efe8cecbddb6478a55e2ce7788c57a0add4df477dede679",
+    ),
+  "gtk3":
+    struct(
+      version = "0.14.9",
+      sha256 =
+        "48e14ac9180fb090718fdaa5ec8f345173edbe5fdbebd6151f0a64804d0796e5",
     ),
   "gym-http-api":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.0.1",
       sha256 =
-        "1708df8beba2df0cd2d4dfd34f1a138a96930f9713bb22415d11c79ff8b5a845",
+        "2c3fd9b261cd7bc3a004d41f582cd6c629956c78f7236eb91d615ca0c9b0c910",
     ),
   "h2c":
     struct(
@@ -6448,69 +5457,57 @@ packages = (
     ),
   "hOpenPGP":
     struct(
-      version = "2.5.5",
+      version = "2.7.1",
       sha256 =
-        "1801efa965085572197253eb77bfaf2fc2a20c18d93c43c436d506237871ad54",
+        "25d5c55287841e02da98b93d7e4503d6141e4bc8f8c241f5ce69fdd26fd1dc0a",
     ),
   "hackage-db":
     struct(
-      version = "2.0",
+      version = "2.0.1",
       sha256 =
-        "f8390ab421f89bd8b03df9c3d34c86a82ea26d150dfb5cfb1bdb16f20452bf27",
+        "f0aac1af6d8d29b7fc2ffd43efaf5a7a5b00f2ead8dacff180bc3714c591ef8d",
     ),
   "hackage-security":
     struct(
-      version = "0.5.2.2",
+      version = "0.5.3.0",
       sha256 =
-        "507a837851264a774c8f4d400f798c3dac5be11dc428fe72d33ef594ca533c41",
-    ),
-  "hackernews":
-    struct(
-      version = "1.3.0.0",
-      sha256 =
-        "65944d0feb940d967c6b9823d28550f797cb6bc85f0b5bb06fe588cbe97090a0",
+        "db986e17e9265aa9e40901690815b890b97d53159eb24d0a6cafaa7c18577c21",
     ),
   "haddock-library":
     struct(
-      version = "1.4.3",
+      version = "1.5.0.1",
       sha256 =
-        "f764763f8004715431a184a981493781b8380e13fd89ca0075ac426edc5d445b",
+        "ff2c10f043524135c809303c0d81c7f27a954f0174784e59a497e75e287aabb2",
     ),
   "hailgun":
     struct(
-      version = "0.4.1.6",
+      version = "0.4.1.8",
       sha256 =
-        "066c4a4e6362420d7cd60315c3be561ea8ac06058682dda79d5180b68d317f42",
-    ),
-  "hailgun-simple":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "30526e6b7ec6083b090e880ef6fe942cc8425d3b2700bac565e4fc6629ec2954",
+        "9dcc7367afec6605045246d4959f27a29a54bbdbcec543e6f5ae59b048e2dcc3",
     ),
   "hakyll":
     struct(
-      version = "4.10.0.0",
+      version = "4.12.3.0",
       sha256 =
-        "82b7b84c5a45bcac95ba9652205a24c03418c7761d8ac0597816c646237ae57f",
+        "a472dc12e18415c0d8bab788334d753233789f2fd58a8f70de57172814639fb1",
     ),
   "half":
     struct(
-      version = "0.2.2.3",
+      version = "0.3",
       sha256 =
-        "85c244c80d1c889a3d79073a6f5a99d9e769dbe3c574ca11d992b2b4f7599a5c",
+        "06b26fb062a55fa8f5df1cc2fddc47e5303f09977279f05f62d1950a51b72093",
     ),
   "hamilton":
     struct(
-      version = "0.1.0.2",
+      version = "0.1.0.3",
       sha256 =
-        "15acc8563f60448621cffc58acf880487cc997e682e8cbc79032d5886bdc1cba",
+        "3c7623217c8e49cabc6620835e53609e7b7339f39a1523da2467076252addb1b",
     ),
-  "hamlet":
+  "hamtsolo":
     struct(
-      version = "1.2.0",
+      version = "1.0.3",
       sha256 =
-        "d1c94b259163cb37f5c02ef3418ebf4caf8d95c8ee00588d4493aa3aae1a8a66",
+        "d0deda06a582db978a417d8eed9e403c339a54c4bc9c2b6c6cdee8555dbb7035",
     ),
   "handwriting":
     struct(
@@ -6520,45 +5517,21 @@ packages = (
     ),
   "hapistrano":
     struct(
-      version = "0.3.5.2",
+      version = "0.3.5.8",
       sha256 =
-        "845fed8a507e3d1b646f7b93d15d29842add5a142f034572ac1cd191face4b61",
-    ),
-  "happstack-hsp":
-    struct(
-      version = "7.3.7.3",
-      sha256 =
-        "63185f6d991acf2bca3a060a40f4ba153e9cbbf8bd0d0db58c7d8cd74cd3f754",
-    ),
-  "happstack-jmacro":
-    struct(
-      version = "7.0.12",
-      sha256 =
-        "bab4b4197373cb674c6fcbfe48a7a5d34ec31967b6e3c771f0049d885b74aeae",
+        "ff945ebe45c1c4120a5673ebe5d7f7871c597996d132d71371d2cd4adee3e179",
     ),
   "happstack-server":
     struct(
-      version = "7.5.0.1",
+      version = "7.5.1.1",
       sha256 =
-        "8075f6b4e8e1a88365989e64e2ace2dfd9b948b572af394b3eda632233108b15",
-    ),
-  "happstack-server-tls":
-    struct(
-      version = "7.1.6.5",
-      sha256 =
-        "782fb8d8bf6b2f63c337a1308710f1611d789f42cedf7571a346c3a73a1fe142",
+        "614a65dd721bfa74ff4e0090e70c4b5c7dfb1fdb6485218b4ce1c5d50509fd61",
     ),
   "happy":
     struct(
       version = "1.19.9",
       sha256 =
         "3e81a3e813acca3aae52721c412cde18b7b7c71ecbacfaeaa5c2f4b35abf1d8d",
-    ),
-  "harp":
-    struct(
-      version = "0.4.3",
-      sha256 =
-        "4749146989a144c430f9aa52b4502570828080adb5b52117f335efc69f8ea99d",
     ),
   "hasbolt":
     struct(
@@ -6568,21 +5541,15 @@ packages = (
     ),
   "hashable":
     struct(
-      version = "1.2.6.1",
+      version = "1.2.7.0",
       sha256 =
-        "94ca8789e13bc05c1582c46b709f3b0f5aeec2092be634b8606dbd9c5915bb7a",
-    ),
-  "hashable-time":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "b5752bb9b91d7cb98b01aa68c27d6a9338e1af39763c0157ef8322d0bc15234d",
+        "ecb5efc0586023f5a0dc861100621c1dbb4cbb2f0516829a16ebac39f0432abf",
     ),
   "hashids":
     struct(
-      version = "1.0.2.3",
+      version = "1.0.2.4",
       sha256 =
-        "ecd74235e8f729514214715b828bf479701aa4b777e4f104ea07534a30822534",
+        "27991fc8a6debe76a086af80f6b72a5d451e7f1466b79cb0df973b98a2f5f3cf",
     ),
   "hashmap":
     struct(
@@ -6592,39 +5559,33 @@ packages = (
     ),
   "hashtables":
     struct(
-      version = "1.2.2.1",
+      version = "1.2.3.1",
       sha256 =
-        "7aad530a9acca57ebe58774876c5a32e13f9c4ea37e80aa50c9be9ca88dcf6bc",
+        "8fd1c7c77c267eae6af01f1d9ca427754fb092cfffc8041cd50764a9144b3cbe",
     ),
   "haskeline":
     struct(
-      version = "0.7.4.2",
+      version = "0.7.4.3",
       sha256 =
-        "5543ec8cd932396360a5c707bf0958b39bb99a559fb4fd80ed366a953c6cb0eb",
+        "046d0930bc2dbc57a7cd9ddb5d1e92c7fdb71c6b91b2bbf673f5406843d6b679",
     ),
   "haskell-gi":
     struct(
-      version = "0.20.3",
+      version = "0.21.3",
       sha256 =
-        "18d9289daa6d5fb7b52463f58f18339791e18644a131d4f3b28926dbc66f4910",
+        "c0ae6687f2402742109c3c5dab03d17ca96dfce0680624ea595ee269deb75527",
     ),
   "haskell-gi-base":
     struct(
-      version = "0.20.8",
+      version = "0.21.1",
       sha256 =
-        "91a82f170b92ed8374e1f7835c50434568702448f21ba32f0c87a15fb2fed3e1",
+        "667cf211eb6ce1e3e84fc2126670847228b4cb4211dd7d7f4ae627ef6f15295d",
     ),
   "haskell-gi-overloading":
     struct(
       version = "1.0",
       sha256 =
         "3ed797f8dd8d3535640b1ca99851bbc5968817c25a80fc499af42715d371682a",
-    ),
-  "haskell-import-graph":
-    struct(
-      version = "1.0.3",
-      sha256 =
-        "6284909ac8edd0eb3e9ac3fcc606846c3531fbf49dfe5007a346320c89b503ba",
     ),
   "haskell-lexer":
     struct(
@@ -6634,27 +5595,15 @@ packages = (
     ),
   "haskell-lsp":
     struct(
-      version = "0.2.0.1",
+      version = "0.2.2.0",
       sha256 =
-        "1ed5ce34cf5ddd86ad7babdde239fc81455a1ebc07b8445270be7c3767a86f77",
+        "adfb9231a1580ff7586130f513dc2d4436d3fc0315f0eeca60e283081a5f71c0",
     ),
-  "haskell-lsp-client":
+  "haskell-lsp-types":
     struct(
-      version = "1.0.0.1",
+      version = "0.2.2.0",
       sha256 =
-        "1c9b131e405bd1aec6e98e43f3926061fbe4e5ef4ac64cd08cae38082d40fd1b",
-    ),
-  "haskell-names":
-    struct(
-      version = "0.9.0",
-      sha256 =
-        "bd202a3ea66f0ad3ce85fb79eac4ea4aae613b762b965d6708dd20171bf7f684",
-    ),
-  "haskell-neo4j-client":
-    struct(
-      version = "0.3.2.4",
-      sha256 =
-        "30eea529b6d8bd4b887cec7a6b210dd80223d97811bb26042b0c1ccfc8c381c2",
+        "bd7a5a259daa504154c701d84d0b1176b46cbfbe46342341d2a0909631f29071",
     ),
   "haskell-spacegoo":
     struct(
@@ -6664,93 +5613,99 @@ packages = (
     ),
   "haskell-src":
     struct(
-      version = "1.0.2.0",
+      version = "1.0.3.0",
       sha256 =
-        "2a25ee5729230edddb94af8d9881efbc1d8798bd316097f4646749cb2fa491a6",
+        "b4b4941e8883da32c3f2b93f3ecdd5cff82ff9304cb91e89850b19095c908dbc",
     ),
   "haskell-src-exts":
     struct(
-      version = "1.19.1",
+      version = "1.20.2",
       sha256 =
-        "f0f5b2867673d654c7cce8a5fcc69222ea09af460c29a819c23cccf6311ba971",
+        "9f6686e8bc8b849991207304e524747b0d1dcedfea351ac073ce971b36f9a3ea",
     ),
   "haskell-src-exts-simple":
     struct(
-      version = "1.19.0.0",
+      version = "1.20.0.0",
       sha256 =
-        "41bc9166e7d08bb18b5309eb2af00ce122c70eeffd047da47e9e2d9db89a2406",
+        "b305be88204f70af3b7f2e1feb972cf38f3feafb82781e94909484c5ebbde95c",
     ),
   "haskell-src-exts-util":
     struct(
-      version = "0.2.2",
+      version = "0.2.3",
       sha256 =
-        "8f325e89da8b2856d22ddf5199a5ba961fbafc441613c392596e8edf32e33093",
+        "e833ef33423645fee4a300ff4e1354618a0d115a954cd62e72096175513803a0",
     ),
   "haskell-src-meta":
     struct(
-      version = "0.8.0.2",
+      version = "0.8.0.3",
       sha256 =
-        "4b7b143b94fcf147b96bb34822c2feeae29daadd3a22796ee36cadd5ca262c8b",
+        "8473e3555080860c2043581b398dbab67319584a568463b074a092fd4d095822",
     ),
   "haskell-tools-ast":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "a9bd5a15b850ed7d4d9c28506bb43b8ed22ec0af71eaeefc3584552cfe570d00",
+        "2cf0f51aa551c896634ee2649782ee8994bed7088a14e03961b4bf2a5e6d0149",
     ),
   "haskell-tools-backend-ghc":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "4f78531f87fec816c64e925bf0a40cfff91c5fe99331523143029365674f2031",
+        "14fe9a12005f05fac32be4c973e4b08c223bf0d6b2a879e92e190d6bf7230530",
     ),
   "haskell-tools-builtin-refactorings":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "9141196c58f6797729ce5becb31789d74ba89784defdd5792a6ed8699144b4c3",
-    ),
-  "haskell-tools-cli":
-    struct(
-      version = "1.0.0.4",
-      sha256 =
-        "d878d8095429711f8426d85a7683e352a93ab781c2fb6ff44a924a109b4f3888",
-    ),
-  "haskell-tools-daemon":
-    struct(
-      version = "1.0.0.4",
-      sha256 =
-        "9b2c32d9659b7b0db4fce768c1b432af91c22fd5807e2ac4b102d783ac4d1dbf",
+        "8916acba20c47d3091272458a131e38cb8edb26f5dd44cb7793f12ce8661a7f2",
     ),
   "haskell-tools-debug":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "402ce6c2cf22297a7f8c31f19c90735001de8d0d897eb5c5d4f2b228dd420452",
+        "14da03518f3ea1cf1778cbf7f157437a899b86bf06b99b74f8e01502894cdbd2",
     ),
   "haskell-tools-demo":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "d87af00c4f15567ac3f2b1a29bac35337a0b9dda6e7a68e2904cc99739d1126f",
+        "7deec5cfae29cecb99ee6b57cfd9d37deb0a2f2546263bbc4a5d08ca70375530",
     ),
   "haskell-tools-prettyprint":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "8905a72281f09927cff4e3426f535ab3201d402231f0a1118d06d0de1c9a3500",
+        "78396c1ac41c5810a0013077738a5ce7bf958201f6703689c0f0746ca3084206",
     ),
   "haskell-tools-refactor":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "6989c55c56547a9bf876bedcde7440a054e431356f05413bdc05e4e19d5456a4",
+        "f833e8ca1af652c68b3e3f3f5c3714c509d9748585a004a3c4764f61a2acf389",
     ),
   "haskell-tools-rewrite":
     struct(
-      version = "1.0.0.4",
+      version = "1.1.0.2",
       sha256 =
-        "4fba9235f33e47728fb6a21673778fb452af9ea8f69343e1f9d252a904374fca",
+        "a50009039c4428744f63905b0e3ca599aa4362dbe5c887deb15745bd8848e7ab",
+    ),
+  "haskey":
+    struct(
+      version = "0.3.0.2",
+      sha256 =
+        "901c08a8155d8e394a868fe5a4b7318912afda8f91349f870c4384c5ab9944e8",
+    ),
+  "haskey-btree":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "90387d9a8e2afb22f9a4ace4b8f3b1a2045b955c1283c70a614abeff2294465a",
+    ),
+  "haskey-mtl":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "1ffb00a2901dc19edeeb18299dd1a52a49ca8c25bc04e87555c1bcec90b79294",
     ),
   "haskintex":
     struct(
@@ -6758,71 +5713,41 @@ packages = (
       sha256 =
         "9d4974112f33baf47124a56f87b96892a0a37c10587098f851c71256d15cddd8",
     ),
-  "hasmin":
-    struct(
-      version = "1.0.1",
-      sha256 =
-        "53ae47c97b56590dd7b80c2d72a7c30d14c4bfa810a2b21c86abfe8a137dbec0",
-    ),
   "hasql":
     struct(
-      version = "1.1.1",
+      version = "1.3.0.2",
       sha256 =
-        "262514375a08afac2445e725ebb2d749537ce676984c2ae74f737aea931d088b",
-    ),
-  "hasql-migration":
-    struct(
-      version = "0.1.3",
-      sha256 =
-        "2d49e3b7a5ed775150abf2164795b10d087d2e1c714b0a8320f0c0094df068b3",
+        "15415132a2cc533fba7db0a3f6c13ab456eaf04b979169938ace64523c02b88b",
     ),
   "hasql-optparse-applicative":
     struct(
-      version = "0.2.4",
+      version = "0.3.0.3",
       sha256 =
-        "796b6522469fe0d7f437c82b1f833b87591572b26e16a8bcc0314bc73ee4ab3d",
+        "63b4c3da21434bac9a98521cdcfda7815bcebb8829feb889f4050fffd7f06334",
     ),
   "hasql-pool":
     struct(
-      version = "0.4.3",
+      version = "0.5",
       sha256 =
-        "124481643c6ba9a6150d1cc7ba9b9393b5a1a14cd70815d1a55a75163c80df21",
+        "3a33cdfc9ae253f193afb824c9488051103b4c71316b6db39d51dce27c825d2f",
     ),
   "hasql-transaction":
     struct(
-      version = "0.5.2",
+      version = "0.7",
       sha256 =
-        "d557161241449e9743e2a13fa2b5bdcc68b5fe97e9c6db8d9997b08777319e70",
-    ),
-  "hastache":
-    struct(
-      version = "0.6.1",
-      sha256 =
-        "8c8f89669d6125201d7163385ea9055ab8027a69d1513259f8fbdd53c244b464",
+        "decb3c5b08f710413ee65861c30766c53dc79d05f388fab6f8e1105e4d907fcf",
     ),
   "hasty-hamiltonian":
     struct(
-      version = "1.3.0",
+      version = "1.3.2",
       sha256 =
-        "15f713bc72cda97a5efad2c75d38915f3b765966142710f069db72ff49eefb31",
+        "e6299d72e145cfabea798e2088284580fc65f01638e3562e1f01cf9df018cc9e",
     ),
   "haxl":
     struct(
-      version = "0.5.1.0",
+      version = "2.0.1.0",
       sha256 =
-        "49d485041646d3210385c312d34b0cc0c61d130e95ad935e06a695515f24a827",
-    ),
-  "haxl-amazonka":
-    struct(
-      version = "0.1.1",
-      sha256 =
-        "3cdf3ee6bd46ee461e4ae640d300533229c1d4f9ab0489f613a1ec387fa270c6",
-    ),
-  "haxr":
-    struct(
-      version = "3000.11.2",
-      sha256 =
-        "ebcda06d7ee79d5e635a7ec34f86400dd54ddd2434eda082aac6d3c8fd6e8b47",
+        "cd259814d7e358a2a19c4060114b00f0dc891028ad4b89241e8ab2b67197431f",
     ),
   "hbeanstalk":
     struct(
@@ -6836,29 +5761,17 @@ packages = (
       sha256 =
         "d250cb0c066ec45aa9b8e9e0df094677f9e7788b01eaf51ab5bc9bbd52fe029f",
     ),
-  "hdevtools":
-    struct(
-      version = "0.1.6.1",
-      sha256 =
-        "e7e46acf4a6567159e431739f4c4103b91eae257394560e4b1aaa8e427393440",
-    ),
   "heap":
     struct(
-      version = "1.0.3",
+      version = "1.0.4",
       sha256 =
-        "9bd57e9ca3480d4322ccc5ec094767ee2a64425b2d4022065a8f36b44aabf402",
+        "a4c2489e1031e9e8d96dff61ac8c15e5fcd3541080d81e0e47e298b3aad3172a",
     ),
   "heaps":
     struct(
       version = "0.3.6",
       sha256 =
         "181c3cd7f2be698f903dc9649e5ec9311245ad2b9fed91b61f05d0dd7b7dddb2",
-    ),
-  "heatshrink":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "59dd111b2deb207b606d6615a3e5ca7ea3ddead77ea7b525e10e0cf26e4df37f",
     ),
   "hebrew-time":
     struct(
@@ -6868,27 +5781,27 @@ packages = (
     ),
   "hedgehog":
     struct(
-      version = "0.5.2",
+      version = "0.6",
       sha256 =
-        "902e278108a7cf4ac728e9e6a7c8f81e8fe81b34ed723fa6c47c614d21c186da",
+        "b86ffe3cf523d40e77f1547ef79d45edb62762e15328e8152959c440f7237e30",
     ),
-  "hedgehog-quickcheck":
+  "hedgehog-corpus":
     struct(
-      version = "0.1",
+      version = "0.1.0",
       sha256 =
-        "610a5ccdfcdb4d657f5b25da622ad62562d1854ddb2e7381328e0b63a66f8412",
+        "c3569cd8316770115871acf334587350e887b046e35abc0d52a90dd0e6d719f2",
     ),
   "hedis":
     struct(
-      version = "0.9.12",
+      version = "0.10.2",
       sha256 =
-        "4a15475fcd7d9173c8808247d30607f6ddb12260246a6758709da4e142032d7d",
+        "1c99bd415a3bdc241a8a3ea6397b6fff10ed3b099de79e46ffe435ad89aa7615",
     ),
   "here":
     struct(
-      version = "1.2.12",
+      version = "1.2.13",
       sha256 =
-        "ac3f7657593a087ffd26018ba3b0b5e4f309dc38ee3e8c883fbf9030ed643c4e",
+        "406f9c27ba1e59cd662d078d81dcf2908840a77df15aed31d75dd017b7773c00",
     ),
   "heredoc":
     struct(
@@ -6898,9 +5811,9 @@ packages = (
     ),
   "heterocephalus":
     struct(
-      version = "1.0.5.1",
+      version = "1.0.5.2",
       sha256 =
-        "97a4868ba4923f8d8d6048cd687476a734d891abe077e5c1d86ac5ca4dee7406",
+        "50b829508715ba246f095accd1b49f7c5f67380948d349df355bac39f4155923",
     ),
   "hex":
     struct(
@@ -6932,23 +5845,11 @@ packages = (
       sha256 =
         "40d8dbfe22f572ffdb73f28c448b228a75008e83cc3bf78e939add0c9d800914",
     ),
-  "hformat":
-    struct(
-      version = "0.3.1.0",
-      sha256 =
-        "0d6a72b70434858e9a858499bbc218b31fb6264265ccd0a2f5bbcb803ceac6d1",
-    ),
   "hfsevents":
     struct(
       version = "0.1.6",
       sha256 =
         "74c3f3f3a5e55fff320c352a2d481069ff915860a0ab970864c6a0e6b65d3f05",
-    ),
-  "hid":
-    struct(
-      version = "0.2.2",
-      sha256 =
-        "0dd5c562b871626cfad11846d0d3b788823adc12fe009403a42e5f56108773d2",
     ),
   "hidapi":
     struct(
@@ -6968,29 +5869,17 @@ packages = (
       sha256 =
         "75f17f09b9c38d51a208edee10da2f4706ee784b5cdfe8efc31f7f86bbcdccb1",
     ),
+  "hierarchy":
+    struct(
+      version = "1.0.2",
+      sha256 =
+        "25f90eff98036266e279d5730297e24bdfe27b3151cf155d29415cf7d07b1318",
+    ),
   "higher-leveldb":
     struct(
-      version = "0.4.0.1",
+      version = "0.5.0.1",
       sha256 =
-        "a1987fb0b1527c282a808e9534d6697934a488526afe47d6c6920492bbd64345",
-    ),
-  "highjson":
-    struct(
-      version = "0.4.0.0",
-      sha256 =
-        "c3eb05ed1abd9dd59eedcd22bd60b326059d0c3dcaee2a9f8238b0ac08a26962",
-    ),
-  "highjson-swagger":
-    struct(
-      version = "0.4.0.0",
-      sha256 =
-        "2df02d2fd764fd5386094de59e181314ba152bd87dc2905d9869fefd4cb87e1f",
-    ),
-  "highjson-th":
-    struct(
-      version = "0.4.0.0",
-      sha256 =
-        "f30c4937a9db6eb1cea8b9efef76855af3b4745e3a620798681b8cf3c73202c5",
+        "44fc8de63416b7878e67d8c93f0ae25e3cba4a7fad2149bb5eac34d2b8d2f95c",
     ),
   "highlighting-kate":
     struct(
@@ -6998,41 +5887,23 @@ packages = (
       sha256 =
         "d8b83385f5da2ea7aa59f28eb860fd7eba0d35a4c36192a5044ee7ea1e001baf",
     ),
-  "hindent":
-    struct(
-      version = "5.2.4.1",
-      sha256 =
-        "ce5137546afa9ef3449454464d9f31ff1699157a02cd647557962592457b6554",
-    ),
   "hinotify":
     struct(
-      version = "0.3.9",
+      version = "0.3.10",
       sha256 =
-        "f2480e4c08a516831c2221eebc6a9d3242e892932d9315c34cbe92a101c5df99",
+        "af2b7d5733ab52ca38f0d9aed1ec37304f1d6964caa0fb556b8215858c1d5d9d",
     ),
   "hint":
     struct(
-      version = "0.7.0",
+      version = "0.8.0",
       sha256 =
-        "299a735848bd6b2e0bdeeee4b47d9d52f865198fbb9403df3f6571801b3e8155",
-    ),
-  "hip":
-    struct(
-      version = "1.5.3.0",
-      sha256 =
-        "f9c7a34e9fbbb208adcf15d8ea76c44a8a13ec852261f0bb4913a3dfcac74f1e",
+        "2e702d62c8f56b799d767f3d3707bec12597bc529a051ad90bd5840581551c41",
     ),
   "histogram-fill":
     struct(
-      version = "0.8.5.0",
+      version = "0.9.0.0",
       sha256 =
-        "fbdd167d6f27c0d88f9aa8647ae95a313101c63a827275ac8d016d6028975133",
-    ),
-  "hit":
-    struct(
-      version = "0.6.3",
-      sha256 =
-        "db86b3712029a4e40d1306dd6cc9ca2c9f4c77fe65a2b74106f1cbd2de26e471",
+        "a6d078059b6b839e6785443f28e224b20a0b3a72a17354028dbc68e031b34402",
     ),
   "hjsmin":
     struct(
@@ -7040,59 +5911,41 @@ packages = (
       sha256 =
         "bec153d2396962c63998eb12d0a2c7c9f7df6f774cb00e41b6cdb1f5a4905484",
     ),
-  "hjsonpointer":
-    struct(
-      version = "1.3.0",
-      sha256 =
-        "445b496c6408ed0a84b8f4df9cc96f5faa10b437d2ba26ef850171ce3335d831",
-    ),
-  "hjsonschema":
-    struct(
-      version = "1.7.2",
-      sha256 =
-        "0381b49800e1928b28f7abf626af0b0ba3eae3d418f58206eafd1f0a1d77fdb3",
-    ),
   "hledger":
     struct(
-      version = "1.4",
+      version = "1.10",
       sha256 =
-        "e544cf4fbf7b1c25299d365ed3b891064bcf1aa1a431ecd8888ac978e9a7d490",
+        "f64420f852502e84dfa9374ace1d00a06ecf1641ad9fd3b22d7c2c48c1d5c4d3",
     ),
   "hledger-api":
     struct(
-      version = "1.4",
+      version = "1.10",
       sha256 =
-        "4739ae5cd753abd5711fe9ca61dded8c9dfa9bbec27ae4cf7000ed0059a07703",
-    ),
-  "hledger-iadd":
-    struct(
-      version = "1.2.6",
-      sha256 =
-        "66341ac68c67cca5301d15fc52cd956c21ed6d053e924307d30616e53dfcbbd0",
+        "6e51bf6eb84d600777e4008bc53cea8ab08b103d720c23e04a9954836fbcacab",
     ),
   "hledger-interest":
     struct(
-      version = "1.5.1",
+      version = "1.5.2",
       sha256 =
-        "0a02354f4e8d53e75817e05b140c4760220ac4e414fbf9772abe4f20a9f90da6",
+        "78b588a37cb4d46d93b864ad8e104d954eaa118b47327457a7bef364da109381",
     ),
   "hledger-lib":
     struct(
-      version = "1.4",
+      version = "1.10",
       sha256 =
-        "b8e310190791aae4fbb73e5b5e2e9a5e82df436df23d2844279dbb08eccd1e96",
+        "e18aaf23705f46c432519113148229ff78ddae3dcf41ef784e032bf5cc1943ce",
     ),
   "hledger-ui":
     struct(
-      version = "1.4",
+      version = "1.10.1",
       sha256 =
-        "636078c9eafea22b7705cb3a5c85f0f428345e19af91334d84325e6a4302a666",
+        "c7d41f9d2c9f486ab25a9cdb4d89759eae3974f8c4991bf46e3e5ea9bc8690c0",
     ),
   "hledger-web":
     struct(
-      version = "1.4",
+      version = "1.10",
       sha256 =
-        "f0f02f4a5f6b836cbd96f58da0b74dc108a4736d13579c740b78d8fde0eeb5d0",
+        "c9dfd130a2430a09672121d8c2e769358c9bc78e7e68118aaf8c2638f24cd4c1",
     ),
   "hlibgit2":
     struct(
@@ -7102,27 +5955,33 @@ packages = (
     ),
   "hlibsass":
     struct(
-      version = "0.1.6.1",
+      version = "0.1.7.0",
       sha256 =
-        "3e120a4f266445f50299a0009c24bd0a69a7af4c88376de0e1882a505d580849",
+        "62a75c444d8771303c6712e6fd3b3b5fd988773ec61ff06b4ed7e9d92c1c9f6d",
     ),
   "hlint":
     struct(
-      version = "2.0.11",
+      version = "2.1.8",
       sha256 =
-        "cb1897115c929e9c66b2e5e9c958ca476d8c459e7ca7214c04244b7972261710",
+        "9713ebf3d0ae16c169d0e02486ba93bfdc6349d9b82dccf8a19a58c1177e75ce",
     ),
   "hmatrix":
     struct(
-      version = "0.18.2.0",
+      version = "0.19.0.0",
       sha256 =
-        "960cdc81143d68841a036f7c642a06c5303bf8ded9737bcfc560755fef138560",
+        "52eb2e42edc5839bfd9d2dec6c4fb29997eca737537a06df7b2d09bf6c324d82",
+    ),
+  "hmatrix-backprop":
+    struct(
+      version = "0.1.2.3",
+      sha256 =
+        "bd12d7feec08e396f4174dfc35f808bfbf096370fc75aee185827d86881a03f5",
     ),
   "hmatrix-gsl":
     struct(
-      version = "0.18.0.1",
+      version = "0.19.0.1",
       sha256 =
-        "fda5c3b067bb2e47fac80995c0722bdbdf9f9320ea8a04fc2eca30f3fea9d455",
+        "157637d336c72cded119127cc3631a569018284ea8ca54b0e29e742388a2cd6c",
     ),
   "hmatrix-gsl-stats":
     struct(
@@ -7132,21 +5991,21 @@ packages = (
     ),
   "hmatrix-morpheus":
     struct(
-      version = "0.1.1.1",
+      version = "0.1.1.2",
       sha256 =
-        "729b81f4b434e0132e13508e02e688a9af182390120c0ba2144702b11f9fecf8",
-    ),
-  "hmatrix-repa":
-    struct(
-      version = "0.1.2.2",
-      sha256 =
-        "51c3a46800aea072258b05047cb0c6f24999bbb626268ce32809c5872e0e71be",
+        "f2f3ee02607096a56c7c5c7f1ddff2f7f91ee05211ec2bd659add8208b1505a7",
     ),
   "hmatrix-special":
     struct(
-      version = "0.4.0.1",
+      version = "0.19.0.0",
       sha256 =
-        "72a9c9c559da6b6314e6042ddfd53d638fdf1b819978a630fc339e0859c3ec4e",
+        "1f1f8c7f1700cea53132daecc53ca1a9733d4beac91ae1dcd2a2a03c83c9dcd7",
+    ),
+  "hmatrix-vector-sized":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "8b4edc591aa301ee2c4d2f5894ad690db8d88c9d48754f6d13c30d3eacc03b1d",
     ),
   "hmpfr":
     struct(
@@ -7154,41 +6013,23 @@ packages = (
       sha256 =
         "2badebf032a24f6ab3bde068d5246bc9cc00bf5a8ac17da8cc0bd45c882816f5",
     ),
-  "hnix":
-    struct(
-      version = "0.3.4",
-      sha256 =
-        "ec890845cc8a782ff8a2e7a2dcbaf763d5ddb3ff202293f701828d04a85adbf2",
-    ),
-  "hoauth2":
-    struct(
-      version = "1.5.1",
-      sha256 =
-        "6abf67d54ba3b6c455ea9056b817d63debe65cb19bb3c7189c5c2848103067d1",
-    ),
-  "hocilib":
-    struct(
-      version = "0.2.0",
-      sha256 =
-        "7c29cc84e7ac320cd1ddfb9d387d19c7c03fea3eedfb41713115d0e94aeafb78",
-    ),
-  "holy-project":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "b0f60f48377986212ee45a7ab360f4ef32578d4fa4b65cc21132f9c1e90a2814",
-    ),
   "hoogle":
     struct(
-      version = "5.0.14",
+      version = "5.0.17.3",
       sha256 =
-        "e7cfa9ca7496d7a30b476f3502c0dfa38671d4235042bb46806568602e97bbf8",
+        "66bebaf75600fef1c5fc0613ccc55c137aaed4c8f69653cf903f4fb003b98f9c",
+    ),
+  "hoopl":
+    struct(
+      version = "3.10.2.2",
+      sha256 =
+        "097b1316d5f1c8ffe71133223209eb2b095fe13f43dc01d1fe43fd8a545a2b97",
     ),
   "hopenpgp-tools":
     struct(
-      version = "0.19.5",
+      version = "0.21.1",
       sha256 =
-        "e0630a90c0565923b4244eb1df5ba034bcc8a7d092854d197cf47c783bd566f9",
+        "8a17a224c21115134c02844e12fa1e6c5eb5070d761fcf32d48415138b8dc77f",
     ),
   "hopenssl":
     struct(
@@ -7201,12 +6042,6 @@ packages = (
       version = "0.2.2.1",
       sha256 =
         "4d71dc0f599c87445c22403b447ce310bf8567d6b10cc82efbdd00a4d4d12a18",
-    ),
-  "hosc":
-    struct(
-      version = "0.16",
-      sha256 =
-        "72ed7430ca8b3121cb59325973c4dd75fe9df27c4023618d888eff3fef9c45f6",
     ),
   "hostname":
     struct(
@@ -7240,39 +6075,21 @@ packages = (
     ),
   "hpack":
     struct(
-      version = "0.21.2",
+      version = "0.28.2",
       sha256 =
-        "0c547729a2b6a49dd4a2cf32b737667ab94b8745e8648b375b827c1488c83abf",
-    ),
-  "hpc-coveralls":
-    struct(
-      version = "1.0.10",
-      sha256 =
-        "e222c0d36a6d266205957d0c71e1baeb1581847e79b0b5b9d883a4ef7381d0d9",
-    ),
-  "hpio":
-    struct(
-      version = "0.9.0.5",
-      sha256 =
-        "118df7aaf296d59989b24c68a614f12f45a16260504890ed088d16761415364c",
-    ),
-  "hpp":
-    struct(
-      version = "0.5.1",
-      sha256 =
-        "2be18288e29e7191a06bcddbe988330faa06960ed18574272f8b25966641bd2d",
+        "b9601332bbac2f042947be1f7478ed0c72367e4caa211b779a75dc26cd8180a3",
     ),
   "hpqtypes":
     struct(
-      version = "1.5.1.1",
+      version = "1.5.3.0",
       sha256 =
-        "b99c214d7cc83573f5bf295837b42a13a4057dc9cab701b25798086f0d54795a",
+        "ff25807beee2ce9fa59b823313b6e2fdbd6e575e6e91d885ddee0ebf8b92ffc5",
     ),
   "hprotoc":
     struct(
-      version = "2.4.6",
+      version = "2.4.11",
       sha256 =
-        "5f900d5dbe8f7152d8946abfa39b9649c1f73fc281ee894e16bd4dbdf2abc816",
+        "93f2e87e8d6fb85464162183b7c9fa4bac09676058f9f7e29cdac63706f3801c",
     ),
   "hquantlib":
     struct(
@@ -7294,9 +6111,9 @@ packages = (
     ),
   "hruby":
     struct(
-      version = "0.3.5.1",
+      version = "0.3.5.4",
       sha256 =
-        "969b829f28d369a3a99960e3890427470459425b3434576e54f8fd3ca13fef3f",
+        "739b014908dc4746880cb9e34eadbfdcfba8c5cde9abcdd06de16cf37a29d59e",
     ),
   "hs-GeoIP":
     struct(
@@ -7306,39 +6123,33 @@ packages = (
     ),
   "hs-bibutils":
     struct(
-      version = "6.2.0.1",
+      version = "6.6.0.0",
       sha256 =
-        "4b668090049bf67f107b8bcd39a4664c00b78ff596de9ccb63720af49ed4a630",
+        "14b80075b17b9bfa517e42156dafa2e2ca8951413126d27cbe5a5942bff85a58",
+    ),
+  "hs-functors":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "a7f1f058915b3554cbb0d99b475c853023f33d5dcd5b3bc280b9420841a4104a",
     ),
   "hsass":
     struct(
-      version = "0.5.0",
+      version = "0.7.0",
       sha256 =
-        "8dc4c6a7455a1182ec2dba36c489f89d7e5c1053388b2c63c4ddba6080b7501e",
-    ),
-  "hsb2hs":
-    struct(
-      version = "0.3.1",
-      sha256 =
-        "8ad800820554f273ada083dfce2f463d920fb1ceb053255023a4c883b090f9d8",
+        "73758e87ba43096c0b3eb9ed7029f30d3a4d602dbe68c97760f89e5165901a57",
     ),
   "hscolour":
     struct(
-      version = "1.24.2",
+      version = "1.24.4",
       sha256 =
-        "55fb86bafdcad9613c25910b1cbca4b071c1ddc6365538c3b3d4e350cb30cf22",
+        "243332b082294117f37b2c2c68079fa61af68b36223b3fc07594f245e0e5321d",
     ),
   "hsdns":
     struct(
       version = "1.7.1",
       sha256 =
         "4fcd00e85cde989652ab5c6b179610c9514180a00cd7b161ea33ebfec3b8a044",
-    ),
-  "hse-cpp":
-    struct(
-      version = "0.2",
-      sha256 =
-        "eeb0168c00bf5dd2975faf3f5915035c73b40063b1f315ce3fd58f66a6ae4b4c",
     ),
   "hsebaysdk":
     struct(
@@ -7364,11 +6175,11 @@ packages = (
       sha256 =
         "2f12ea1060adb46c9afb74d32b82989b3883968403e21ff125f5cf9da869b06e",
     ),
-  "hsignal":
+  "hsini":
     struct(
-      version = "0.2.7.5",
+      version = "0.5.1.2",
       sha256 =
-        "0f61f820556c431c3811643cc40e49a6d6c68075da1be0b39298a41c1c7119ac",
+        "eaa6ae68c6271d5c3187054e702719b3ee7916524ffda27bb328cc9aad9ed8e4",
     ),
   "hsinstall":
     struct(
@@ -7384,33 +6195,21 @@ packages = (
     ),
   "hslua":
     struct(
-      version = "0.9.5",
+      version = "0.9.5.2",
       sha256 =
-        "56040ace124f8d670e045fa6a9856587496a9c176b1a0b9678dc7b7bdc995fc8",
+        "0e4d26f8a76cbfb219851f33d31417c4a3c8f193123367a0749f047103d8bbe5",
     ),
   "hslua-aeson":
     struct(
-      version = "0.3.0.1",
+      version = "0.3.0.2",
       sha256 =
-        "5c90d514239f8764ebeb6697dc35fe0c6133244c3bdf684c236d9ea7161a9440",
+        "a22acf0984e7d78955ce76f75e7660f84d50b6b59fc70357d01ccbf2bbc0d861",
     ),
   "hslua-module-text":
     struct(
       version = "0.1.2.1",
       sha256 =
         "aeb384f9743b76360f3779e44065fe297fb60f27519933f203b75bd8c2ba8e2d",
-    ),
-  "hsndfile":
-    struct(
-      version = "0.8.0",
-      sha256 =
-        "e97e7ef4c26b0dba9400d9a77d3d5001735f64094b93f9733443f58f7f568efb",
-    ),
-  "hsndfile-vector":
-    struct(
-      version = "0.5.2",
-      sha256 =
-        "2ffe11eb9a3e63aae24e8e06d2e04e8ca4a617ccf1238843cc71517a905b2895",
     ),
   "hsp":
     struct(
@@ -7420,9 +6219,9 @@ packages = (
     ),
   "hspec":
     struct(
-      version = "2.4.4",
+      version = "2.5.4",
       sha256 =
-        "b01a3245da9c597608befddc4fc3cae35e5bc753235877076f11ae8e0647cf21",
+        "a852de873e4a389b62e562506f2fc11f1e8bbb4fe05350eb9004bfac0dd050a7",
     ),
   "hspec-attoparsec":
     struct(
@@ -7438,21 +6237,21 @@ packages = (
     ),
   "hspec-contrib":
     struct(
-      version = "0.4.0",
+      version = "0.5.0",
       sha256 =
-        "6f9e2201ee176c723f91ee932b7fc8b677e0d54376f897f52c133c8ca9860c16",
+        "dba7348e75572f7cd79f3f0719ab39973431927f9bb5bec1445e2f8e5b4fa78c",
     ),
   "hspec-core":
     struct(
-      version = "2.4.4",
+      version = "2.5.4",
       sha256 =
-        "601d321cdf7f2685880ee80c31154763884cb90dc512906005c4a485e8c8bfdf",
+        "589c3a979a1d05db93024a012382de441cb3d2e5eeb8a026e96bd0866d2a30e5",
     ),
   "hspec-discover":
     struct(
-      version = "2.4.4",
+      version = "2.5.4",
       sha256 =
-        "76423bc72f3ed0a80ccefb26fbf3fb16c3d74a69d69b4ce0bc88db54984d5d47",
+        "d4fed4fa3d13a8afaa23ccc4d1b8cde615bd4bbe99e05708b0003b7cdc33eef3",
     ),
   "hspec-expectations":
     struct(
@@ -7474,9 +6273,9 @@ packages = (
     ),
   "hspec-golden-aeson":
     struct(
-      version = "0.4.0.0",
+      version = "0.7.0.0",
       sha256 =
-        "f3057e3fc151be53bd6aa06392fc0da79120ceefe9410a77915cceaa64e2fa0d",
+        "114ccdbe3b7425f6bacc7d0d78d160879528aa76d2a3e774d9c152d8444a4ca2",
     ),
   "hspec-megaparsec":
     struct(
@@ -7498,9 +6297,9 @@ packages = (
     ),
   "hspec-smallcheck":
     struct(
-      version = "0.4.2",
+      version = "0.5.2",
       sha256 =
-        "ba09d4b2eb1c6ff2d680aa09b36eb6c0b395cc258ae716b8d1db511073385ed3",
+        "9a301a26a439a92b303217545b65792bd8500f25aeccbe48e46dfe914ef58119",
     ),
   "hspec-wai":
     struct(
@@ -7514,24 +6313,6 @@ packages = (
       sha256 =
         "a1c5401fa7fc7ffc46950274702a0ef30045568c2d2f5bc528cd6bf26ae28085",
     ),
-  "hspec-webdriver":
-    struct(
-      version = "1.2.0",
-      sha256 =
-        "05d0f818de7f21e3dcb10860f60fe53b393fad75892ec1c520815dd53a0385c8",
-    ),
-  "hsshellscript":
-    struct(
-      version = "3.4.5",
-      sha256 =
-        "7dbfd595832e4ecd7d12d8b36ce8a82192d79a764631c98071440a7daa7ec634",
-    ),
-  "hstatistics":
-    struct(
-      version = "0.3",
-      sha256 =
-        "7af3f698d1bded8690b1ec05017ae05310fad1f2d25ec138fb72994b0812eeec",
-    ),
   "hstatsd":
     struct(
       version = "0.1",
@@ -7540,15 +6321,9 @@ packages = (
     ),
   "hsx-jmacro":
     struct(
-      version = "7.3.8",
+      version = "7.3.8.1",
       sha256 =
-        "97c7efa3f8acc5159d697e080fb9ed7abddfca64e4f03d67cb66583fd7114495",
-    ),
-  "hsx2hs":
-    struct(
-      version = "0.14.1.2",
-      sha256 =
-        "ab3c3af38c6171be61489846d10a175c48674ecddd2bc1c6bd48a1e705b3421a",
+        "f1903d80017381408ae3f7b9d7b2e4d8c193d72ede96a33ce68fe7e276f1af59",
     ),
   "hsyslog":
     struct(
@@ -7558,15 +6333,15 @@ packages = (
     ),
   "hsyslog-udp":
     struct(
-      version = "0.2.0",
+      version = "0.2.3",
       sha256 =
-        "94bff17a34cd34efc4ce5be6905f973d0d114fef9cab5ef8bf2eaf72dbbb927c",
+        "f03fc4e26fd19f74834bff62891adeee49909326c2a7b9c93a70a9d370f4b6be",
     ),
   "htaglib":
     struct(
-      version = "1.1.1",
+      version = "1.2.0",
       sha256 =
-        "238f11b9018946760a1a22cb7bfab5abe332e4798b20dfeaecf10f3202ff9928",
+        "4a17c36ff45995c079d71368a3eeabe595ed7efe2b3e4a3dcbff4bed8324005e",
     ),
   "html":
     struct(
@@ -7576,15 +6351,21 @@ packages = (
     ),
   "html-conduit":
     struct(
-      version = "1.2.1.2",
+      version = "1.3.1",
       sha256 =
-        "536e04c9f35ab60cdb6ba62b44d903c9e55eb31d50c82cffadc30b3b33b9519c",
+        "71c13c149f471f4c7d9b6c2016eba59f3ccb80829c85ae8cc5234518e9d2e335",
     ),
   "html-email-validate":
     struct(
       version = "0.2.0.0",
       sha256 =
         "3d2a3ec75b638cec71df57512473052d485dc118aec4662d5a8dae5e95aa6daf",
+    ),
+  "html-entities":
+    struct(
+      version = "1.1.4.2",
+      sha256 =
+        "161a0c9193b4c1279e41b2ce1203ee821e8d6ee2cf755b9f070d68602ed5cee7",
     ),
   "html-entity-map":
     struct(
@@ -7600,21 +6381,21 @@ packages = (
     ),
   "http-api-data":
     struct(
-      version = "0.3.7.2",
+      version = "0.3.8.1",
       sha256 =
-        "68516edab1c01d083a9f08baa9cb78adb60cb3f6e645f1096d02879a68bf6c82",
+        "6eeaba4b29a00407cb20b865825b17b8d884c26b09c5bbe7b6e673b4522106b3",
     ),
   "http-client":
     struct(
-      version = "0.5.10",
+      version = "0.5.13.1",
       sha256 =
-        "f5f9696ed632f945f113ff23c98656aec4bcc77ed3653286c72f567d9286bac2",
+        "e121b5c676aec29f2a3b92dcbbb8b3f6acfad4ac5985141f35e5b739f75bfc6b",
     ),
   "http-client-openssl":
     struct(
-      version = "0.2.1.1",
+      version = "0.2.2.0",
       sha256 =
-        "24ee231322d25ea17ad9503c9460f5b9c20e3ff11320e3abcac6b13e4e157a9c",
+        "96410d977b70f25208d74ffc31ee00ceab4aa970347ef4f8d5757246c61210aa",
     ),
   "http-client-tls":
     struct(
@@ -7630,15 +6411,15 @@ packages = (
     ),
   "http-conduit":
     struct(
-      version = "2.2.4",
+      version = "2.3.2",
       sha256 =
-        "f4a8ffd63238059c044a6ac8dad0ad0b276a5c75499e2313a63e6cf22e1d94f1",
+        "7596448325d8b3ad31b2100fe6ba4a3447a470a461cfb7fbcc0bc90a32245ec5",
     ),
   "http-date":
     struct(
-      version = "0.0.6.1",
+      version = "0.0.7",
       sha256 =
-        "f2e106603e2b3f710f1189e478f6c20067d9a9d21a20a633fe362b3f91807636",
+        "cef9dc7e0fb512bd0c665b208b0687c1d939dc0a3d1f8fc513f7636c88d1ffc2",
     ),
   "http-link-header":
     struct(
@@ -7654,27 +6435,33 @@ packages = (
     ),
   "http-reverse-proxy":
     struct(
-      version = "0.4.5",
+      version = "0.6.0",
       sha256 =
-        "5676add3b73e5c140418bd5018416dd5c87fb526d7c25efbd2a1b0fac60f2e6c",
+        "fb1c913111478384c4f23647810b8c3c01c79e9276a08a1ea46215e4a42dd1a8",
     ),
   "http-streams":
     struct(
-      version = "0.8.5.5",
+      version = "0.8.6.1",
       sha256 =
-        "0e422240e61f5837e4736eff3172184678c8f3e403e1e2da10a90bec7c7f5ebc",
+        "b8d71f2753ac7cda35b4f03ec64e4b3c7cc4ec5c2435b5e5237fe863cb687da3",
     ),
   "http-types":
     struct(
-      version = "0.9.1",
+      version = "0.12.1",
       sha256 =
-        "7bed648cdc1c69e76bf039763dbe1074b55fd2704911dd0cb6b7dfebf1b6f550",
+        "3fa7715428f375b6aa4998ef17822871d7bfe1b55ebd9329efbacd4dad9969f3",
     ),
   "http2":
     struct(
       version = "1.6.3",
       sha256 =
         "61620eca0f57875a6a9bd24f9cc04c301b5c3c668bf98f85e9989aad5d069c43",
+    ),
+  "httpd-shed":
+    struct(
+      version = "0.4.0.3",
+      sha256 =
+        "b0ff87d81e61f788d3920d952e4469d984742ba49c006df086c159886bf09218",
     ),
   "human-readable-duration":
     struct(
@@ -7684,9 +6471,9 @@ packages = (
     ),
   "hunit-dejafu":
     struct(
-      version = "0.7.1.1",
+      version = "1.2.0.6",
       sha256 =
-        "de0bb118abdaaeada2ed759cbb0e05b15916ab36038ff01642347f27d0262cad",
+        "54aac2479fec2ecefeb7ff42e659d2d0d1fba125a339eb3df33ed2fb266ff683",
     ),
   "hvect":
     struct(
@@ -7720,9 +6507,15 @@ packages = (
     ),
   "hw-excess":
     struct(
-      version = "0.2.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "f17a4b6098f5b0337d00d77025bbcbf2c0736576bcb36eeeec1aff3b00b561a9",
+        "6735d0cd4ee86d5c13d5ea067251c6b1126f7569d78c6241f3147eb114b7a1f6",
+    ),
+  "hw-fingertree-strict":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "1127b7cff38319a292ca6d57c8b7a1996bb80b90e86488a0f82a76eba9f91268",
     ),
   "hw-hedgehog":
     struct(
@@ -7732,15 +6525,21 @@ packages = (
     ),
   "hw-hspec-hedgehog":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.0.5",
       sha256 =
-        "bce11692f95611d3182bf117bfa1f617e6382996aa63532fc34b06db24c33eb8",
+        "d3d17aadf474e82bb2d90c2d48cadf18724cbeab08e010bdf250591ce9c5f64f",
     ),
   "hw-int":
     struct(
       version = "0.0.0.3",
       sha256 =
         "8336a5111638d3298266c9a1458233a09798bfa6d558219d4fe3bdd35d8d4a3f",
+    ),
+  "hw-ip":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "3664d0fbbb1fd734b9b3a8d39b1115390ddc1a8a5e48b4ae5d5960d3ba7980bf",
     ),
   "hw-json":
     struct(
@@ -7762,9 +6561,9 @@ packages = (
     ),
   "hw-prim":
     struct(
-      version = "0.5.0.0",
+      version = "0.6.2.0",
       sha256 =
-        "32dddccbe58eedf215bc4544d05720883b47f5eb5a048faf530a9e1782df5103",
+        "dd22d1bb6e78dddf023538f8a9b327706dd570d1641642ad8d42886e8bc14e5d",
     ),
   "hw-rankselect":
     struct(
@@ -7774,9 +6573,9 @@ packages = (
     ),
   "hw-rankselect-base":
     struct(
-      version = "0.2.0.2",
+      version = "0.3.2.0",
       sha256 =
-        "de4f88db97ae2f477c3ca1ec18947a086b10a6f4815f0de0a2686d190fbae27a",
+        "7ad80a78f10fafb12851ba01825e9b1b4577be839cda54b840e43953368e654d",
     ),
   "hw-string-parse":
     struct(
@@ -7792,9 +6591,9 @@ packages = (
     ),
   "hw-xml":
     struct(
-      version = "0.1.0.1",
+      version = "0.1.0.3",
       sha256 =
-        "6dd9567dcbbebf105eeef83628840747bc967443d52f389f3932d7fb0d050e3a",
+        "27a9a8212331c8c91d4a66baf8f0785c4ce90c087c02359bd16dfaeabc627e97",
     ),
   "hweblib":
     struct(
@@ -7886,12 +6685,6 @@ packages = (
       sha256 =
         "a25c5073f42896ccf81ff5936f3a42f290730f61da7f225b126ad22ff601b1c0",
     ),
-  "ical":
-    struct(
-      version = "0.0.1",
-      sha256 =
-        "f5e45df4249aa90a87080ef6714d77d8e961c5ba50e6813062379fcdaea7d882",
-    ),
   "iconv":
     struct(
       version = "0.4.1.3",
@@ -7903,12 +6696,6 @@ packages = (
       version = "0.2.2",
       sha256 =
         "3679b4fcc0a5bcc93b6ed2009f43e3ec87bf9549aee3eef182f7403d0c10f263",
-    ),
-  "idris":
-    struct(
-      version = "1.2.0",
-      sha256 =
-        "b32f5ebcb379ceb4ea30a38f70a5ca0863a13af25d15690bd303f2902b2d352e",
     ),
   "ieee754":
     struct(
@@ -7928,11 +6715,11 @@ packages = (
       sha256 =
         "6b8845808481307e2d374fd8d17e82a5de1284e612cf8ade27db8785e9e12837",
     ),
-  "ignore":
+  "ihaskell":
     struct(
-      version = "0.1.1.0",
+      version = "0.9.0.3",
       sha256 =
-        "aaf481fdab8bdc5a506e4726eadf56697726f82086a3cd0439526b9442c73575",
+        "9720c1037f0bf79f36b2aaa960e8afd30d9672b8b5d7b5b75e4f24cf0fa38b8d",
     ),
   "ihs":
     struct(
@@ -7954,15 +6741,9 @@ packages = (
     ),
   "immortal":
     struct(
-      version = "0.2.2.1",
+      version = "0.3",
       sha256 =
-        "ed4aa1a2883a693a73fec47c8c2d5332d61a0626a2013403e1a8fb25cc6c8d8e",
-    ),
-  "importify":
-    struct(
-      version = "1.0.1",
-      sha256 =
-        "c34736871d15e77f25402902de44bd20bf13167dd8e8882993db8e3b6e39d5ea",
+        "11c89db97f33c8bbfe6f72c728c68135a247608ceb2335dfb7ac6679acb41f88",
     ),
   "include-file":
     struct(
@@ -7972,9 +6753,9 @@ packages = (
     ),
   "incremental-parser":
     struct(
-      version = "0.2.5.3",
+      version = "0.3.1.1",
       sha256 =
-        "ea508d2acdd7a2ce5c0ce33d98527b409ca2fa32b7ada59cab1716d164878618",
+        "7f87bf760af2d12967d8ffdabc8fa6f94a03a63c49e5520e2c046eb54e42f5dc",
     ),
   "indentation-core":
     struct(
@@ -7990,51 +6771,39 @@ packages = (
     ),
   "indents":
     struct(
-      version = "0.4.0.1",
+      version = "0.5.0.0",
       sha256 =
-        "14cfec09c5f54b47c9905b897cd29acdb5f7975ae3512aea938e846cecaf687f",
+        "16bcc7ca0c1292e196a9c545df507e20e96f54a94392b775a686312503d9c3d3",
+    ),
+  "indexed-list-literals":
+    struct(
+      version = "0.2.1.1",
+      sha256 =
+        "cf5d8cf1815c1798887658b616457e8ef39831323dd0ff0e19fbc46b52108fac",
     ),
   "inflections":
     struct(
-      version = "0.4.0.1",
+      version = "0.4.0.3",
       sha256 =
-        "e2c9d1063ca39147f42b7cc24be00805203bab6cc65da2732b70d3729d2280ed",
+        "bda19185f3948a8988a53b1d6b7dc8f6676033c988c1d0d3c2e615fd6e920d09",
     ),
   "influxdb":
     struct(
-      version = "1.2.2.3",
+      version = "1.6.0.6",
       sha256 =
-        "31549eb36d0f19af4259ec9f90e8c4bcf5d63f9b5b43ee8f687ed24d88218590",
+        "870e64877ede7c604571f5761ea46d2b9ce8c40961efbf86791f3103813ab9f1",
     ),
   "ini":
     struct(
-      version = "0.3.5",
+      version = "0.3.6",
       sha256 =
-        "bfd3836dfe38440987ce53f7eeffee00b54e3b7e4c0cd81ba315932cd7562cc6",
+        "fcbbe3745a125e80dd6d0b4fe9b3a590507cf73dfaa62e115b20a46f0fd53cd9",
     ),
-  "inline-c":
+  "inliterate":
     struct(
-      version = "0.6.0.5",
+      version = "0.1.0",
       sha256 =
-        "87fc915d9acc2b7a39f12dbeb66b475311a6550605c4a7e684df7793c74fc13b",
-    ),
-  "inline-c-cpp":
-    struct(
-      version = "0.2.1.0",
-      sha256 =
-        "37a690b7d1d798f16b81f6634d9597811dbf057be2d21b6d8ed6cb9cece0a70a",
-    ),
-  "inline-java":
-    struct(
-      version = "0.7.2",
-      sha256 =
-        "ab004724fc50760ea747c5fd1058860566fa3ce66ccad325fc23428df67cd241",
-    ),
-  "inline-r":
-    struct(
-      version = "0.9.1",
-      sha256 =
-        "5a65cf0ebc8c1b7647e9f690f518b10e9328e823461dae769fd29bc29ef2fbf2",
+        "2d96cc64e3b923003668c88fd73c30d5da09a2c9e2fb6af62912f54478d1e39f",
     ),
   "insert-ordered-containers":
     struct(
@@ -8044,9 +6813,9 @@ packages = (
     ),
   "inspection-testing":
     struct(
-      version = "0.1.2",
+      version = "0.2.0.1",
       sha256 =
-        "3289a12f6684475b6c18877b13b63bf4edb55488df57a811e2f830a6cb4a28ea",
+        "1f699bf8e95ab90d36725a8a090ad052dbb051cce379fd45a664f561e66ea194",
     ),
   "instance-control":
     struct(
@@ -8056,9 +6825,9 @@ packages = (
     ),
   "integer-logarithms":
     struct(
-      version = "1.0.2",
+      version = "1.0.2.1",
       sha256 =
-        "31069ccbff489baf6c4a93cb7475640aabea9366eb0b583236f10714a682b570",
+        "32ad4a482a60ec957d1af1268952e2a6b382b67438c14f74f6c2aef2e49b48f2",
     ),
   "integration":
     struct(
@@ -8068,15 +6837,15 @@ packages = (
     ),
   "intern":
     struct(
-      version = "0.9.1.4",
+      version = "0.9.2",
       sha256 =
-        "60fe200de0a1906fe22105e5c284c19b89172e5223d01abcd73fd1584b56d26a",
+        "93a3b20e96dad8d83c9145dfc68bd9d2a6a72c9f64e4a7bc257d330070f42e20",
     ),
   "interpolate":
     struct(
-      version = "0.1.1",
+      version = "0.2.0",
       sha256 =
-        "4b08483ab481ea25aa47a6b41c1e852d62cf16ba68a7dc0f6352bb8d747f1e88",
+        "6e112006073f2d91e7e93432ccb147b79a21fcc21a9dedd0d8c38cef51926abe",
     ),
   "interpolatedstring-perl6":
     struct(
@@ -8104,15 +6873,21 @@ packages = (
     ),
   "invariant":
     struct(
-      version = "0.5",
+      version = "0.5.1",
       sha256 =
-        "80bbcaeaeeeb69dfbb28648d7737b48e1d1d6cc4e7ee0d192eaade9a6351e9ff",
+        "eb8c9c45ad24020af2978f22271458bf3787937d931c50c86b580c53ca3f122b",
     ),
   "invertible":
     struct(
-      version = "0.2.0.3",
+      version = "0.2.0.5",
       sha256 =
-        "8ee341f897bf33dd4e9d7d3033f9ba59d05f175f01274ac734869b6d0385935d",
+        "0a0adaa1f371f739fd2c506ff2ba3c4db278bbdfda0171bd8329d678c15b8dbb",
+    ),
+  "invertible-grammar":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "29900cf54783b8f67449a7fd45e986efaec6270cb31f3815650e9a0406061bef",
     ),
   "io-choice":
     struct(
@@ -8164,27 +6939,27 @@ packages = (
     ),
   "ip":
     struct(
-      version = "1.1.2",
+      version = "1.3.0",
       sha256 =
-        "5201cba09422ea754cb7128332f3669bce79616963929c10e444ef2b335b729b",
+        "9e4c869d00cc8348b4648983627fb05f4b4eb4cc6b51ec72523d0419c81aac81",
     ),
   "ip6addr":
     struct(
-      version = "0.5.3",
+      version = "1.0.0",
       sha256 =
-        "1ff90994e691785a6eb4bc080d71556761f0ef6f91f0a3a1452c58a8b06e03c6",
+        "e805be52d77edfb0e71740dbfa57403654cb34929083589d79d44757c01f80f1",
     ),
   "iproute":
     struct(
-      version = "1.7.1",
+      version = "1.7.5",
       sha256 =
-        "57b8d03ca8ce92f8ec1334564f3edff53a0621ccbc43c00ba02eaa5007ee3eee",
+        "ed638e0b0a098ee4a0f5c5fe48b2a803939c0be4a3612b2d86e16fa447b581ef",
     ),
   "ipython-kernel":
     struct(
-      version = "0.9.0.1",
+      version = "0.9.0.2",
       sha256 =
-        "478f11fe74c1c7e80e91427ab7a19598188b88b94cb76828b88d0d40d92ff45b",
+        "5923468f359c50c2e9313cf1aadc1d0ba09b571a621129ff672f8e337d158206",
     ),
   "irc":
     struct(
@@ -8194,15 +6969,15 @@ packages = (
     ),
   "irc-client":
     struct(
-      version = "1.0.1.1",
+      version = "1.1.0.4",
       sha256 =
-        "dd920760a32252d9e610d410a20b88ac9793f911dcd7d44c24d6cf5bb0f0bdb4",
+        "07c1ef48d6df16da9cb46a3d917810ccd5c40d7337aa0c7291638f3275cde1a9",
     ),
   "irc-conduit":
     struct(
-      version = "0.2.2.5",
+      version = "0.3.0.1",
       sha256 =
-        "52cf916205a17be32b12d8cc844043f23a37ea81a9de7694a89e97f089de2db9",
+        "b0a8f935eb3b4613e74efce7a913592f72835194b8977271f35eb09c578b3b52",
     ),
   "irc-ctcp":
     struct(
@@ -8236,9 +7011,9 @@ packages = (
     ),
   "iso8601-time":
     struct(
-      version = "0.1.4",
+      version = "0.1.5",
       sha256 =
-        "761d737ea0841ee8fd3660cfe20041e9458be8ab424de8b3b661bb249b930126",
+        "f2cd444b2be68402c773a4b451912817f06d33093aea691b42ebeed3630ff0c8",
     ),
   "iterable":
     struct(
@@ -8252,53 +7027,35 @@ packages = (
       sha256 =
         "5007ffb6a8a7bb490f962cedceed5ceb7c435126d09bc565441070cbfda79222",
     ),
-  "ixset":
-    struct(
-      version = "1.0.7",
-      sha256 =
-        "2f0e5a581b1d3c5e4685da8b109b2089177632fe8931ae68f5973fba687b42d1",
-    ),
   "ixset-typed":
     struct(
-      version = "0.3.1.1",
+      version = "0.4",
       sha256 =
-        "d06b466c2cc56df15035d0b79f3a3eb6e7d39d878ae27dea3a7fbb9c78addc12",
+        "4aa500595aabda4a9a9099f4b801549853d4ba1936b25e5a64e692ebe53e5276",
     ),
   "jack":
     struct(
-      version = "0.7.1.1",
+      version = "0.7.1.3",
       sha256 =
-        "d17b5d299154edf55f479b9fc4508b662f4852e545dc47afa60b166ca7306c40",
+        "8cbc488ebfdb359d55f89b2ace9ea233c3875b359bee300f6171233ca6b51fd8",
     ),
   "jailbreak-cabal":
     struct(
-      version = "1.3.2",
+      version = "1.3.3",
       sha256 =
-        "212a8bbc3dfc748c4063282414a2726709d651322f3984c9989179d2352950f4",
-    ),
-  "javascript-extras":
-    struct(
-      version = "0.3.2.0",
-      sha256 =
-        "6820e8a2b33f88a10b2836d69d03bd8697d094ea7e13046c4ce09437d9640c79",
+        "6bac08ad1a1ff7452a2963272f96f5de0a3df200fb3219dde6ee93e4963dd01c",
     ),
   "jmacro":
     struct(
-      version = "0.6.14",
+      version = "0.6.15",
       sha256 =
-        "acb9411ab79f192a4ae0cd67cb45abbacef19c7a59d3199db36348b015df9920",
+        "fae43fec6f4ba9ebc1fbd5605fc1b65b1c80bb0869bcfcd80d417e6d82cb6cac",
     ),
   "jmacro-rpc":
     struct(
-      version = "0.3.2",
+      version = "0.3.3",
       sha256 =
-        "a32f53b97bc84e79834df4c4630745c6b07ae46b45bc2ca2d43d91a38571c5d9",
-    ),
-  "jmacro-rpc-happstack":
-    struct(
-      version = "0.3.2",
-      sha256 =
-        "99cdee3c1a5bd4499acf8decb2e76af48e7da7ccba01d51b86f65ea92944b064",
+        "ee912cdc6970ae6e71874e460eb40206f107371c2764f53777624a483cda1e3f",
     ),
   "jmacro-rpc-snap":
     struct(
@@ -8306,17 +7063,11 @@ packages = (
       sha256 =
         "48aea4a4ba90532ca105b6b274060a47a1c509b8346e0db1b61365c2a9e8dfeb",
     ),
-  "jni":
-    struct(
-      version = "0.5.1",
-      sha256 =
-        "8a606e511d1ee5e28424ab6e2203ec3624f8c0eb58bfc3e5afea58d85b912f53",
-    ),
   "jose":
     struct(
-      version = "0.6.0.3",
+      version = "0.7.0.0",
       sha256 =
-        "bd8b5bd4b2bd5a81c1a3d71f2be1fe2b8978ba2641ebd05c35b1951d0c17cdb4",
+        "8cd90a1a205c2dd7d8ab5e37caf4889192820128f01f9164aaefc7a91d963914",
     ),
   "jose-jwt":
     struct(
@@ -8332,69 +7083,57 @@ packages = (
     ),
   "js-jquery":
     struct(
-      version = "3.2.1",
+      version = "3.3.1",
       sha256 =
-        "60503d82d0a601291cf0aa495edecbdb749dcf8982502bf18b9a886979ac1e0f",
-    ),
-  "jsaddle":
-    struct(
-      version = "0.9.4.0",
-      sha256 =
-        "01af1f5c54a4c6e43913a152dc12693b543e78b74cc2040e637f5841f7626452",
-    ),
-  "jsaddle-dom":
-    struct(
-      version = "0.9.2.0",
-      sha256 =
-        "18c8a1a9020d3001ce6fae663887330339693d0f3ffec580e2ed5222b728a792",
+        "e0e0681f0da1130ede4e03a051630ea439c458cb97216cdb01771ebdbe44069b",
     ),
   "json":
     struct(
-      version = "0.9.1",
+      version = "0.9.2",
       sha256 =
-        "96b57e4d167e45dc80aeff872a922ae9cdb953a1ded29ebbb51019b68f0085a2",
+        "e6bb16fa791cc3833ae7b459b7e7885c1c2b11b0d294b7e095287c54fa73738e",
     ),
   "json-autotype":
     struct(
-      version = "1.0.18",
+      version = "2.0.0",
       sha256 =
-        "f0f09112c9e329f7dda2a67276d0009129b70d8ae7c85c03e25868330f8e4a40",
+        "c8f4a45a495e534d51d7c3b045894d586ca6d9d2602ffe3fd6418c84c81c3756",
     ),
-  "json-builder":
+  "json-feed":
     struct(
-      version = "0.3",
+      version = "1.0.3",
       sha256 =
-        "b5ef217d5432e8e962fac45f5a266993a0ea26d29c2580b93d0c9988d7480b4d",
+        "a0c04b49c0f499070e2eb80784139f9a85729d4fdcfea15f71c099a634e1c623",
+    ),
+  "json-rpc-client":
+    struct(
+      version = "0.2.5.0",
+      sha256 =
+        "5349f5c0b0fa8f6c5433152d6effc10846cfb3480e78c5aa99adb7540bcff49c",
     ),
   "json-rpc-generic":
     struct(
-      version = "0.2.1.3",
+      version = "0.2.1.4",
       sha256 =
-        "ca4ee53106eff161467fd067b6d9ec74ed12acafa7baba96dd6841104c07bb80",
+        "741e68586714f163cc044634c718a3b940ffac3271c9e6beaaa96257585f2b7e",
+    ),
+  "json-rpc-server":
+    struct(
+      version = "0.2.6.0",
+      sha256 =
+        "169e9997734bd1d7d07a13b5ae0223d5363c43de93b0d5fbb845a598f9eaccf5",
     ),
   "json-schema":
     struct(
-      version = "0.7.4.1",
+      version = "0.7.4.2",
       sha256 =
-        "560d6a17d6eab734f43d329e51967e3ed62f8df2a6fea4a92d06359fe77d7c96",
-    ),
-  "json-stream":
-    struct(
-      version = "0.4.1.5",
-      sha256 =
-        "304e2b7f5e95c277d3f68e7bdefc42290c57fe6d1eb65e778bc044989f39af40",
+        "e872038810b6befd18cc6a29d315ad2099f81a112b71fa5a2662070c00636f25",
     ),
   "justified-containers":
     struct(
-      version = "0.2.0.1",
+      version = "0.3.0.0",
       sha256 =
-        "82d71f25b7fa4d9d456be92e9421d9b5527cb484a2f469d09172c2331ae25b4c",
-    ),
-  "jvm":
-    struct(
-      version = "0.4.1",
-      sha256 =
-        "59fa78fa63c7bc962683f8abd9d8481895e2dd00c8c8014fe68c4f4f54b990d7",
+        "d830c0ccd036e98ec6bab2bd336bb0bd580ce0495dedf3bf2176bd8084733e87",
     ),
   "jwt":
     struct(
@@ -8404,39 +7143,21 @@ packages = (
     ),
   "kan-extensions":
     struct(
-      version = "5.0.2",
+      version = "5.2",
       sha256 =
-        "1c9ede8595424209944e59fd46c1d2edb654758be9a45c1c48a4d3cedf42482e",
+        "6b727e586f744b96529415eeabc745dfe05feea61f6b6bad90c224c879f4dbd3",
     ),
   "kanji":
     struct(
-      version = "3.0.2",
+      version = "3.4.0",
       sha256 =
-        "cba892f927b7f50a44a3dcf771797b345c3989575373835c1ee9c58ab445f8cd",
+        "d945ded925216b8f260c62c2fce593631d772bffa1f203550a6b9750ca3a81f1",
     ),
   "kansas-comet":
     struct(
       version = "0.4",
       sha256 =
         "1f1a4565f2e955b8947bafcb9611789b0ccdf9efdfed8aaa2a2aa162a07339e1",
-    ),
-  "katip":
-    struct(
-      version = "0.5.2.0",
-      sha256 =
-        "fd780a39703fe84290414a20a9c6ad1d741431f057cd0dd4771eeca98bce78d7",
-    ),
-  "katip-elasticsearch":
-    struct(
-      version = "0.4.0.4",
-      sha256 =
-        "72f92f81ac48160907f97b718203a0f9c7daeb42464e9b41fbc939fc5971e07d",
-    ),
-  "katydid":
-    struct(
-      version = "0.1.1.0",
-      sha256 =
-        "7c7bdea56f41bea000b1b0f0985e890e53529f85ed5fa6b2ff4af99ee76934c8",
     ),
   "kawhi":
     struct(
@@ -8458,21 +7179,21 @@ packages = (
     ),
   "keys":
     struct(
-      version = "3.11",
+      version = "3.12.1",
       sha256 =
-        "0cf397b7e6eb8cda930a02118c0bf262f9ef80c5a2f91822238b7778042cc4b2",
+        "7fcea48187df82c02c159dea07a581cddf371023e6a3c34de7fa69a8ef2315fb",
+    ),
+  "kleene":
+    struct(
+      version = "0",
+      sha256 =
+        "c652aecfb2a42fec6b7cc0135fe95764a27fe099c6934071ef5fa55075cd0b02",
     ),
   "kmeans":
     struct(
       version = "0.1.3",
       sha256 =
         "3d9e24a12ce01354c2a731ee079144c3bea2c9f011ffd51db82e5c26da1a2c0b",
-    ),
-  "knob":
-    struct(
-      version = "0.1.1",
-      sha256 =
-        "8c2c84cfa20f3a2d7ca0636d2b3f2822c62501358075bfa356eb964b803e1217",
     ),
   "koofr-client":
     struct(
@@ -8500,9 +7221,21 @@ packages = (
     ),
   "lackey":
     struct(
-      version = "0.4.7",
+      version = "1.0.5",
       sha256 =
-        "280d505bcc90edf6872096a91986d12d771bf4b0ad9a5e4d3ae985f32b3fdc08",
+        "c3e53667fcdc74b0d6cec072de9fc9440a045927d99a282e5cb3e923efc5b147",
+    ),
+  "lambdabot-core":
+    struct(
+      version = "5.1.0.2",
+      sha256 =
+        "c104f2294b1a4436c96c17616056335ef91137ff45de837732813515d7c40cd8",
+    ),
+  "lambdabot-irc-plugins":
+    struct(
+      version = "5.1.0.1",
+      sha256 =
+        "4e50f2430da752ac36e23cf87ce5b2db9e42cf2e76b48447d2fbc882cdeab1ab",
     ),
   "lame":
     struct(
@@ -8512,33 +7245,27 @@ packages = (
     ),
   "language-c":
     struct(
-      version = "0.7.1",
+      version = "0.8.1",
       sha256 =
-        "a7447123f9b3bec9319ee2a22b22d97f03acd6566b4f6caf5b9a1f71e4f7a9ca",
+        "6dd42c9518d22f239bc1add06c145a59e72da75c929ada984be6220c8194b369",
     ),
   "language-c-quote":
     struct(
-      version = "0.12.1",
+      version = "0.12.2",
       sha256 =
-        "ec3537f5764068890b9e9a12ec94e42f33b9d0ae2549af7eb916d59457dd3584",
+        "eb319b4d1154f88f4d0f8817c85efad34c14d774c47d4c9193c89c9064cb8695",
     ),
   "language-docker":
     struct(
-      version = "1.0.0",
+      version = "6.0.4",
       sha256 =
-        "01391b51258ec4cf5de2dc918d876042ad1c3d81074def0678f908cf3a546f08",
+        "8111f95648723df0a31fbf0424536e24dbe3a95996c013aed8f1c0a03ac534af",
     ),
-  "language-fortran":
+  "language-ecmascript":
     struct(
-      version = "0.5.1",
+      version = "0.19",
       sha256 =
-        "44cd3f3e76dc627cce8f442dbaf4f1d54b1db633c313868c8ad1d5dbe16e7f9a",
-    ),
-  "language-glsl":
-    struct(
-      version = "0.2.1",
-      sha256 =
-        "0012116b0a164831906386205df7136bc8810bcf12ea766d300a108374a21922",
+        "570a4b7bdebf4532e9c059f2afa7575247be2b7f539361995297308c387c658f",
     ),
   "language-haskell-extract":
     struct(
@@ -8548,15 +7275,15 @@ packages = (
     ),
   "language-java":
     struct(
-      version = "0.2.8",
+      version = "0.2.9",
       sha256 =
-        "0b789e089e4b18bf6248c2a1a9f3eff23cc19548899899f912597a1c33e9c367",
+        "1d15c8ad2a1eff6b195ec1ed799b8523aeda1c183392b9b713bc4aff2092190e",
     ),
   "language-javascript":
     struct(
-      version = "0.6.0.10",
+      version = "0.6.0.11",
       sha256 =
-        "caf14c410bf4463fda497af2b9ea750eddff34e55bc1cfc696f2fb4a36983e54",
+        "d4756e9bc9a180cb93701e964a3157a03d4db4c7cb5a7b6b196067e587cc6143",
     ),
   "language-nix":
     struct(
@@ -8566,27 +7293,27 @@ packages = (
     ),
   "language-puppet":
     struct(
-      version = "1.3.14",
+      version = "1.3.19.1",
       sha256 =
-        "2d950ec7fbd02021511f44c0c2317aee44a8626a58e2bb269f858bd85c03c8ed",
+        "f076c2a8f4b32c7eda47b2bec4e3d963c99a03ec1c998bf4f5d26b3fb04e2f38",
     ),
   "lapack-carray":
     struct(
-      version = "0.0",
+      version = "0.0.2",
       sha256 =
-        "3418f45efa2d3d4fbfb2c741ad0516763732f9a2d2a5f4f347b19a0d8fe203a4",
+        "ca3a3d99016b7428b3781142ca2ab96eb2ad3318257a3dedaa41f8c2e0aa24b7",
     ),
   "lapack-ffi":
     struct(
-      version = "0.0",
+      version = "0.0.2",
       sha256 =
-        "03edba5267725a411784bfbbe1fe5732ff8e06c47f1f40fb437e9a13691146e4",
+        "d4b73268bb25244f0234ef4a8b4407818e244d297612a189c7f34fe0b64ae584",
     ),
   "lapack-ffi-tools":
     struct(
-      version = "0.0.0.1",
+      version = "0.1.0.1",
       sha256 =
-        "48bf4761d014674e1118a68812d1059a70822fd72343835b7a813d93644a2724",
+        "7c9c500a04bd4c56b6d86f59498867a012b7c647c39538e4945a9c0a0d83ad31",
     ),
   "large-hashable":
     struct(
@@ -8608,21 +7335,21 @@ packages = (
     ),
   "lattices":
     struct(
-      version = "1.7",
+      version = "1.7.1.1",
       sha256 =
-        "cc062bf2b8dc0668153ff2e76343c20c6d19cc47c0ffa639595141a446c6abdc",
+        "797c89a34c6d631f76ff3bf342275f090ebceb705d6ad69c1a4108582b14ddaf",
+    ),
+  "lawful":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "0056794106bbf7fa4d8d4d943fdc75a39b8a5ac1e18ceac2909183a1a7cc8d04",
     ),
   "lazyio":
     struct(
       version = "0.1.0.4",
       sha256 =
         "8b54f0bccdc1c836393ce667ea0f1ad069d52c04762e61fad633d4d44916cf6c",
-    ),
-  "lazysmallcheck":
-    struct(
-      version = "0.6",
-      sha256 =
-        "9dd4dfb590c77e4f6aff68296602de58422eed5e7148fc29190d875a4e7d0f53",
     ),
   "lca":
     struct(
@@ -8642,17 +7369,17 @@ packages = (
       sha256 =
         "cd3bb27caf704a975ef5718a9a8e641cd9cf9a9f2df27153f7cf80405292a8d6",
     ),
+  "learn-physics":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "d28460d3ed415eb5060a8bdcaeb53339bdc05c130358efe78f52daefe5c1c948",
+    ),
   "lens":
     struct(
-      version = "4.15.4",
+      version = "4.16.1",
       sha256 =
-        "742e7b87d7945e3d9c1d39d3f8440094c0a31cd098f06a08f8dabefba0a57cd2",
-    ),
-  "lens-accelerate":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "e4a736962342c116960425a32a17f4eaccc03bf583c09d2a619779deee5c9548",
+        "f5bec97b1d5cf3d6487afebc79b927bd5a18f1fd594b104de36a35bf606ea4c6",
     ),
   "lens-action":
     struct(
@@ -8686,15 +7413,27 @@ packages = (
     ),
   "lens-family-th":
     struct(
-      version = "0.5.0.1",
+      version = "0.5.0.2",
       sha256 =
-        "fa37572374dc69fc859c023864654704d490160b579a51434ae22208cbe93703",
+        "9c275afad37a5064b9a13c6207ee2307f6ccccc3a5517c0fae84524bad65b0e6",
     ),
   "lens-labels":
     struct(
-      version = "0.1.0.2",
+      version = "0.2.0.1",
       sha256 =
-        "01ef26c8a59e720d8dff21658cffac91f1b6535b2e9defb25cfe81262d6efc86",
+        "929fea0fe771702780d309e4b2915327cde062a51219df5561bc18dac1c5c0da",
+    ),
+  "lens-misc":
+    struct(
+      version = "0.0.2.0",
+      sha256 =
+        "59925fe9125e297df0f1afcc8ac0f25de14fd017f7848ac2687ed63850ecd8cb",
+    ),
+  "lens-properties":
+    struct(
+      version = "4.11.1",
+      sha256 =
+        "4f7c5b75a7204c151dbe62160a6917a22ab9e2a1b2e3848b7043d972ac8f4cb1",
     ),
   "lens-regex":
     struct(
@@ -8708,23 +7447,17 @@ packages = (
       sha256 =
         "613d99b8074197f8a026a641a9940dd188e0d81e808169f420981a9ca15b832a",
     ),
-  "lentil":
+  "lenz":
     struct(
-      version = "1.0.9.1",
+      version = "0.3.0.0",
       sha256 =
-        "3998153cde9222a81c5b04e0d6bb8ab9244987e64c5f0567b31159612cf04081",
+        "632232db41f7c49359f37ed541bbbbe99f74d45c1cf583d1081b83af426a439d",
     ),
   "leveldb-haskell":
     struct(
       version = "0.6.5",
       sha256 =
         "a417b088068deba73a77936c1345302bac7ce06019fb10254857cafad1d76c28",
-    ),
-  "lexer-applicative":
-    struct(
-      version = "2.1.0.1",
-      sha256 =
-        "3e9612800e7d70f997e0d3396628b91133568b9e85e2c160834d1eb96acca49c",
     ),
   "libffi":
     struct(
@@ -8744,41 +7477,17 @@ packages = (
       sha256 =
         "b7978be50d6182101ca79fb3ea83d0621f5394d483d1fa1eb7d590e45f8d3f3f",
     ),
-  "libinfluxdb":
-    struct(
-      version = "0.0.4",
-      sha256 =
-        "25b5bbc274c9e18bc46ea0271805adfcaaec6d46caa69eb465e0cbc03f63ef3f",
-    ),
   "libmpd":
     struct(
-      version = "0.9.0.7",
+      version = "0.9.0.8",
       sha256 =
-        "17f0f200227ee74999e70fb2c45a590efc73af80187bc0c9de60af8e22d92622",
-    ),
-  "liboath-hs":
-    struct(
-      version = "0.0.1.0",
-      sha256 =
-        "cf2a2763d43b59747e2e35429fa4f5f09af803c4744a8aaec924d27240caafb2",
-    ),
-  "libsystemd-journal":
-    struct(
-      version = "1.4.2",
-      sha256 =
-        "f3f900d329d0daa1e927ebb5da89636587e489fda8d9c17a3f9854e7ae26ab5d",
+        "582b0a405e39148d3a5046e8ad00c9e217688e60c70393eb36cd651e1991ed4e",
     ),
   "libxml-sax":
     struct(
       version = "0.7.5",
       sha256 =
         "99141784cc0d6c5749f0df618b2d46922391eede09f4f9ccfc36fb58a9c16d51",
-    ),
-  "licensor":
-    struct(
-      version = "0.2.2",
-      sha256 =
-        "9f7e0d24279553b79af2152d04f652d0f569ce67dc2e58f5550827dd02d7ac4f",
     ),
   "lift-generics":
     struct(
@@ -8788,15 +7497,15 @@ packages = (
     ),
   "lifted-async":
     struct(
-      version = "0.9.3.3",
+      version = "0.10.0.2",
       sha256 =
-        "ae37d9cab3dd21aa65e4722c5268585d2d555fea1e8870920e7e567160240dbf",
+        "8ed740437f5ca16aa4d7508626cfa3da14f3305f292b0976a8a2072642c9e380",
     ),
   "lifted-base":
     struct(
-      version = "0.2.3.11",
+      version = "0.2.3.12",
       sha256 =
-        "8ec47a9fce7cf5913766a5c53e1b2cf254be733fa9d62e6e2f3f24e538005aab",
+        "c134a95f56750aae806e38957bb03c59627cda16034af9e00a02b699474317c5",
     ),
   "line":
     struct(
@@ -8806,15 +7515,9 @@ packages = (
     ),
   "linear":
     struct(
-      version = "1.20.7",
+      version = "1.20.8",
       sha256 =
-        "4b88b6268d327220a296b6790c82db8ebab52973735af0a9de1c734cdc07cab6",
-    ),
-  "linear-accelerate":
-    struct(
-      version = "0.5.0.1",
-      sha256 =
-        "3444712b29b06f8412d1f34fbe4252f81e4d3704e546e7b914fb2232be810b4e",
+        "5ebd1b99837f2e3c7386bcd2ca425d9c66b09a61409792b141428345fb9edb10",
     ),
   "linked-list-with-iterator":
     struct(
@@ -8830,15 +7533,15 @@ packages = (
     ),
   "linux-namespaces":
     struct(
-      version = "0.1.2.0",
+      version = "0.1.3.0",
       sha256 =
-        "585c69130dfcc499cfba00385ae7facc8ab9f2c26bdf746a6e25fc96d3b5f67b",
+        "1412db341c574b6a18e2fa23ee5e3ca6f32719409ea602a6215f1fd0aafb73e7",
     ),
   "list-t":
     struct(
-      version = "1.0.0.1",
+      version = "1.0.1",
       sha256 =
-        "4a4929b3733e692dd8072cc8521691dcc5e207f2218fe0201b9285641df8f701",
+        "c3438dde9d22e882ccdad091eb9c6f95706e9d564a57d5f845e991e706436773",
     ),
   "listsafe":
     struct(
@@ -8848,15 +7551,21 @@ packages = (
     ),
   "llvm-hs":
     struct(
-      version = "5.1.3",
+      version = "6.3.0",
       sha256 =
-        "ccdac4683f56135ba83ed0883231f686d1784e9bc7f072a34fcf041e0661976b",
+        "4d9e74b6ab369d4d3abe8395bda47a395d0c44c9bcbc0be9f94a6a76811b6183",
+    ),
+  "llvm-hs-pretty":
+    struct(
+      version = "0.5.0.0",
+      sha256 =
+        "0dca50bf44df9128fe6f4ad0ed09281c1fc4e615ceac390b2197d2f7f8e9259c",
     ),
   "llvm-hs-pure":
     struct(
-      version = "5.1.2",
+      version = "6.2.1",
       sha256 =
-        "c4d0993aacda72107e6d34865421f128b8c27b586b95a68e2a3e94700645d954",
+        "7908a944616107142a804b5e4a9772c12358b3bd78de3ddb91a63d82cdfb3da9",
     ),
   "lmdb":
     struct(
@@ -8866,27 +7575,27 @@ packages = (
     ),
   "load-env":
     struct(
-      version = "0.1.2",
+      version = "0.2.0.1",
       sha256 =
-        "062cdaed7fc6d8958b60de1e0e7192896981fe231b0f397c0e3c998489aebdb4",
+        "cbe747e854d7ef3626487114d5cc4a93cbb303ed1df353ab5d8eaceba83873f6",
+    ),
+  "locators":
+    struct(
+      version = "0.2.4.4",
+      sha256 =
+        "2d6d0940206e285a086ea66c7b5f8b3a082fa629a8d335323dbbf78547e09aa5",
     ),
   "loch-th":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "77541dcb8fb0ae2c7984fc704e53635dbec83974a172611339941bfc9f96d9cd",
+        "cc059372b12a79375a0f268db7dc5a2973307a200440d4112e665b9a3d9b6dc3",
     ),
   "lockfree-queue":
     struct(
       version = "0.2.3.1",
       sha256 =
         "2a576a54bae8eabde01ebe901c9fd26a11bebb30516841de4525b5b60c0f3a8c",
-    ),
-  "log":
-    struct(
-      version = "0.9.0.1",
-      sha256 =
-        "c32bd5eabc0f37d0a410aac44bda615f2c880bb39358fb0283e26021411c50be",
     ),
   "log-base":
     struct(
@@ -8900,23 +7609,11 @@ packages = (
       sha256 =
         "7191cba40b9b348c54171f2b86caabb75a30e52b6d7e4c57321bf5dcdf1f367e",
     ),
-  "log-elasticsearch":
-    struct(
-      version = "0.9.1.0",
-      sha256 =
-        "a5a6ecae199afc03ce20b58af6c11f10cb16cfd3b1dc347d52bc881760bbd544",
-    ),
   "log-postgres":
     struct(
       version = "0.7.0.2",
       sha256 =
         "51c60374838cbd89d027cde9cdf2d8982b4f4152befe76899085520922e5639b",
-    ),
-  "log-warper":
-    struct(
-      version = "1.8.3",
-      sha256 =
-        "bf0377b98b52aefc7840b4999f994da79fa309e66175a630e5cc3203fba68bab",
     ),
   "logfloat":
     struct(
@@ -8932,27 +7629,9 @@ packages = (
     ),
   "logging-effect":
     struct(
-      version = "1.2.3",
+      version = "1.3.2",
       sha256 =
-        "332f549d8f9b1f123f81b0b02f6e18e3d3ec33dc4aca02b11a981c42a98b4220",
-    ),
-  "logging-effect-extra":
-    struct(
-      version = "1.2.2",
-      sha256 =
-        "fccb190db3f4f81b761df1b6a4428311691d57a435dc78916e00a1f1bb0b2a4b",
-    ),
-  "logging-effect-extra-file":
-    struct(
-      version = "1.1.2",
-      sha256 =
-        "d53334812651a2c1dfa87e93f43913b190bc63380752498593f593717026b1b7",
-    ),
-  "logging-effect-extra-handler":
-    struct(
-      version = "1.1.2",
-      sha256 =
-        "14efc5291632570746ba5a807e0634fb5af5c0f49f9994c59f1179ff69db0899",
+        "6dbdcbf3043186dabf7446206558ed1993a72d909da3462c9eac97f4a18615e1",
     ),
   "logging-facade":
     struct(
@@ -8992,21 +7671,27 @@ packages = (
     ),
   "lucid":
     struct(
-      version = "2.9.9",
+      version = "2.9.10",
       sha256 =
-        "d1aad51adf5ec30c0831ebce129c4fb10b69c287778f3cf644d6553543a50d33",
+        "c0e7dfae8337694082e3f34573c144d2672dc8c8e16175614079cd9d2d434390",
     ),
-  "lxd-client":
+  "lucid-extras":
     struct(
-      version = "0.1.0.5",
+      version = "0.1.0.1",
       sha256 =
-        "cc67fac34ff56ca97273e3516a79f65733cee087cd43a123edf5f57056c001a5",
+        "5cc5e269c313cba6871b70d48825e6b63ae49db91d507b7f9dccc10bf12dcb73",
     ),
   "lxd-client-config":
     struct(
       version = "0.1.0.1",
       sha256 =
         "903852c99bebc0af3cc3a26734056003f9097ada08eb1f361abce097a120afcf",
+    ),
+  "lz4":
+    struct(
+      version = "0.2.3.1",
+      sha256 =
+        "98cc62bea1a359201f9e39a7db2457272f996ede25d97a2dbee3a07aa80693f1",
     ),
   "lzma":
     struct(
@@ -9016,15 +7701,15 @@ packages = (
     ),
   "lzma-conduit":
     struct(
-      version = "1.2.0",
+      version = "1.2.1",
       sha256 =
-        "6a1dd57bb9fd73d4263e3e74db4d40bd0841272f907a328b0a4d08b26ca0ff4a",
+        "e955da2b8b108b3bf07073e12e5b01c46d42c8f3e40828fb1f34cd7e5413a742",
     ),
   "machines":
     struct(
-      version = "0.6.3",
+      version = "0.6.4",
       sha256 =
-        "3fd2e863a9a2ea2e3ef123668082757e48a5ec25e9659f4e02a3f56e44bdbecf",
+        "72de2b2e27cb36832ec4a66de36f1ba6c53d2abd197b7f0351865b4567db7768",
     ),
   "machines-binary":
     struct(
@@ -9044,23 +7729,23 @@ packages = (
       sha256 =
         "4d579d5e9e94fafcfca91322734263498999d2e2af45c40ff0d1db78f4a8f5d4",
     ),
-  "magic":
-    struct(
-      version = "1.1",
-      sha256 =
-        "b21c3b69f57b64199c1d7be0ac8ea1d02d698be59943058f6a2d642ea57ce082",
-    ),
   "magicbane":
     struct(
-      version = "0.1.4",
+      version = "0.3.0",
       sha256 =
-        "a07b86e06179c855e284974e19779737aead8acb3c998b50f5e0191e110ad2fd",
+        "20d334206f75bc4d569ec6c55991ccda8bdd00b1a27f0e2bb8ed190222ace6c9",
+    ),
+  "main-tester":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "ac09d9c0ac602252d7baef90ef87933b66469f18522e014c475bbe365daa4f69",
     ),
   "mainland-pretty":
     struct(
-      version = "0.6.1",
+      version = "0.7",
       sha256 =
-        "e34624877cd2d2a2caae87598d0a9512834f560d7b17982fcdab533992dd45e0",
+        "11777bd365251813c512a3e17e0303b30f2a86411a12118751858cbb20dbeaf7",
     ),
   "makefile":
     struct(
@@ -9068,35 +7753,29 @@ packages = (
       sha256 =
         "ed7a12094fe93ef0c6350ed6607ad488703f54bc2ad5d8cb2f9d89eb10b75c07",
     ),
-  "mallard":
-    struct(
-      version = "0.6.1.1",
-      sha256 =
-        "1594a75dc75cf8482d0b9a7ba443c9322287267faf6b044d18888cb167c1b10a",
-    ),
   "managed":
     struct(
-      version = "1.0.5",
+      version = "1.0.6",
       sha256 =
-        "b9c99943dadaa730ea3d889a09c3ca0efa1b7728f2bb0854815d49f40d4772e0",
+        "f1a70a23c0866b75d609b2c818b426712d7a2b4256f43a3d5da517e853e279cd",
     ),
-  "mandrill":
+  "mapquest-api":
     struct(
-      version = "0.5.3.2",
+      version = "0.3.1",
       sha256 =
-        "270d7df72da9c7d1d17bb3c5b115dac449b05a2931a6be41e55336b24e74f4cb",
+        "43339221b91816e8f793a98a4d281285e8e9de8788f13bb30ec345ef855a7b85",
     ),
   "markdown":
     struct(
-      version = "0.1.16",
+      version = "0.1.17.1",
       sha256 =
-        "08b0b352e208316ddc99c6f161704c8ecaf248c2e51f506900e344c93757ed85",
+        "e1f72d8829bdc86f52aba9f31f107847dc29b240cca9de7dd5efc2ba01673b58",
     ),
   "markdown-unlit":
     struct(
-      version = "0.4.1",
+      version = "0.5.0",
       sha256 =
-        "7438d86988b5950be1a0696a9bf54bbcda0bc66b4e3af0a0cc762b7ad78b0903",
+        "e72d0d7b82525e2a2c664012ce9dc35835b3fff91040d9f20897ed82f24ec7bf",
     ),
   "markov-chain":
     struct(
@@ -9104,23 +7783,23 @@ packages = (
       sha256 =
         "6e51b800101a28593be28ce7ef1b21b7cc7a177a821fb99ecd8a28c69b7b92cd",
     ),
-  "markup":
-    struct(
-      version = "4.0.3",
-      sha256 =
-        "0362bedb0692350fc10c9ab509dc2addfc39160581cdbe5ef44f8f8f644296a8",
-    ),
-  "marvin":
-    struct(
-      version = "0.2.5",
-      sha256 =
-        "50bdbb5300d03a0cb5f47e1b535c41044c67d8efd39961d3868aaaa31fe2f551",
-    ),
   "marvin-interpolate":
     struct(
       version = "1.1.2",
       sha256 =
         "d640c3bc2f70e17d1fb23c914a3d19b11f72568fda5d5c52e52c1de2e940eccf",
+    ),
+  "massiv":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "32690aeda5953db2231f0eb4b513a5426416e5e6d565b8f64a423502ff8dd94b",
+    ),
+  "massiv-io":
+    struct(
+      version = "0.1.4.0",
+      sha256 =
+        "8c118ca171008d92cf4f68a3504e328d6b557afeeb4d4cff9fa9a4cace0b5079",
     ),
   "math-functions":
     struct(
@@ -9134,12 +7813,6 @@ packages = (
       sha256 =
         "23c30ae0c962a7858d57bed320be6421baeb82fa795260e1eea0bc8fcc4871ad",
     ),
-  "matplotlib":
-    struct(
-      version = "0.6.0",
-      sha256 =
-        "6ddf08827bd7737b1e66969d5f869b6c91bb0610f7e1bf3b7eda3e7cf1c2b980",
-    ),
   "matrices":
     struct(
       version = "0.4.5",
@@ -9148,9 +7821,9 @@ packages = (
     ),
   "matrix":
     struct(
-      version = "0.3.5.0",
+      version = "0.3.6.1",
       sha256 =
-        "7a3d41c0f66212360057b29ae9f81779c8da9f71b040ad7676699af7e7ca35b5",
+        "fa976ca3bc98149ce59b7ae37869eda615562711e1fef90889f6e0c4f2093b2c",
     ),
   "matrix-market-attoparsec":
     struct(
@@ -9182,6 +7855,12 @@ packages = (
       sha256 =
         "b8a82f0a1c551a59961449587f031f679dd2f5f082ce45b6f7d88d81f99ad62f",
     ),
+  "mbug":
+    struct(
+      version = "1.3",
+      sha256 =
+        "21450dc132fa7a30805ba5a72012c9fc4a0560233dc2930e092b63d1bcaf43dd",
+    ),
   "mcmc-types":
     struct(
       version = "1.0.3",
@@ -9202,21 +7881,21 @@ packages = (
     ),
   "mega-sdist":
     struct(
-      version = "0.3.0.6",
+      version = "0.3.3.1",
       sha256 =
-        "87ee721b6f71bbb1b1359d56437c05962778f035454bbc2e5b3ec970619aea31",
+        "9c27f3f84bfdb48ee6c85e17201893a8767f3f5b28d8f282b60ca018522d965c",
     ),
   "megaparsec":
     struct(
-      version = "6.3.0",
+      version = "6.5.0",
       sha256 =
-        "5b779cfdc3c5c327de1674d246bade7a33dade36b8be182c5328d4af237c7095",
+        "bebdef43c6b857b8c494de79bcd2399ef712c403ee1353e5481db98b8f7f2f8a",
     ),
   "memory":
     struct(
-      version = "0.14.11",
+      version = "0.14.16",
       sha256 =
-        "674cf05ccf238c8ba0aa1673da3132c4f573163dd9a21b9f5e1fb938322add4c",
+        "7bb0834ab28ce1248f3be09df211d49d20d703cdcda3ed16cde99356e2d72b0f",
     ),
   "mercury-api":
     struct(
@@ -9256,21 +7935,21 @@ packages = (
     ),
   "microformats2-parser":
     struct(
-      version = "1.0.1.7",
+      version = "1.0.1.9",
       sha256 =
-        "def0a462fcfaa344629ee05ced7a93593bad2749148873b4f4c63e3f0c6758f1",
+        "50c71d9cd57991011855ad16759a6d43f56abc0e7424475db5263c5f04e2abd3",
     ),
   "microlens":
     struct(
-      version = "0.4.8.3",
+      version = "0.4.9.1",
       sha256 =
-        "53445b345d493e381173e6d7dc428116717cee9216e1fe069b96e68657151d9f",
+        "a1401c6f92c142bafea4cf58a1d99cc34af285df808b97f5b64af4bb81fb5648",
     ),
   "microlens-aeson":
     struct(
-      version = "2.2.0.2",
+      version = "2.3.0",
       sha256 =
-        "8d343c3585b1db18ce21bdb431cc23e50eb8c59034d478dd9b88e8b4dc35f317",
+        "f2f28288bfc190127423a452514d35f7b66f9d5625cf6653bb34cb020aa450c5",
     ),
   "microlens-contra":
     struct(
@@ -9280,9 +7959,9 @@ packages = (
     ),
   "microlens-ghc":
     struct(
-      version = "0.4.8.0",
+      version = "0.4.9",
       sha256 =
-        "dea1ea2fa61dea6ebb431e95b36ae4e2011ddb94ad3e0693173fd41f1858697a",
+        "aa3af55477443a05516d70676926e5b83403c319ed387d22e094bea393cabc71",
     ),
   "microlens-mtl":
     struct(
@@ -9292,21 +7971,15 @@ packages = (
     ),
   "microlens-platform":
     struct(
-      version = "0.3.9.0",
+      version = "0.3.10",
       sha256 =
-        "93076f4c17e5ce65db89ccf50924b395667a730c8ff0c1a94b03b94b9a373539",
+        "9b7fe59900ee35af9b070d154e9505b9f5c1953a95437c588f00cbe45e8596b4",
     ),
   "microlens-th":
     struct(
-      version = "0.4.1.3",
+      version = "0.4.2.1",
       sha256 =
-        "8e5c3bfc477ac9fa516b1a28a02a58a8ba2daeed99ff716cb06c3dda31134195",
-    ),
-  "microsoft-translator":
-    struct(
-      version = "0.1.1",
-      sha256 =
-        "5b01dbeb85c8f570c612268ffa23c8d4ee302143b8bcf99b59a8b1134f9cc589",
+        "ec57108e9ab54c085dd316b60ac156e6624078a46682a60ed2462005cae4fc42",
     ),
   "microspec":
     struct(
@@ -9322,15 +7995,9 @@ packages = (
     ),
   "midi":
     struct(
-      version = "0.2.2.1",
+      version = "0.2.2.2",
       sha256 =
-        "441931731ab75fd4dbbce459a3494941cb6f12a897d4bacdf33ab2f2501003cf",
-    ),
-  "midi-music-box":
-    struct(
-      version = "0.0.0.4",
-      sha256 =
-        "373c67bf3135499331ec00748dd003a26155f4c567ab06105c92d9e5d6d81651",
+        "de7cb58971a43f23e2a1ec0c4c01f690c1dd11ba55bc71264e1b9731014a693b",
     ),
   "mighty-metropolis":
     struct(
@@ -9340,9 +8007,9 @@ packages = (
     ),
   "milena":
     struct(
-      version = "0.5.2.1",
+      version = "0.5.2.2",
       sha256 =
-        "c2d568c54723f990b7edaf53354e59ff883860c99195480f7e49c18d2e9ed4d7",
+        "21da8cd70415a1ea46a463f715c228cd222785829caed39a3f065f9e4e164f35",
     ),
   "mime-mail":
     struct(
@@ -9352,15 +8019,15 @@ packages = (
     ),
   "mime-mail-ses":
     struct(
-      version = "0.4.0.0",
+      version = "0.4.1",
       sha256 =
-        "bc2660fd086b217bd269e57605d5a8350b167edca5a376763f91cea2905a0771",
+        "a76f29d1e52d8fbfc7ea8119f6ede5ed87f9e5b9d5587f1e6c69295f2a23d3f0",
     ),
   "mime-types":
     struct(
-      version = "0.1.0.7",
+      version = "0.1.0.8",
       sha256 =
-        "83164a24963a7ef37543349df095155b30116c208e602a159a5cd3722f66e9b9",
+        "a88b14a27cb03a0193b1d7afdbfcded82f3aff3eec2e20fd3f41794190a08c91",
     ),
   "minimorph":
     struct(
@@ -9370,33 +8037,33 @@ packages = (
     ),
   "minio-hs":
     struct(
-      version = "0.3.2",
+      version = "1.2.0",
       sha256 =
-        "249b5b22bf9758d4a7e88382aa6533a610cf9c39b773df6101f008feecb6d079",
+        "311494977fdab5f112807b13d485542c5b57147039063ad57c09bc1367541093",
+    ),
+  "minisat-solver":
+    struct(
+      version = "0.1",
+      sha256 =
+        "c12098dee034afb98b31ce7ac346398b93a3537c11e30e7573d25160120fd37d",
     ),
   "miniutter":
     struct(
-      version = "0.4.6.0",
+      version = "0.4.7.0",
       sha256 =
-        "bde66af62bb1f9d4649bc9ddaf6b82f70ba5078591d6cd7462effb650c876a24",
+        "adc9ac6a2160e87a8a4c4b88087d478ee74dded59d0cf6205a105dc0f778dc82",
     ),
   "mintty":
     struct(
-      version = "0.1.1",
+      version = "0.1.2",
       sha256 =
-        "c87f349f1999e8dee25f636428fc1742f50bcd2b51c9288578c60c58102e9f83",
-    ),
-  "misfortune":
-    struct(
-      version = "0.1.1.2",
-      sha256 =
-        "ae4b44215f811e7af6af756c813b9bd6e4161be555f30dd817324f8d1ffe2349",
+        "7c8af77bcde4e9b54692e3761f41adf35a50664974ba77f2ba65ea2af9f950da",
     ),
   "miso":
     struct(
-      version = "0.10.0.0",
+      version = "0.21.1.0",
       sha256 =
-        "fdb4c4a4976572215686912b9397ffb28d4a903a9577789fd8eb933053b3b05c",
+        "14017e15fa6cebe493705f0a0b30bb0121928b42b9e03549dd12835a6d02e9fb",
     ),
   "missing-foreign":
     struct(
@@ -9412,9 +8079,9 @@ packages = (
     ),
   "mltool":
     struct(
-      version = "0.1.0.2",
+      version = "0.2.0.1",
       sha256 =
-        "379ca73b496e1a589be6d8d75a4067e2eb382e6500530f10b40bfda59042f5bf",
+        "716ec75fc8eb573c9c6ab327a9658685f5131eacff69fbbc72289cdd0133e0ff",
     ),
   "mmap":
     struct(
@@ -9424,21 +8091,27 @@ packages = (
     ),
   "mmark":
     struct(
-      version = "0.0.4.0",
+      version = "0.0.5.6",
       sha256 =
-        "9015a9ea5cce5b441b4f660da12ac298e1cf45d113209e6a1497b9a6b3a2ba15",
+        "fc036385fd4cea07a490df00d8fe443cc6656a6d090d537d4d5e860564ef1234",
+    ),
+  "mmark-cli":
+    struct(
+      version = "0.0.3.0",
+      sha256 =
+        "37d3e98d15ccc036db5e2ec1b8b1e84a20c303ba1821a44ec441e835c43c6159",
     ),
   "mmark-ext":
     struct(
-      version = "0.0.1.2",
+      version = "0.2.1.0",
       sha256 =
-        "59e12257836c1088da3def0b43ba2c27d14fad1888eea68e30782f46b747c938",
+        "1a02396a80708c60b3aecb668c16a3d0cb890bbfcc4fbf722c9742b75ce23fcd",
     ),
   "mmorph":
     struct(
-      version = "1.1.0",
+      version = "1.1.2",
       sha256 =
-        "c1bcb45560753203f5ce3952f3c8a100b7d5b37c91746372c1da4988c4db74de",
+        "c90afd7996c94be2b9a5796a7b94918d198c53b0c1d7a3eaf2982293560c5fbe",
     ),
   "mnist-idx":
     struct(
@@ -9452,65 +8125,41 @@ packages = (
       sha256 =
         "b7a1edacd3d32dc7f0e28c67877209d3ca3551d1da186f6445f825f3477dd727",
     ),
-  "model":
-    struct(
-      version = "0.4.4",
-      sha256 =
-        "44e0a604e5461b00818fbb6f2ec755dd56f7b533a5d255c1c50f328f4e0dbbd6",
-    ),
   "modern-uri":
     struct(
-      version = "0.1.2.1",
+      version = "0.2.1.0",
       sha256 =
-        "30241a63db2fb28efe30f84e71e3ae5acb491950aacb34e13c2835d2d8bdc383",
-    ),
-  "modify-fasta":
-    struct(
-      version = "0.8.2.3",
-      sha256 =
-        "dcee07de4f97b10c557cc3a18aee35d75caf8ef65bdc104bcd6785bfabc7465e",
+        "e65aca7e994b3a470584da17571878084e90120507b8deab9a9b021d529f981a",
     ),
   "moesocks":
     struct(
-      version = "1.0.0.43",
+      version = "1.0.0.44",
       sha256 =
-        "2ea5428cb0cccefe7cd590abdb4c9a5936c49bd562d86e50804a85a9a3de7df1",
-    ),
-  "mole":
-    struct(
-      version = "0.0.6",
-      sha256 =
-        "ab7803cd42f79d5aad4492c257b06c9d7079f15f84e52d63978565c374e81a6a",
+        "bf35a237dffeaebc82237439fe457d0c423d235a48a69f02c9e616297540e1c8",
     ),
   "monad-control":
     struct(
-      version = "1.0.2.2",
+      version = "1.0.2.3",
       sha256 =
-        "1e34a21d123f2ed8bb2708e7f30343fa1d9d7f36881f9871cbcca4bb07e7e433",
+        "6c1034189d237ae45368c70f0e68f714dd3beda715dd265b6c8a99fcc64022b1",
     ),
   "monad-control-aligned":
     struct(
-      version = "0.0.1",
+      version = "0.0.1.1",
       sha256 =
-        "ddb75107f0896931a83066d2ad85745c0bf4e0396046a3d5c17f35809a114287",
+        "44e78fd32d6644e974ab0644dc79331643c8ada4837c8f3c94f4a30b5ee011f6",
     ),
   "monad-coroutine":
     struct(
-      version = "0.9.0.3",
+      version = "0.9.0.4",
       sha256 =
-        "08aafe8499ef2311a238197b67ec74e5faa8c887a0e24592e38fde37ab64c9e4",
+        "13e0ff12046296390ea69dda5001aa02b1b57e968447d27712a24c8c7cfe5de7",
     ),
   "monad-extras":
     struct(
       version = "0.6.0",
       sha256 =
         "df33d7c51a97d16226b8160d9bc09686cb6f7b7bf5c54557381c6fe4a3c84f2c",
-    ),
-  "monad-http":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "a333b087835aa4902d0814e76fe4f32a523092fd7b13526aad415160a8317192",
     ),
   "monad-journal":
     struct(
@@ -9520,9 +8169,9 @@ packages = (
     ),
   "monad-logger":
     struct(
-      version = "0.3.28.1",
+      version = "0.3.28.5",
       sha256 =
-        "f93162f0672275dd20106acdede3be56d95ebba384a20bd0f9d161ffb8c9f795",
+        "225ed7cd2d0d375c0207d5d3b9faa12b339ca7dd51ca92f96d3eaf2d360027f1",
     ),
   "monad-logger-json":
     struct(
@@ -9532,9 +8181,9 @@ packages = (
     ),
   "monad-logger-prefix":
     struct(
-      version = "0.1.7",
+      version = "0.1.10",
       sha256 =
-        "6d13d371d4e7237ed9ec405ab58ed7299a2ba9193bc719fe1f93e11d46bf164d",
+        "a3ac2d043a13d9e9296692dc729a299361b04757690894cac1b6904510a0d975",
     ),
   "monad-logger-syslog":
     struct(
@@ -9556,15 +8205,9 @@ packages = (
     ),
   "monad-metrics":
     struct(
-      version = "0.2.1.0",
+      version = "0.2.1.2",
       sha256 =
-        "17e03ff8ec120a28d40ba870005a289c74232a604f4e208c2f9551b2e5923c9d",
-    ),
-  "monad-mock":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "7bafe50c2671d83e1bc7d4697985d1cda12ab5570b7fa4ddbf09c047b9982a7b",
+        "38130b74de16bde2862a96245b25135b719488c4fcb803b78db6e95b4e6fbb7f",
     ),
   "monad-par":
     struct(
@@ -9580,9 +8223,9 @@ packages = (
     ),
   "monad-parallel":
     struct(
-      version = "0.7.2.2",
+      version = "0.7.2.3",
       sha256 =
-        "60bd1aed8ece1cc1e309d87e1722c6d489173dfe24eae95091ef5d9ce610efb3",
+        "128fb8c36be717f82aa3146d855303f48d04c56ba025078e6cd35d6050b45089",
     ),
   "monad-peel":
     struct(
@@ -9598,9 +8241,9 @@ packages = (
     ),
   "monad-recorder":
     struct(
-      version = "0.1.0",
+      version = "0.1.1",
       sha256 =
-        "313df1493b39ad691a0eaf04141cbcd4d96dd7f2786481b959085915f7b86bd8",
+        "0863eb37dae0a9dc996a73dd7743d0c9fc22b9713d4be4d7c7e49e4e073ca215",
     ),
   "monad-skeleton":
     struct(
@@ -9616,9 +8259,9 @@ packages = (
     ),
   "monad-time":
     struct(
-      version = "0.2",
+      version = "0.3.1.0",
       sha256 =
-        "a9b901ca94b4c71d5f374a472506db92d26b13af523ceafe1e3302e8bae8b05d",
+        "0af450bfc710a9653e008de3df4cff094423e434d54ac5b7419fe2552660607c",
     ),
   "monad-unlift":
     struct(
@@ -9632,35 +8275,11 @@ packages = (
       sha256 =
         "0f059539297478ad8b7e861682207b37b91eaf7e36bd8fdcc3f865a3c6971d1d",
     ),
-  "monadcryptorandom":
-    struct(
-      version = "0.7.1",
-      sha256 =
-        "85c37875743cd2357fba28d0bde3b06cd90f4f2d9770b8e0221e15258ac6b9e7",
-    ),
   "monadic-arrays":
     struct(
       version = "0.2.2",
       sha256 =
         "667714c6100272b48c4377cf2e2984b67a4445521a2a2e9c37539128c7e276a0",
-    ),
-  "monadloc":
-    struct(
-      version = "0.7.1",
-      sha256 =
-        "b25a0f6b3ebb051e58e2a58f2f5d588ff67622584cb575d40c46eaacbd1de7a8",
-    ),
-  "monadoid":
-    struct(
-      version = "0.0.2",
-      sha256 =
-        "26c2e9fb0456dbec761c6d9723ad33cbb9fcd3a1318ff4197859d766e14ec877",
-    ),
-  "monadplus":
-    struct(
-      version = "1.4.2",
-      sha256 =
-        "366ed520db1eaf2ec56d8508fee2804cc24c7a6016de4b75b9addec681186595",
     ),
   "monads-tf":
     struct(
@@ -9670,9 +8289,9 @@ packages = (
     ),
   "mongoDB":
     struct(
-      version = "2.3.0.2",
+      version = "2.4.0.0",
       sha256 =
-        "6d1d7df6d3777b880dc52cbf3e974c8d4cba43bc213fed45a85b4e684248f481",
+        "fdb80241825c70d795a1e552b25afc916e58d7755ec31feaf7ab7afdd5aee719",
     ),
   "mono-traversable":
     struct(
@@ -9688,33 +8307,33 @@ packages = (
     ),
   "monoid-extras":
     struct(
-      version = "0.4.2",
+      version = "0.5",
       sha256 =
-        "13ff4e055c9656a3e599567cbc4a46ef8617c05534de46909a4239696e34281f",
+        "c6571ab25a24e4300d507beeb8e534c20b3e530c6bd19c82694f1d6d5d0d4d9c",
     ),
   "monoid-subclasses":
     struct(
-      version = "0.4.4",
+      version = "0.4.6",
       sha256 =
-        "97793736943c0c49a4c867dcbee7556eea2029737943d4fb474bdb37786699f9",
+        "15c1aade7351bea9db03e047b063d3f68507e31bebff8e49fc9797a5d4be51e7",
     ),
   "monoid-transformer":
     struct(
-      version = "0.0.3",
+      version = "0.0.4",
       sha256 =
-        "94c8661eac0cdd85bbf9a2adc78c3030363ff94f482f5299ba8583b2f7bd06b8",
+        "43abf147e4d1b57c5d306d9533e42fb52828d64e761e0e3d8797fb52cfc98388",
     ),
   "monoidal-containers":
     struct(
-      version = "0.3.0.2",
+      version = "0.3.1.0",
       sha256 =
-        "326a48e1a1938c7ab11651ef297112f9a3b80270156183e5016e9e13397072c7",
+        "44c325aa5a46a624688eefca1a0a3cc818e932a3805ed7749d0693c2c8c5f785",
     ),
   "morte":
     struct(
-      version = "1.6.14",
+      version = "1.6.20",
       sha256 =
-        "552fe158225678c51ba5928aafaf12e5202dee8aa5668dba7810d5fe044a35f3",
+        "7449e92308373c7459f97da2389a26ee1cead0532a7931868b49e9338240a306",
     ),
   "mountpoints":
     struct(
@@ -9730,9 +8349,9 @@ packages = (
     ),
   "mtl":
     struct(
-      version = "2.2.1",
+      version = "2.2.2",
       sha256 =
-        "cae59d79f3a16f8e9f3c9adc1010c7c6cdddc73e8a97ff4305f6439d855c8dc5",
+        "8803f48a8ed33296c3a3272f448198737a287ec31baa901af09e2118c829bef6",
     ),
   "mtl-compat":
     struct(
@@ -9764,17 +8383,11 @@ packages = (
       sha256 =
         "e543fb307beb14fc366171d7767a6a18244bacf78db295d8d161c5c03d94043c",
     ),
-  "multiset":
-    struct(
-      version = "0.3.3",
-      sha256 =
-        "c74e77d3dbbe81fe3b48629fc257fa084df89bfb575c82c42f5549af376de135",
-    ),
   "multistate":
     struct(
-      version = "0.7.1.2",
+      version = "0.8.0.0",
       sha256 =
-        "9189313c54130173171077a64851244e517ec135bf0a9230d39b272aee0394d5",
+        "013fb518a342cca9650859f21016077693f7b594d70df569548b7de9074a5d69",
     ),
   "murmur-hash":
     struct(
@@ -9796,9 +8409,15 @@ packages = (
     ),
   "mwc-probability":
     struct(
-      version = "1.3.0",
+      version = "2.0.4",
       sha256 =
-        "0f9ba623fa2fea7770e3f1cacb1d8a0b14711e60039590d5181864e5a2fe1f6f",
+        "9fe9ed0e264bf85420a3086a1af9d6e749ff33c9c59428891dfaaa72b1385157",
+    ),
+  "mwc-probability-transition":
+    struct(
+      version = "0.4",
+      sha256 =
+        "3e44b6f3f3b2a739776484e7d4ab98ab1d5c7e50bcba53a40d2f0ac96003e768",
     ),
   "mwc-random":
     struct(
@@ -9806,17 +8425,11 @@ packages = (
       sha256 =
         "065f334fc13c057eb03ef0b6aa3665ff193609d9bfcad8068bdd260801f44716",
     ),
-  "mwc-random-accelerate":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "30fad33d12b130457a6dcb8bedc885700e6ac0eea9b0f25fe6e5fe34968932e3",
-    ),
   "mysql":
     struct(
-      version = "0.1.4",
+      version = "0.1.5",
       sha256 =
-        "9b8675db208851524a77b6e5c4278e6bc29eab16d970a9dda312ae366bdb668e",
+        "49b367d07f6d93fd4cbd08390f83bbf8e40c66156a1d2b0f570b68921e6f3075",
     ),
   "mysql-haskell":
     struct(
@@ -9838,15 +8451,9 @@ packages = (
     ),
   "mysql-simple":
     struct(
-      version = "0.4.4",
+      version = "0.4.5",
       sha256 =
-        "b51c2f4638857b931cf73b181900df0a3a06a49f20145f2a0f56b7af13833ce7",
-    ),
-  "n-tuple":
-    struct(
-      version = "0.0.1.1",
-      sha256 =
-        "212779940d40cca3c3527300c1038123f3d98836609fca388556ad0574269fdf",
+        "b03c422ed8a62fa7f98b62634a06da8454980c6a733e275020ca7cedbb6e7cb1",
     ),
   "nagios-check":
     struct(
@@ -9854,17 +8461,17 @@ packages = (
       sha256 =
         "1bc9b85cb10c396943d53c44e2701c5bc2a02ecdf3e8f46da238981f8b7860b7",
     ),
-  "nakadi-client":
+  "named":
     struct(
-      version = "0.3.0.0",
+      version = "0.1.0.0",
       sha256 =
-        "5eabcda72644078ebadb1376ce41c156f1f421be7b07253f088e9d6e56409991",
+        "e7fa5c63906a3e8db05ead8c64a962045016ef8d450ab0f8579861080b024658",
     ),
   "names-th":
     struct(
-      version = "0.2.0.3",
+      version = "0.3.0.0",
       sha256 =
-        "0ebe2b2f9bfe079d71d4ac805db6f3239f70a92c27dde0cea6c5235e273f5ec6",
+        "0be38f6a22afb69ddda5a3cae095b51835bdae853256403e97078679a9fba526",
     ),
   "nano-erl":
     struct(
@@ -9878,17 +8485,17 @@ packages = (
       sha256 =
         "cf14ccc2b296c910000cdc3eb51b37389b3eb94139384b9555db79b8128595e5",
     ),
-  "naqsha":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "4941224601df58a801a5cd2fb345fa8785972c6fe098d0088bd5f8f369f39c94",
-    ),
   "nats":
     struct(
       version = "1.1.2",
       sha256 =
         "b9d2d85d8612f9b06f8c9bfd1acecd848e03ab82cfb53afe1d93f5086b6e80ec",
+    ),
+  "natural-induction":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "99aa944a9bf54f549a867b73de56e56adf95d67408822054ee1abfcbe7ae33af",
     ),
   "natural-sort":
     struct(
@@ -9910,21 +8517,21 @@ packages = (
     ),
   "neat-interpolation":
     struct(
-      version = "0.3.2.1",
+      version = "0.3.2.2",
       sha256 =
-        "5530e43ca4de09b972d173e522f9dc96265f3afe0df695a25f0141be816fa014",
+        "b6c8c5eca58ee99f9528ff21386ffa8e7dbc2e02186824cbaf74d795b0c9cc39",
     ),
   "netlib-carray":
     struct(
-      version = "0.0",
+      version = "0.0.1.1",
       sha256 =
-        "19d0327410c2524e25629ec94ed2adf43f34e4174ebe884dff6363e21bbc709c",
+        "9bc702f6d09240400b99d0769aaa0fe6bf32f83b312d33a6e2dd7b75a173beef",
     ),
   "netlib-ffi":
     struct(
-      version = "0.0",
+      version = "0.1",
       sha256 =
-        "ac270bb45b8528e06f0f1476fbd4736b0feb26576cdac29b0d27a45da17a0444",
+        "505ca55093efdbd71b8b8cbeaa52ce2cbdd5477dc6c35b163e52748772517c32",
     ),
   "netpbm":
     struct(
@@ -9934,33 +8541,33 @@ packages = (
     ),
   "nettle":
     struct(
-      version = "0.2.0",
+      version = "0.3.0",
       sha256 =
-        "220184713b802c53ee26783b891a3bbee6c6b2571f798bd6def2496a504e9bde",
+        "cf3f08980e8e52190301d33db3b1fe7f02bcf5d276a74a8b8283b79e72bf7d5d",
     ),
   "netwire":
     struct(
-      version = "5.0.2",
+      version = "5.0.3",
       sha256 =
-        "4d790f19642c62e555d167d53d88da56cc83daf093ff4ee37c83e21a2112cd83",
+        "f1dde7293efe9cdb3080f53a1be702f473ef0bcc0d3e4ea2d23b847fa3ef222e",
     ),
   "netwire-input":
     struct(
-      version = "0.0.6",
+      version = "0.0.7",
       sha256 =
-        "4a04c52371358471eaef127ed37547ec35fe58bef2cd6b22ce8b1074fb0db88e",
+        "29c6b087c2092ca409442b28aca500642b870461ad820d8bc579097f19ed3db9",
     ),
   "netwire-input-glfw":
     struct(
-      version = "0.0.7",
+      version = "0.0.10",
       sha256 =
-        "0f517a132f437c35f0847d5794d15ed0505722e39137759cbb18809c3b875be7",
+        "1ea458273055fa2f82451b889b9a2c54e0b5bbdf55a16c35d0ccd392793728e4",
     ),
   "network":
     struct(
-      version = "2.6.3.3",
+      version = "2.6.3.6",
       sha256 =
-        "776668b0a969d0d57ebabf78943cfc21a1aaf7e5e2ae6288322292125c9440f5",
+        "9bde0609ab39441daa7da376c09f501e2913305ef64be5d245c45ba84e5515a5",
     ),
   "network-anonymous-i2p":
     struct(
@@ -9980,17 +8587,11 @@ packages = (
       sha256 =
         "9790a9bad286ab1474dadbece3e4b2e1dd068d4ede3847cb73bcd66386bf08f0",
     ),
-  "network-carbon":
-    struct(
-      version = "1.0.11",
-      sha256 =
-        "d81729280cd36ef06de7032ebbaa8f7ffde46a767ea4d6f8334b4c1242927eda",
-    ),
   "network-conduit-tls":
     struct(
-      version = "1.2.2",
+      version = "1.3.2",
       sha256 =
-        "12a2cddfacd19d0585e57ff143d625e255e1a4628a463a41332eabc3c02bb087",
+        "ecfd60e162de3993a71906293dcf2ec8bd4c794471eb8dca13746c1d8fd3ad7f",
     ),
   "network-house":
     struct(
@@ -10000,21 +8601,15 @@ packages = (
     ),
   "network-info":
     struct(
-      version = "0.2.0.9",
+      version = "0.2.0.10",
       sha256 =
-        "632939efc095b8dd01a813243e8cb14f4ffd1b9052a26523b9c04dc81993aa66",
+        "5680f6975d34cf4f81fa7ca0c8efd682261d6a1119e06dece0f67c7bd97fd52a",
     ),
   "network-ip":
     struct(
       version = "0.3.0.2",
       sha256 =
         "ee259d236312aafc4bd08dfeff2ebe4b4f930b2f5879764e1a6d5675c5105efe",
-    ),
-  "network-msgpack-rpc":
-    struct(
-      version = "0.0.4",
-      sha256 =
-        "59185bdaa263eff55c35a571d0a03637d20cbd9926aaf419958c0afa5ca7342d",
     ),
   "network-multicast":
     struct(
@@ -10024,9 +8619,15 @@ packages = (
     ),
   "network-simple":
     struct(
-      version = "0.4.0.5",
+      version = "0.4.1",
       sha256 =
-        "0947b409ebf68d0fa0d94c0a99c6b01165a1c5ab40507b489d195a84b4cd6aaa",
+        "72be3a16779fffeb71436f421c7de4b83a78523362c4787a807c3174d7db9b1d",
+    ),
+  "network-simple-tls":
+    struct(
+      version = "0.3",
+      sha256 =
+        "bc2dffc45af7771721f13c4ffe739fbef3b2050f9d3ebb6abd47ad15f7c94587",
     ),
   "network-transport":
     struct(
@@ -10045,12 +8646,6 @@ packages = (
       version = "0.5.2",
       sha256 =
         "8245d795330157d90ad9de599854d119c6d8938a45ab8c4ec89f3160b2e9ef4e",
-    ),
-  "network-transport-tcp":
-    struct(
-      version = "0.6.0",
-      sha256 =
-        "774f0134e7ce09c833eb2ad21057c26b9041398b6ca991b5df1d4cfb42f2e696",
     ),
   "network-transport-tests":
     struct(
@@ -10072,21 +8667,15 @@ packages = (
     ),
   "newtype-generics":
     struct(
-      version = "0.5.1",
+      version = "0.5.3",
       sha256 =
-        "273f429691ae550a77ee1cf42d7f2213c6a51ea581721945c3b599ff54d9a9b2",
+        "f295f001a86bdbcf759d6b91b9e7ae27cd431ccf41d9b9d34ee1c926b88efe45",
     ),
   "next-ref":
     struct(
       version = "0.1.0.2",
       sha256 =
         "a586f15c17d5d53dd647411d02660dcbfd293f38a75f030d6892a76a2c24789f",
-    ),
-  "nfc":
-    struct(
-      version = "0.1.0",
-      sha256 =
-        "63b8f1d434c9e20c1df08ab532c4e098871b0788f9d1b8a5ed84bce1abb01167",
     ),
   "nicify-lib":
     struct(
@@ -10114,33 +8703,21 @@ packages = (
     ),
   "non-negative":
     struct(
-      version = "0.1.1.2",
+      version = "0.1.2",
       sha256 =
-        "464bfa128fa3038d2aef7ac3cb828a0d196237aa34c218cc23c1f095bff2aaf8",
+        "5614acf55f3c16a21fea263e375e8993f9b859e21997b0410c74fe6642c20138",
     ),
   "nonce":
     struct(
-      version = "1.0.5",
+      version = "1.0.7",
       sha256 =
-        "cdc6ab31b99af6a852f163a142cf27b917e6d168f8e0c04a9ab406bfaa7beb95",
+        "4b4f6232b2cb07a6de47a838b4dc35c346a745683866dbfc6ebb8682158037e1",
     ),
   "nondeterminism":
     struct(
       version = "1.4",
       sha256 =
         "3037c93b0277037ab51ad8640f72a7975dcf48ba81570640be12d390d7b47dc5",
-    ),
-  "normaldistribution":
-    struct(
-      version = "1.1.0.3",
-      sha256 =
-        "6d7ba381946f76f3bd848c90e5bcc6f6ae5c418f7ae294cfc2559541fa02f7e0",
-    ),
-  "normalization-insensitive":
-    struct(
-      version = "2.0.1",
-      sha256 =
-        "3b54ba0c2fc0ea99321bbec7f28bedc771bf1ec0a3f9796da7e479829282cb02",
     ),
   "nsis":
     struct(
@@ -10150,9 +8727,9 @@ packages = (
     ),
   "numbers":
     struct(
-      version = "3000.2.0.1",
+      version = "3000.2.0.2",
       sha256 =
-        "736d0551e4a13510dfe43a777a220bd4b17a19a73e6cd17bf901b1854b5ce183",
+        "f0cee40b90c3746bd0bc0559d3827d3cf1b1e2c43270b7ec9bf4fa458fcb5a77",
     ),
   "numeric-extras":
     struct(
@@ -10162,21 +8739,33 @@ packages = (
     ),
   "numeric-prelude":
     struct(
-      version = "0.4.2",
+      version = "0.4.3",
       sha256 =
-        "5327a9ffcc5997a062d2a9ea405130741114a0c6fe440a8e5b6d6c35fe56d8c4",
+        "b8f8f9a660e598055898c1d6c981885c629882ae028fec90f91955bade19892d",
     ),
   "numhask":
     struct(
-      version = "0.1.4.0",
+      version = "0.2.3.1",
       sha256 =
-        "f255a7ebe3479575d771ec528105b58107dc8b4a06591007ce2d4a8d1d69448c",
+        "33084f2bd2dd37cdc1923745896e39d3a34f8d7b5181dff6577c4605dd7fc111",
+    ),
+  "numhask-prelude":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "b1f15bcf21f33b25f841d1b6f0c5cbfc2a2837b3bb8962a0082950fa9b8ca25f",
     ),
   "numhask-range":
     struct(
-      version = "0.1.3.0",
+      version = "0.2.3.1",
       sha256 =
-        "f1ca2e5d0e4e9e2a4a8af7c64a3f953a7157a5bb2740297f577bb79811b982c0",
+        "6c62a172d2d35da7e5cb4ade742e802a4e1b9a21746149cd367d71f95822dcfd",
+    ),
+  "numhask-test":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "de74c9e8cc66ead2eeffc9062d6f7b57728c9aef834751132e03d5deb17decb3",
     ),
   "numtype-dk":
     struct(
@@ -10186,27 +8775,27 @@ packages = (
     ),
   "nvim-hs":
     struct(
-      version = "0.2.5",
+      version = "1.0.0.2",
       sha256 =
-        "4be016f62eb2c931d9916e732c94718e66edfccae2948bc6941f20cb52bb3ee2",
+        "40647aeebc690b678b301007a4d0e2551796faf69101a5e5445dfdafbe554803",
     ),
   "nvim-hs-contrib":
     struct(
-      version = "0.2.0",
+      version = "1.0.0.0",
       sha256 =
-        "6ee5e9777fbe4dcfa7085923ee1386c2f9c317177c9d61f332cf424e544d2915",
+        "bd342ebd086b2825e74908ebe93621d7d06cd6b06f0bb2fdf98c44351f7a1394",
     ),
-  "nvim-hs-ghcid":
+  "o-clock":
     struct(
-      version = "0.2.0",
+      version = "1.0.0",
       sha256 =
-        "6ed326f9de682ec3a7b8493c1f5ef710f7e14ec65c815a67911e306def880e81",
+        "7294710f111b9a0b803e0780b8a8d173db700936164daf656d2414eb40f295a3",
     ),
-  "nvvm":
+  "oauthenticated":
     struct(
-      version = "0.8.0.2",
+      version = "0.2.1.0",
       sha256 =
-        "63a496373d4f3a4d15c23c7ff87609ec5c73ab0b8fcecdac2af0768cfb02fd16",
+        "d44cd060a4bfb26b0b958a8a203fb25dc171c146093eab82827542264f57d222",
     ),
   "objective":
     struct(
@@ -10214,11 +8803,11 @@ packages = (
       sha256 =
         "2fcf283ede3f447f2e65ed9c434bb8facef873ba534aa0de29eb5ffefcc86644",
     ),
-  "ochintin-daicho":
+  "odbc":
     struct(
-      version = "0.1.0.1",
+      version = "0.2.0",
       sha256 =
-        "d49094e19869862a4dcc24fc39b976be1b4b637c100b7d404f8c921ed10456e8",
+        "276edb22591f21c7d47f4765594c44c1e8dafca761a6f4a1d72d156f988067b7",
     ),
   "oeis":
     struct(
@@ -10244,6 +8833,12 @@ packages = (
       sha256 =
         "1ccb158b0f7851715d36b757c523b026ca1541e2030d02239802ba39b4112bc1",
     ),
+  "om-elm":
+    struct(
+      version = "1.0.0.3",
+      sha256 =
+        "af10f05a0eed4e17829211f06e79b7c4884dbd5c2736674e9e7680bbe426c744",
+    ),
   "once":
     struct(
       version = "0.2",
@@ -10252,33 +8847,27 @@ packages = (
     ),
   "one-liner":
     struct(
-      version = "0.9.2",
+      version = "1.0",
       sha256 =
-        "ab3056b1833685da9810ba40eccc381416cd3c531dd3c930f9a83fb7dcf4c7d7",
+        "c7f4fbea856adcaa145eb4ff9c81bb730f0a1796b24f4075c0a8028ae87a31b6",
+    ),
+  "one-liner-instances":
+    struct(
+      version = "0.1.2.1",
+      sha256 =
+        "9384f47a3bdd5be17fa8ac3deca8e406794a1e9e140ec3b173ccd8d22c00c9bf",
     ),
   "online":
     struct(
-      version = "0.2.1.0",
+      version = "0.3.0.0",
       sha256 =
-        "9d7a7db4b78f4162f2495e4f85e16fd1606125b95d6cf087fe144d291c83419b",
+        "baadb1cccc0b59547bf9e0829fba1c8079e38a68a925971c07f2b99f674bca14",
     ),
   "oo-prototypes":
     struct(
       version = "0.1.0.0",
       sha256 =
         "9eaee40e3221f817b957e472917977bdb06ac0e163a0c6ef87941de29a12f576",
-    ),
-  "opaleye":
-    struct(
-      version = "0.6.0.0",
-      sha256 =
-        "383cf7acecfdf5bc9ca1b3a7447b30494224c7859c6a326a83f662936ea73c5f",
-    ),
-  "opaleye-trans":
-    struct(
-      version = "0.4.2",
-      sha256 =
-        "95977ca6e4c79325bbb8dd8f9323a671df6749f0bcd631170775d340f1e2db15",
     ),
   "open-browser":
     struct(
@@ -10300,9 +8889,9 @@ packages = (
     ),
   "openpgp-asciiarmor":
     struct(
-      version = "0.1",
+      version = "0.1.1",
       sha256 =
-        "5cd45aad8fb9e0d07ed27da1801937b4d8598dac1c55bcfbfe11d9608f053bf7",
+        "b92f3f5316f18c9e30a95cd59888658384ddd20b628e4cd5fbb647177f52f607",
     ),
   "opensource":
     struct(
@@ -10336,9 +8925,9 @@ packages = (
     ),
   "optional-args":
     struct(
-      version = "1.0.1",
+      version = "1.0.2",
       sha256 =
-        "940604d6ebc1fb1b5372cb21e0b3870cd9d920655e41841844131994d1f1fd99",
+        "2e3454ad77cba80b15c02dbe1915889fafa81a22deb7fe5e7e01b0dd8d85b0e4",
     ),
   "options":
     struct(
@@ -10348,15 +8937,15 @@ packages = (
     ),
   "optparse-applicative":
     struct(
-      version = "0.14.0.0",
+      version = "0.14.2.0",
       sha256 =
-        "b55b32fdd5d101b2d6edb2746a66648fc2cd1b850d7adea185f201ac71b83c1a",
+        "e1341e9831c7b10332d1b29cfa966a80d46b476bb52d99d50bdb53eb770d7f30",
     ),
   "optparse-generic":
     struct(
-      version = "1.2.3",
+      version = "1.3.0",
       sha256 =
-        "f37d9eb00a14aa75f560a9d3d75c39f7f79e4cd63cab78c7736a0dd989bcbff3",
+        "80929958606e4a73672b570ba1a23493fbf46268666d14ab5af53623301c398f",
     ),
   "optparse-simple":
     struct(
@@ -10370,29 +8959,29 @@ packages = (
       sha256 =
         "f6c081ecec880ae4124f25c1d91ba3a1a3caed9d2fde9e977bceab7d300884ef",
     ),
-  "package-description-remote":
+  "overhang":
     struct(
-      version = "0.2.0.0",
+      version = "1.0.0",
       sha256 =
-        "4a936d2346265d4d960875b12272e9f15aedf6aa6aa5f177f7ce30c7e4f68744",
+        "1d68f59354930cdb4372adb86386ca9cbd699d90d2d8c8a1042314f296772a1e",
+    ),
+  "packcheck":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "1b76a08553d65e62235a9ca8ba001a2620fbee5a2169e4d40e06e28bdf0a27e8",
     ),
   "packdeps":
     struct(
-      version = "0.4.4",
+      version = "0.4.5",
       sha256 =
-        "54a8d40b3a5cb6c7df349884dc7f0f37b6bac21f5064fc12f52ee0d4e2628b7e",
+        "17de7170a104434ba1c686a0a279cc43a3841fae89f75636e0e7f8a27bb7da1e",
     ),
   "pager":
     struct(
       version = "0.1.1.0",
       sha256 =
         "3e1e4f2ca17be6dd68d2d480f29e7a770c0f7ca3109aa1980da677d96cd4eef3",
-    ),
-  "pagerduty":
-    struct(
-      version = "0.0.8",
-      sha256 =
-        "2f8f9ef70a672dd9160beb1e87d9b88d8cbd6f137637f4aed98df756ea270463",
     ),
   "pagination":
     struct(
@@ -10402,45 +8991,45 @@ packages = (
     ),
   "palette":
     struct(
-      version = "0.1.0.5",
+      version = "0.3.0.1",
       sha256 =
-        "7434530139793650b5a2dc8b8b32348ab8021c4eeaad774a1fd709c040ab9812",
+        "f1153525439d18423b73599a545f4f4bfa49fc481d5608c0770e56a0ce7a9c7a",
     ),
   "pandoc":
     struct(
-      version = "2.0.6",
+      version = "2.2.1",
       sha256 =
-        "f2f236e91986b522510c7ea8212c1641da6006d0acec3e6b587a4e4faf3612ee",
+        "fe037f5fbb62fb27e7b1dbddfbd0aa45ea6e9fcdaff1f2203f7484c245b211b7",
     ),
   "pandoc-citeproc":
     struct(
-      version = "0.12.2.5",
+      version = "0.14.3.1",
       sha256 =
-        "ddfb40b4ff42e1781172bf1077e344fb8909df99b3463c12b39f5a46ddb2a8d0",
+        "42c0b2c8365441bf884daa6202e6ed01b42181cf255406c88b3b31cd27cb467a",
     ),
   "pandoc-types":
     struct(
-      version = "1.17.3.1",
+      version = "1.17.5.1",
       sha256 =
-        "4b1674f7d000da4f86e775f6178e1939fe506e2e4b45c8842dc0182ad92a1736",
+        "271cebd0300e236000c2352d597afe2e72a65bc7b01e32b623e2c868fd12dbe0",
     ),
   "pango":
     struct(
-      version = "0.13.4.0",
+      version = "0.13.5.0",
       sha256 =
-        "1f08c7e941f35c3be60b6b77347c0e9ac87feaca865aee21b0a5400b04d1ead4",
+        "bf59b9273134e5d1c9c648a253e5a766cd1ef51afc2216175bce21a15b6d49e8",
     ),
   "papillon":
     struct(
-      version = "0.1.0.5",
+      version = "0.1.0.6",
       sha256 =
-        "f384ff05d5cb0fed420bc700dabdb3e8beef191921f9759b12bf3dfe60ad82b0",
+        "2b5a614c8792ab3e36fae53f5303a9e62b78b896da1752d65b8ebf7b98ea1ac8",
     ),
   "parallel":
     struct(
-      version = "3.2.1.1",
+      version = "3.2.2.0",
       sha256 =
-        "323bb9bc9e36fb9bfb08e68a772411302b1599bfffbc6de20fa3437ce1473c17",
+        "170453a71a2a8b31cca63125533f7771d7debeb639700bdabdd779c34d8a6ef6",
     ),
   "parallel-io":
     struct(
@@ -10468,21 +9057,21 @@ packages = (
     ),
   "parser-combinators":
     struct(
-      version = "0.4.0",
+      version = "1.0.0",
       sha256 =
-        "b124e9411de085972e4d9ae8254299e8e773e964b2798eb400d5cf6814f8f3ab",
+        "e54c8d6071bc67866dffb661e5f56de6d632f40abdfe76b9f56a734ca76e8edf",
     ),
   "parsers":
     struct(
-      version = "0.12.8",
+      version = "0.12.9",
       sha256 =
-        "5aba0afdd53f3bd39b145ca858b696ba0a36d099c694742fb6a5d38900806bc8",
+        "81e52fc9d71b587a8034015344e9162c59975750094f930a47933e5603d305e4",
     ),
   "partial-handler":
     struct(
-      version = "1.0.2",
+      version = "1.0.3",
       sha256 =
-        "fae9f291f4146631eb3be173299bbc7755343a0e9b74e62ee1921e209a6aa4f1",
+        "94c72af024417ec04e3d94b5b57c7bfeb8b48acb8444e7c0fe0764ff1139c131",
     ),
   "partial-isomorphisms":
     struct(
@@ -10496,12 +9085,6 @@ packages = (
       sha256 =
         "e37dc77f4b8852b1c96fe9b8b06db41aa00d06c5ce7f0c1c5bea15ea462ac397",
     ),
-  "partial-semigroup":
-    struct(
-      version = "0.3.0.2",
-      sha256 =
-        "ed97c1c99ed633e3ffc8517fc4adec38edbf8d3cd31638804461d17130835964",
-    ),
   "path":
     struct(
       version = "0.6.1",
@@ -10510,9 +9093,9 @@ packages = (
     ),
   "path-extra":
     struct(
-      version = "0.0.6",
+      version = "0.2.0",
       sha256 =
-        "883aa371560b3b0d41df1954ed44c6dd6e5d77cb3bd4ebf0fd4b9d72df0a6935",
+        "eb08be914e718762cad0e1fc7588201258bd8637c486990791e5b816f7a8043a",
     ),
   "path-io":
     struct(
@@ -10526,29 +9109,17 @@ packages = (
       sha256 =
         "080bd49f53e20597ca3e5962e0c279a3422345f5b088840a30a751cd76d4a36f",
     ),
-  "path-text-utf8":
-    struct(
-      version = "0.0.1.0",
-      sha256 =
-        "8f110e6ef0f50566ff0ee03e4551d5c6913ad3c1d5da9ee91229a44b2437f37c",
-    ),
   "pathtype":
     struct(
-      version = "0.8",
+      version = "0.8.1",
       sha256 =
-        "14e3b9d03c222a061ffeb40ecc0940d980e25fddd70339d04ec86dbae6f27897",
+        "d5e6dc557dcf53e97cc2f7f6d6ee30992920e3ea074042b6ac11f74f2792340f",
     ),
   "pathwalk":
     struct(
       version = "0.3.1.2",
       sha256 =
         "76e0d0646a3133a062dbae4e9d37d59e71d6328706bb178552a93800e4550e91",
-    ),
-  "patience":
-    struct(
-      version = "0.1.1",
-      sha256 =
-        "35c7c334d344b3cbdc61cc88c559bedb300ace860a80e3990aeb268f1f10db63",
     ),
   "pattern-arrows":
     struct(
@@ -10564,9 +9135,15 @@ packages = (
     ),
   "pcf-font-embed":
     struct(
-      version = "0.1.1.0",
+      version = "0.1.2.0",
       sha256 =
-        "8fc8bc667f5e711210bc35a2874a6dbc71a22ee1f8cf4399a0a6ef733a9fe456",
+        "c55d51ee6f959c9c05bb9d9adac3aad1cd87b2bba3cca7d3667d67f1a230fd51",
+    ),
+  "pcg-random":
+    struct(
+      version = "0.1.3.5",
+      sha256 =
+        "de43ff8805f9e0ffd4cd6b4f2fed8c9cfa9ab45c0fd42374636ac7a5567840a4",
     ),
   "pcre-heavy":
     struct(
@@ -10586,89 +9163,77 @@ packages = (
       sha256 =
         "1f2a80ca63308e182542534866a844efaf880deac4145213bf1c83a560586df4",
     ),
-  "pdf-toolbox-content":
-    struct(
-      version = "0.0.5.1",
-      sha256 =
-        "1c104e232e178603ff9dd8c6eaaf0ccbda918c70b40ed63f08fa1922a3c88488",
-    ),
-  "pdf-toolbox-core":
-    struct(
-      version = "0.0.4.1",
-      sha256 =
-        "cce3949ef5596b5d61032ce1547160dc5f52e3d5c556dcdb9aabf1582173a981",
-    ),
-  "pdf-toolbox-document":
-    struct(
-      version = "0.0.7.1",
-      sha256 =
-        "3f7d379baa85c1cf9998e3f84177ad24b5cc8632fb211af7a09603e59596f0e1",
-    ),
   "pdfinfo":
     struct(
       version = "1.5.4",
       sha256 =
         "9a6a1f7d8ab0a5e8f7f8276da070ccddec140d6b2549b084042159b639230911",
     ),
-  "pell":
+  "peano":
     struct(
-      version = "0.1.1.0",
+      version = "0.1.0.1",
       sha256 =
-        "5e2002920c97bddbe3047dbc2eba3ddadd3823c4ca137c4a1d3314cb12dc4ad4",
+        "31fdd23993a76155738224a7b230a1a6fcfde091b2fbc945df4cb54068eeec7b",
     ),
   "pem":
     struct(
-      version = "0.2.2",
+      version = "0.2.4",
       sha256 =
-        "372808c76c6d860aedb4e30171cb4ee9f6154d9f68e3f2310f820bf174995a98",
+        "770c4c1b9cd24b3db7f511f8a48404a0d098999e28573c3743a8a296bb96f8d4",
     ),
   "perf":
     struct(
-      version = "0.3.0",
+      version = "0.4.1.0",
       sha256 =
-        "38f463fc0c0966b707fbb5c1b4a270a916a1b1329dcad34f8ecabb3798141851",
+        "881d50dc3603ba7008807ab03247a321bb1f9377da192135922a536c1d1201fc",
+    ),
+  "perfect-hash-generator":
+    struct(
+      version = "0.2.0.6",
+      sha256 =
+        "df727611ca45994fc40e3e37ebae783a892f3b46db95897ba2df876e65f7b110",
     ),
   "persistable-record":
     struct(
-      version = "0.6.0.0",
+      version = "0.6.0.4",
       sha256 =
-        "3d0c6820ca5d9ea0fd9cef3aba8585c604f939b71550c44e5cb5440d3a44f024",
+        "6d3abe73d61cf691bb1b5a412fa8a6d8fcc5cb3070176041ad8953b63ca5f8f9",
     ),
   "persistable-types-HDBC-pg":
     struct(
-      version = "0.0.1.5",
+      version = "0.0.3.5",
       sha256 =
-        "89a4b31fb916afd21e99af0d3dbcbb69c68ef97842c824113958ef238dc5b94d",
+        "955c73edd056e1ecb6a3543d726070c3f219a67017ef18ac9ae75711f63cec2f",
     ),
   "persistent":
     struct(
-      version = "2.7.1",
+      version = "2.8.2",
       sha256 =
-        "c2896ef228486c02c08b8594c9eccef8ca246291c4f16eff538fef9dc332391d",
+        "696bb279259e307778dc7fbd49565c48a66429f14e793a41a13cfae0968c1ec0",
     ),
-  "persistent-mongoDB":
+  "persistent-iproute":
     struct(
-      version = "2.6.0",
+      version = "0.2.3",
       sha256 =
-        "e34ee25417a232e97c25989d04d8d62d907def78c6fd1710ba61f15c3d9924f9",
+        "f595a11ceaa1c19e11d6f4fc58ec2834eb100791ae82626912115f1d79edbfaa",
     ),
   "persistent-mysql":
     struct(
-      version = "2.6.2.1",
+      version = "2.8.1",
       sha256 =
-        "339e326034ea5d861b6e59e63a1fc1d34a7aeae129accd544d0b78f4e9cd6366",
+        "80cc29f8fa90503a13c348e14f10dd0883f17837ca72a5cd5b2884fdb286e654",
     ),
   "persistent-mysql-haskell":
     struct(
-      version = "0.3.6",
+      version = "0.4.1",
       sha256 =
-        "23493eab38e1a6d0ea2072db930c78fe437de63edb29bb66c4a428bd324c02a9",
+        "2109f8e08fbc499ad3059e72a2ea2335ef6bcf8cbf52c8280771001a84dae8f2",
     ),
   "persistent-postgresql":
     struct(
-      version = "2.6.3",
+      version = "2.8.2.0",
       sha256 =
-        "916e515e40ce8d1d2a35dee5e459f5f4e29cb15eadca8ae6f9e8d6731641237b",
+        "f2f3c80b9f1d5ae494492204f3170e33ff3a5792b9675748839de6309d082f49",
     ),
   "persistent-refs":
     struct(
@@ -10678,15 +9243,15 @@ packages = (
     ),
   "persistent-sqlite":
     struct(
-      version = "2.6.4",
+      version = "2.8.1.2",
       sha256 =
-        "75e5dbd330337e6e60346f309457f56deabb4260bd53391962de2f085416ac9a",
+        "2f7157f3830370f60c7c36490ea49b7c52caf0f2a7349f86cf47970189f9ad0c",
     ),
   "persistent-template":
     struct(
-      version = "2.5.3.1",
+      version = "2.5.4",
       sha256 =
-        "8ddb28d564a1decf9eb21587c989aec3d55fdd5437ccf3543b58003b78bc8910",
+        "4cae740ce92f98cb3ae9e092e740753394d5687b887399ee5f87af7f3c730a01",
     ),
   "pg-transact":
     struct(
@@ -10706,18 +9271,6 @@ packages = (
       sha256 =
         "f978ef98e810e9a9e53f1479340ba7a28f80a64aba431322959cbf8c620c3811",
     ),
-  "picedit":
-    struct(
-      version = "0.2.3.0",
-      sha256 =
-        "e8525d8ca1d4ab0995293948a05dda3eb57f2456603ba5467fef982d0296c12d",
-    ),
-  "picoparsec":
-    struct(
-      version = "0.1.2.3",
-      sha256 =
-        "8ec7ed678efaf62de15b7c2f1d21f1ddf8b92f5fa233eed9534c12e8812e9150",
-    ),
   "picosat":
     struct(
       version = "0.1.4",
@@ -10732,21 +9285,15 @@ packages = (
     ),
   "pinboard":
     struct(
-      version = "0.9.12.8",
+      version = "0.9.12.10",
       sha256 =
-        "93b7810df9efea605d710452f2a072c4618640ce337cbcfd1f1e8100c7f4344d",
-    ),
-  "pinch":
-    struct(
-      version = "0.3.2.0",
-      sha256 =
-        "a1920f6cf2347ff3eeea8cfe3f59987a771efc5e2044370244cf55fa61eb1764",
+        "bac98d28d29f47d39ca15f0b406f438fb2797841a21edfd1cdf8d54bdb64b049",
     ),
   "pipes":
     struct(
-      version = "4.3.7",
+      version = "4.3.9",
       sha256 =
-        "30a01f4b43221ec62018b9b8298adf8b576b785eabfe085bcb9ef4dbf4c49d99",
+        "5c4cda351f9cf59376832baaeb857db25bd4990fd78c4b061aca0bde47271acb",
     ),
   "pipes-aeson":
     struct(
@@ -10759,6 +9306,12 @@ packages = (
       version = "0.5.1.5",
       sha256 =
         "fe9eb446289dbc4c4acdde39620877b885417990d9774f622fa9d1daa591cafd",
+    ),
+  "pipes-binary":
+    struct(
+      version = "0.4.2",
+      sha256 =
+        "f659d9fd4c816b65abe14a67eb86f7605d15ab5bca5514b25fa6fd82a23064e8",
     ),
   "pipes-bytestring":
     struct(
@@ -10774,9 +9327,9 @@ packages = (
     ),
   "pipes-concurrency":
     struct(
-      version = "2.0.9",
+      version = "2.0.11",
       sha256 =
-        "646d7b10030b6f146170018677a7d9c0b22def4d14cb0da981ae6572b56620af",
+        "9534bc54ef695d8fda55608bb4b0fba0eb8cb7dceb758a84dc9e1816c23a080e",
     ),
   "pipes-csv":
     struct(
@@ -10786,9 +9339,9 @@ packages = (
     ),
   "pipes-extras":
     struct(
-      version = "1.0.12",
+      version = "1.0.15",
       sha256 =
-        "c1e042038444690a3bc5dac3340493a38ccff5a3032fdf44b95e738b2eb0276b",
+        "02a9633ac912fd48e9a5ca0e6b48a6e9541ce59d11243096ca6af6b25701cbb3",
     ),
   "pipes-fastx":
     struct(
@@ -10798,33 +9351,39 @@ packages = (
     ),
   "pipes-fluid":
     struct(
-      version = "0.6.0.0",
+      version = "0.6.0.1",
       sha256 =
-        "8a4097620bbfaf6f7662acbf792defc92434aaadd8dc71f71b7f26e58fb87585",
+        "105d8e8df7e731e2d272a22891eb68db1ca3ec9f425b67af77c5d91e3f032f06",
     ),
   "pipes-group":
     struct(
-      version = "1.0.8",
+      version = "1.0.12",
       sha256 =
-        "6a645b278f43a172223835614122c063f1bd9b3324575ba4ec5f9c640886957d",
+        "1373e89fbeb127c31461042cdda848da2048eda2700ddbd872d444af87745ac7",
+    ),
+  "pipes-http":
+    struct(
+      version = "1.0.5",
+      sha256 =
+        "49a196466de1638f3806a49bf10fef9eb3c06456ababf09ffd025b6b64f23055",
     ),
   "pipes-misc":
     struct(
-      version = "0.4.0.1",
+      version = "0.5.0.0",
       sha256 =
-        "b901c84c1a3a61b1a9c8944d16494a256a5690d3e06bf75e66860e28d626f667",
-    ),
-  "pipes-mongodb":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "0821194bdf7f377beeb20fc8f697ed5388a221b6e8e42c513eea67a91c198340",
+        "4e2e7e396ee0c659ae3742388d06b69e3b5146a5563cd3f4ba56f9a1febb8d26",
     ),
   "pipes-network":
     struct(
-      version = "0.6.4.1",
+      version = "0.6.5",
       sha256 =
-        "a8624aec78e2d2a814956d6759a8d3e18811a82d245480f0404fe408f951a0af",
+        "74a461153a2f650e9e15037002b6d9177b132f409e3204824655ffbb939dc795",
+    ),
+  "pipes-network-tls":
+    struct(
+      version = "0.3",
+      sha256 =
+        "a2694a6b15d71a8cae898dd8e6a085a4e1ae317c40f2752ceed2b991dfb6bab2",
     ),
   "pipes-parse":
     struct(
@@ -10840,27 +9399,15 @@ packages = (
     ),
   "pipes-safe":
     struct(
-      version = "2.2.6",
+      version = "2.2.9",
       sha256 =
-        "9f1b18792617d5ab4a144b3a036b8d7d57cbc53adb98fd2605bbe172710f09f9",
-    ),
-  "pipes-text":
-    struct(
-      version = "0.0.2.5",
-      sha256 =
-        "4489ee02a8ebfd87049fc4dd1380b21e6f33984eb0101c836ab8e054759c0f2a",
+        "17f16403794a2517eb283dd8b34a17c3485143b7fb66870d0a305294815a1898",
     ),
   "pipes-wai":
     struct(
       version = "3.2.0",
       sha256 =
         "04a670df140c12b64f6f0d04b3c5571527f144ee429e7030bb62ec8785056d2a",
-    ),
-  "pixelated-avatar-generator":
-    struct(
-      version = "0.1.3",
-      sha256 =
-        "4d7d87404121f5481faa7d6af087575a9541aaad96b196ec230d1883a563a078",
     ),
   "pkcs10":
     struct(
@@ -10874,17 +9421,17 @@ packages = (
       sha256 =
         "652a78553dcaf6e11b4cd8f0e60010b32da299fbe57721df4bf9157e852d0346",
     ),
-  "plan-b":
+  "plot-light":
     struct(
-      version = "0.2.1",
+      version = "0.4.3",
       sha256 =
-        "7baad85b24abc214e7dba2d9863b1dc0ca6d54f737efa2d608d69d0992071c0d",
+        "abbc116ff80d1e7ee0ed4dd0ba90baf907da7f347fa678767ff9402714399fbb",
     ),
-  "plot":
+  "plotlyhs":
     struct(
-      version = "0.2.3.9",
+      version = "0.2",
       sha256 =
-        "c6146c647010bc46500ab1043abd63d6793b654686c15728cd8003ebed27cfb3",
+        "85fb0446b3e92267357dc52b770da90b222b85337f3db593e0350021d1e53259",
     ),
   "pointed":
     struct(
@@ -10898,12 +9445,6 @@ packages = (
       sha256 =
         "743cb0f89cbb128f8aa24c4519b262b561bf2cd607f83e94f9241e8af1cfba9b",
     ),
-  "pointful":
-    struct(
-      version = "1.0.9",
-      sha256 =
-        "6a1881236419751beb5b2e4e495bd9093ea2dec3f3cbd44e2a62aaabe53cacd6",
-    ),
   "pointless-fun":
     struct(
       version = "1.1.0.6",
@@ -10912,9 +9453,9 @@ packages = (
     ),
   "poll":
     struct(
-      version = "0.0",
+      version = "0.0.0.1",
       sha256 =
-        "77102fd6a79b75c98cdce10a40a746430a7a85d6cccebe70dff81b5072f68c6c",
+        "b9fe87fe1b4d3ecb2ad3c1c290e231b0c93d498f0d318f67018a1dde97a0ed29",
     ),
   "poly-arity":
     struct(
@@ -10934,23 +9475,17 @@ packages = (
       sha256 =
         "f54c63584ace968381de4a06bd7328b6adc3e1a74fd336e18449e0dd7650be15",
     ),
-  "pomaps":
-    struct(
-      version = "0.0.0.3",
-      sha256 =
-        "d56fc99a77377590ce94630f4012dc7b26ffe29639a3764c9d3c35f31856aebf",
-    ),
   "pooled-io":
     struct(
       version = "0.0.2.1",
       sha256 =
         "7d405a8876d55a9c077a304dd378854bc9e6e20f643c357c82bd3f38297ff9d0",
     ),
-  "posix-paths":
+  "portable-lines":
     struct(
-      version = "0.2.1.3",
+      version = "0.1",
       sha256 =
-        "57d28850610f0b820c2dcc2dc4e843e733a05a6a8d8ebbdead5a7c9571cdabfc",
+        "5053f5bc42d4362062e0ec55dd111b0f6611be280c7f871876732853f4b824d1",
     ),
   "post-mess-age":
     struct(
@@ -10960,21 +9495,15 @@ packages = (
     ),
   "postgresql-binary":
     struct(
-      version = "0.12.1",
+      version = "0.12.1.1",
       sha256 =
-        "a20a9f6c102d09f220e5f08357b3cd0a06a5f8d22eff4dd7f9e6fc668e1165cd",
+        "fb00b37b213e00369ae17145ed8487ac0bfe295f35b3ef24afaba76f9dbf36a0",
     ),
   "postgresql-libpq":
     struct(
-      version = "0.9.4.0",
+      version = "0.9.4.1",
       sha256 =
-        "02c50b3acf6869c58fa16b975e8391388241f563ba8f0832ccf191682a528a96",
-    ),
-  "postgresql-query":
-    struct(
-      version = "3.3.0",
-      sha256 =
-        "2867edd5b6823d248dd47334166af763c30b4ca8b7aec0e23c07b222f7f19646",
+        "0d9fa338b67c54786ea123cb9f75f3362aad01057aaa4857687610a39908566b",
     ),
   "postgresql-schema":
     struct(
@@ -10984,15 +9513,15 @@ packages = (
     ),
   "postgresql-simple":
     struct(
-      version = "0.5.3.0",
+      version = "0.5.4.0",
       sha256 =
-        "1e0d7b646d60d79bcc827e3c0b2d3425dfb2ca7dbb57f16903b7089740230e41",
+        "f5d11ae7907307a1a32d62add9ed88cccf4dc7a25c0c1f3f36e0975d44f73a77",
     ),
   "postgresql-simple-migration":
     struct(
-      version = "0.1.11.0",
+      version = "0.1.12.0",
       sha256 =
-        "c00f850a4be88124d83e2bc4f2c5d873ab27aa9fcff6936d9994debf69ac759e",
+        "98f8b2eab06474e63c76b2d048d6a08d818d086b66e84caa27f3f0a368445da3",
     ),
   "postgresql-simple-queue":
     struct(
@@ -11002,9 +9531,9 @@ packages = (
     ),
   "postgresql-simple-url":
     struct(
-      version = "0.2.0.0",
+      version = "0.2.1.0",
       sha256 =
-        "f7d85afe7dd047c63aa56cc67e8d28e1d18f33baff8ee447adc5bec427b6ea4c",
+        "1307f57cde2bd7f6d795a860deab53d3d64043f51af31e3114dee516ef7ee9c9",
     ),
   "postgresql-transactional":
     struct(
@@ -11014,27 +9543,21 @@ packages = (
     ),
   "postgresql-typed":
     struct(
-      version = "0.5.2",
+      version = "0.5.3.0",
       sha256 =
-        "cca083de0d1735dcd784ac9be0b27692162053a97076d96bdb5aa61460ed4973",
+        "b3c01c0821e96a83163f919aff86aba603f13d10ff5245680f4c4e488531f82a",
+    ),
+  "pptable":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "98b7ff404eceaad834b16187af44db37324d3bfaa631347794bb0f28a6dd9317",
     ),
   "pqueue":
     struct(
-      version = "1.3.2.3",
+      version = "1.4.1.1",
       sha256 =
-        "2a2b8b4ebc9acaf3c428be69b0f5548fab24eafdec33a8f6a9b47a4fea065418",
-    ),
-  "pred-set":
-    struct(
-      version = "0.0.1",
-      sha256 =
-        "cb22ec50f94cf76b6bc55fd66b91badfef657cbe1a6b6a59b691e48004c37726",
-    ),
-  "pred-trie":
-    struct(
-      version = "0.5.1.2",
-      sha256 =
-        "437b4f2578444adad0eeb519d23c339d4f5cb3532b12745bc1e94144135a0a34",
+        "3ddc53ea30111047efeacfe0b85d721979b51e9479051d40b00563cc7ea87cff",
     ),
   "prefix-units":
     struct(
@@ -11060,12 +9583,6 @@ packages = (
       sha256 =
         "d4f9f195d31198fa1a5e1edfb50684971cc5dc2695bf38c1e7e2dabdce329727",
     ),
-  "preprocessor-tools":
-    struct(
-      version = "1.0.1",
-      sha256 =
-        "c946c99fe8c9effba27946cd2c26173d2346340528d800a228796d68f8aeee59",
-    ),
   "present":
     struct(
       version = "4.1.0",
@@ -11086,15 +9603,15 @@ packages = (
     ),
   "pretty-show":
     struct(
-      version = "1.6.16",
+      version = "1.7",
       sha256 =
-        "dbee8476bf12ce5bd991d0a52c1340802e07bb706c68c1a7911a38db16ac0350",
+        "382b6ef4a78e4059611b5c86674ad72a6bfce821e8852da4f00b628cfbbc272f",
     ),
   "pretty-simple":
     struct(
-      version = "2.0.2.0",
+      version = "2.1.0.1",
       sha256 =
-        "8464cd62d8cb9de3194ed500e69731c9e49c27a5fffe142e56a4029e9d4eece7",
+        "9aa92eea9cd76e4623fda6759a9f0ccf9e8e3accf1c2dd4b483bfac7ae5cd3d1",
     ),
   "pretty-types":
     struct(
@@ -11110,15 +9627,15 @@ packages = (
     ),
   "prettyprinter":
     struct(
-      version = "1.1.1",
+      version = "1.2.1",
       sha256 =
-        "a0b32ee64d410436e6b411f7f1349a8763b9c26e144abc671b798da72f7feecf",
+        "e7653e0ba87cc06553a50e4780dde81c5dd156196c0199511d03d972e5517fcf",
     ),
   "prettyprinter-ansi-terminal":
     struct(
-      version = "1.1.1.1",
+      version = "1.1.1.2",
       sha256 =
-        "d49a353f0739a1a6df83dec0add10e971534abb9917806eeb7a12dc0c8c97ab4",
+        "d3e0b420df2904ae1ef23daf9bbb6de2c1fbbee056b779fc2cebe303cedf4641",
     ),
   "prettyprinter-compat-annotated-wl-pprint":
     struct(
@@ -11138,11 +9655,17 @@ packages = (
       sha256 =
         "75221f5064e69eead5807a62894e8b5aa768f979c7f8fb75d0e1b2a15345529e",
     ),
-  "prim-array":
+  "prettyprinter-convert-ansi-wl-pprint":
     struct(
-      version = "0.2.1",
+      version = "1.1",
       sha256 =
-        "4edd7820b4edf984833703a916c66ab1798de66c89d2f3f723088ab029f4e4d9",
+        "b8982d38776249d3d29a4ede426a27a02f7cbb6843722b5ec8ede18d032fa60c",
+    ),
+  "prim-uniq":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "fb059785133fe5ecaa57c6c840192f252c4c5a1a598160d5704ac2a83e895aff",
     ),
   "primes":
     struct(
@@ -11155,12 +9678,6 @@ packages = (
       version = "0.6.3.0",
       sha256 =
         "cddeff804e0f577f1be0179d5d145dfc170f8bfb66f663b9fba67104a45d9555",
-    ),
-  "printcess":
-    struct(
-      version = "0.1.0.3",
-      sha256 =
-        "5f6c220f9e0251785c8b250df3636c2d012d2a670677df46dad64ca4949eb52a",
     ),
   "probability":
     struct(
@@ -11176,33 +9693,21 @@ packages = (
     ),
   "product-isomorphic":
     struct(
-      version = "0.0.3.1",
+      version = "0.0.3.2",
       sha256 =
-        "119c1b00171a5d3296e66ac4cd9510056e9eb26aed0e1840f3b1fb359a00a5ee",
+        "b4cba495f0779c619f466cdcc7914a4c2a209543dabebb6a32f003dc567317fb",
     ),
   "product-profunctors":
     struct(
-      version = "0.8.0.3",
+      version = "0.10.0.0",
       sha256 =
-        "4fa4b1c6ba4f84305ef11e001695a7027f37d4a88bf34996ed3724233ac40cc9",
+        "ad8d7687c2eee4bcd2f3925a74f53d743c9f678b80be2a523221039004d51a68",
     ),
   "profiterole":
     struct(
       version = "0.1",
       sha256 =
         "c688d8c4f04e7a674832b39add365cee8eb99ae83643a849529e2ec56a46d2f1",
-    ),
-  "profiteur":
-    struct(
-      version = "0.4.4.0",
-      sha256 =
-        "098e5b87b849ceef6627fd798751348e9dc54900b1bfdde981695093fdf2f622",
-    ),
-  "profunctor-extras":
-    struct(
-      version = "4.0",
-      sha256 =
-        "8a3c51ef41d686e39f87875dd48e72e5aa83956125bdf9922edf531c292a4482",
     ),
   "profunctors":
     struct(
@@ -11228,12 +9733,6 @@ packages = (
       sha256 =
         "5f28c40b864d4773d019725e9f0dd7c06610c676250c8f1126e511d72348d05b",
     ),
-  "prometheus-metrics-ghc":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "dd26541686f69db972ee4e9d6d6d2d71a8525ce44af20e41842e0d77da7fec31",
-    ),
   "promises":
     struct(
       version = "0.3",
@@ -11248,51 +9747,45 @@ packages = (
     ),
   "proto-lens":
     struct(
-      version = "0.2.2.0",
+      version = "0.3.1.0",
       sha256 =
-        "92057ebfb5b2be5dc925b53ce96cf40abe5280bfdac833c0c567087e07fa7a9c",
+        "87bf1aa7d7754ca06ccbfb0daf4a77de53345c1d098e0fa17018ee00c2b994ab",
     ),
   "proto-lens-arbitrary":
     struct(
-      version = "0.1.1.1",
+      version = "0.1.2.1",
       sha256 =
-        "95c28f6bc9be5b1057215e1ab99b06f69fddc28c24068cb576b1d5cdbb12b7c9",
+        "824e013d1f7c4d52434ea318aef63544491cf0e89f63dbcda4c4c07881b11c23",
     ),
   "proto-lens-combinators":
     struct(
-      version = "0.1.0.8",
+      version = "0.1.0.10",
       sha256 =
-        "ffb7ac1486ca81629a66cf9ae3fa8bf16f7cd4c1e004b8f58433b41e5a30df2f",
-    ),
-  "proto-lens-descriptors":
-    struct(
-      version = "0.2.2.0",
-      sha256 =
-        "0b3f4eb9ddc081baef1f45831c17ab4b960ebac630af1f29bbd5521f46ca5bee",
+        "395a8626e75ed17dedcfce2de5b6b769d1fa521b56005e4f30e66a3e5ee6667b",
     ),
   "proto-lens-optparse":
     struct(
-      version = "0.1.0.4",
+      version = "0.1.1.1",
       sha256 =
-        "8b738a61d99282b2f8bbe483d01058cc6ca32b51c1774cf140a40cf6a578dcf3",
+        "1c8706f789809bda1ad9db8b18b2a9c309e6040ded6ce1d85a2b0da7cc9e26fe",
     ),
   "proto-lens-protobuf-types":
     struct(
-      version = "0.2.2.0",
+      version = "0.3.0.1",
       sha256 =
-        "e23848be576ddef65691617419bc7cbed75a7405af31a68c4987e2ee393ed62c",
+        "8a19053eabdff8e84b65181dd1beb4fafe5a84bae5af1bb3b32d043d0ef56018",
     ),
   "proto-lens-protoc":
     struct(
-      version = "0.2.2.3",
+      version = "0.3.1.0",
       sha256 =
-        "f88e71f56db3ecca87e5779124b3c2ad4d08a918c65759083fdf185a041c4923",
+        "7dbfa924db9014caf7bf0bb2dd1eb9f0960b9ef2fa6c80c4610b768aade73042",
     ),
   "protobuf":
     struct(
-      version = "0.2.1.1",
+      version = "0.2.1.2",
       sha256 =
-        "cd659a085b670d204c0b4ddf0cb323e4f024c9d972cf183dc14154a44d5e722c",
+        "b3c871918a665f0543fde247ab8af61c4fc451103140d34bf652c0d5fc4d17de",
     ),
   "protobuf-simple":
     struct(
@@ -11302,21 +9795,33 @@ packages = (
     ),
   "protocol-buffers":
     struct(
-      version = "2.4.6",
+      version = "2.4.11",
       sha256 =
-        "9a761c0d9477de1e1b12235010d24e5fb7b4c371adfb2861008c6df01f4fe0a4",
+        "47cb492a1d2b3ee7d1c8dc7d7b8c1656c754968854bd0caf29cf70c2f38d81e8",
     ),
   "protocol-buffers-descriptor":
     struct(
-      version = "2.4.6",
+      version = "2.4.11",
       sha256 =
-        "e9f4ad6357c5bff731454d62a86acdbf9cd38332f1844736f7da71103254b2cb",
+        "a090bdc834cf4351ebabf15e2eed31877104f6e93900f8da8f350810c1d7681a",
+    ),
+  "protocol-radius":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "ae0c5ec142edb37df6bb51421b29e0a6c25013057e45e22159afb66cda3cf6f9",
+    ),
+  "protocol-radius-test":
+    struct(
+      version = "0.0.1.0",
+      sha256 =
+        "b5cc9a15e7910ecb449d3bbb142b809fa34bee2079e772ca63d4bb975a41ada0",
     ),
   "protolude":
     struct(
-      version = "0.2.1",
+      version = "0.2.2",
       sha256 =
-        "bdbf0e47f8cb8501df93eadfeaaa3a914cebbdd598e6c8b52ee7136c7a574be4",
+        "685d0cf34b63482be84b785561009b8229327233ae311550d20d66b47b0f457c",
     ),
   "proxied":
     struct(
@@ -11332,27 +9837,21 @@ packages = (
     ),
   "psqueues":
     struct(
-      version = "0.2.5.0",
+      version = "0.2.7.0",
       sha256 =
-        "163fe7220b157a535c278ef3b92deddf8abc3ae3a3fcb6f2c4e58959a9cbc2bb",
-    ),
-  "pthread":
-    struct(
-      version = "0.2.0",
-      sha256 =
-        "b6ee8d48c2eccf84acef31c6065a74ae5844e2fc68e4f55a05b44eddae032388",
+        "4cf3628884015b091471e4425f5414207fd547cf71d9546e9b7318d857624fea",
     ),
   "publicsuffix":
     struct(
-      version = "0.20170802",
+      version = "0.20180513",
       sha256 =
-        "1c9420657fcca5281792266bc72a10de6295eb571a202b8561514175dc764c28",
+        "b51f193089fbdadeaecf062047b377e597ef6d72caff13e62d8a88f4c3870973",
     ),
-  "pure-io":
+  "pure-zlib":
     struct(
-      version = "0.2.1",
+      version = "0.6.4",
       sha256 =
-        "a9ef0f324ce29fecdcdb11f2ce0088bcf282951727d983824e05f12e519bfb5f",
+        "eb679aecb3fa310d28a31549cf83c29fba6f6e3c78bcdea82c9e22db36dc3017",
     ),
   "pureMD5":
     struct(
@@ -11362,33 +9861,27 @@ packages = (
     ),
   "purescript-bridge":
     struct(
-      version = "0.11.1.2",
+      version = "0.13.0.0",
       sha256 =
-        "9c00caff498652addaf123d4d719f7488ece06a9279a348b6a182825482f15c6",
+        "2b1a6bbc0e1c155b20bb02356821185c7661d15cc8042ddfe12725eef2065149",
     ),
-  "pusher-http-haskell":
+  "pushbullet-types":
     struct(
-      version = "1.5.1.2",
+      version = "0.4.1.0",
       sha256 =
-        "d65a463504a3cc5545e9db4b680394d39e185a6de1e3558be2499d12a2052bcb",
-    ),
-  "pwstore-fast":
-    struct(
-      version = "2.4.4",
-      sha256 =
-        "7219af66b6f762d9dd5376b3b25393d4d6626e390e9d9c9f87f6e3f13ea7fbb2",
-    ),
-  "qchas":
-    struct(
-      version = "1.0.1.0",
-      sha256 =
-        "55b556e745b178ff7d0bfd124c7e0721079875f3c50441dbecf6f3cbf2851b8a",
+        "6461a2cf5ff0b74f7caaf295ca7601922e9527f5bc9f37e3fbc6325026b5c85b",
     ),
   "qm-interpolated-string":
     struct(
-      version = "0.2.1.0",
+      version = "0.3.0.0",
       sha256 =
-        "c32e56608e4a707cb16d2cd3d409e6c3e56b89818e63540f63106cf833a41f27",
+        "e86b337d1531e75d448f7ab9101f8703b19fa5bc3a94c7ea5c26accd31d12baf",
+    ),
+  "qnap-decrypt":
+    struct(
+      version = "0.3.2",
+      sha256 =
+        "da930b2e821d3a1de08e6f85262793d4cbdd0d63dca017c7b2e3ad63ed6501e3",
     ),
   "quickbench":
     struct(
@@ -11398,9 +9891,9 @@ packages = (
     ),
   "quickcheck-arbitrary-adt":
     struct(
-      version = "0.2.0.0",
+      version = "0.3.1.0",
       sha256 =
-        "d9998dbfa2785f29164c0bdc345b2ffaed630dd5bfb1bdbaa3b0e13e0724c0db",
+        "5c4a2e20366def76ba851211ac554e9a0f60535efcd0940606e4d410c27a45b9",
     ),
   "quickcheck-assertions":
     struct(
@@ -11408,23 +9901,11 @@ packages = (
       sha256 =
         "9b0328a788dcac0824a7d7496ab403eef04170551255c9e58fb6e2e319a9cacf",
     ),
-  "quickcheck-classes":
-    struct(
-      version = "0.3.2",
-      sha256 =
-        "e4376947f8581b952d8e138e11122be88f1ce3ed7786be3ef0f44a507b2be683",
-    ),
-  "quickcheck-combinators":
-    struct(
-      version = "0.0.2",
-      sha256 =
-        "7fcd7b320a3d6d66b1db3cc8e63c21bc2b2b84329ffc490113ea7df61a711b65",
-    ),
   "quickcheck-instances":
     struct(
-      version = "0.3.16.1",
+      version = "0.3.18",
       sha256 =
-        "7fb107e2bbaa58403aaf96a6fc84672623cf94c52b314fd69e70fb948f5e6507",
+        "a570437eb4e5a5244c38ad161bab00ba4aeb8cb21de7c8dadf983557febf01ae",
     ),
   "quickcheck-io":
     struct(
@@ -11432,29 +9913,17 @@ packages = (
       sha256 =
         "fb779119d79fe08ff4d502fb6869a70c9a8d5fd8ae0959f605c3c937efd96422",
     ),
-  "quickcheck-properties":
-    struct(
-      version = "0.1",
-      sha256 =
-        "3c89ed3fb03199853455806aac3852da8fe2973ae1c78320b901aacb030f2643",
-    ),
   "quickcheck-simple":
     struct(
-      version = "0.1.0.2",
+      version = "0.1.0.4",
       sha256 =
-        "8ad6926fcd45d2fab8e8a55c20a6e6037cce8a66a225ad74b2990922f5f1335c",
+        "808eb5966a97bd38a3992b280428a0b289ccb46c38397ea8e34661d1e1ec4414",
     ),
   "quickcheck-special":
     struct(
       version = "0.1.0.6",
       sha256 =
         "9573898509bd30613bdf59338a5754251081420c59fb658727973e2e837f1cb6",
-    ),
-  "quickcheck-state-machine":
-    struct(
-      version = "0.3.1",
-      sha256 =
-        "44cad255e3b633bf5662494d86e261f8f98bd7be5382b1850503dd632ad03990",
     ),
   "quickcheck-text":
     struct(
@@ -11468,35 +9937,29 @@ packages = (
       sha256 =
         "132005ea7edff35e95139c36232a70698cd0f4f4d79dfaa4e66fbcf557d08368",
     ),
-  "quickcheck-with-counterexamples":
+  "quicklz":
     struct(
-      version = "1.0",
+      version = "1.5.0.11",
       sha256 =
-        "0775755444042169f949474f8931bbf2a88b5cba475d190aacad9af0213fde5e",
-    ),
-  "raaz":
-    struct(
-      version = "0.2.0",
-      sha256 =
-        "9ef0560e7c6b47edd54b5999c3bdacd05d65ac3046b508baaca141c03db98120",
+        "0d0b23370a848efa86da80f835d036f468cdb1b201809351116945729b5b699f",
     ),
   "rainbow":
     struct(
-      version = "0.28.0.4",
+      version = "0.30.0.2",
       sha256 =
-        "829296f88be520a9a6c6de715ffa2bb926cecc0135b23f602cc4377bac4e8831",
+        "be021eb05bc3e6a00b4fc10e1af941afa0c0a69ab83e5204e8455cfd5c0f5ec7",
     ),
   "rainbox":
     struct(
-      version = "0.18.0.10",
+      version = "0.20.0.0",
       sha256 =
-        "d692e95565b4ce4454536493ae4d6ba256eecf5e88e0495d156008ea76ba1b05",
+        "937f61d2fbc7b41f065cec9bb9d6550b54346e52b788d30f73ef78cf8545b61f",
     ),
   "rakuten":
     struct(
-      version = "0.1.0.5",
+      version = "0.1.1.4",
       sha256 =
-        "e14e9e20b9d49dc84a86f1e66dae910eff2ccad27b9502376e795f40ebdc2785",
+        "094cc1f5a271c304d736ba98ceca46df05347012d41b96976a0c2e02ed751b04",
     ),
   "ramus":
     struct(
@@ -11509,6 +9972,12 @@ packages = (
       version = "1.1",
       sha256 =
         "b718a41057e25a3a71df693ab0fe2263d492e759679b3c2fea6ea33b171d3a5a",
+    ),
+  "random-bytestring":
+    struct(
+      version = "0.1.3.1",
+      sha256 =
+        "33a826fd04068902acb62b04cb88c5a0c47e483b88053be9f6de1d64911f0eb4",
     ),
   "random-fu":
     struct(
@@ -11534,23 +10003,11 @@ packages = (
       sha256 =
         "2b604e7ce184e2c877fac63dbac1df3060cdc023427b8eb5844106a826591cc2",
     ),
-  "range":
-    struct(
-      version = "0.1.2.0",
-      sha256 =
-        "4b997ffc63dfc93716938b086ceefffd9df14684c511e0fef4656e82d58b0b09",
-    ),
   "range-set-list":
     struct(
-      version = "0.1.2.0",
+      version = "0.1.3",
       sha256 =
-        "3b749cf447dcf1f81f263c9c43dd61ee533b4fb25e6e4ca3bdbe2321702bab67",
-    ),
-  "rank-product":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "79ffdf09bd6eb37109ff80e965c94def0031bd8c0d8b1cdb9918d903e91fc0b6",
+        "e51b393d2c09e3c2b0c21523389a48ce8e6090413abdfff1c623815c76cc96df",
     ),
   "rank1dynamic":
     struct(
@@ -11558,23 +10015,29 @@ packages = (
       sha256 =
         "3c424bfe52b7d4766fd66ea34c204cf920b146455711d8d10d580ca6c175ab1d",
     ),
+  "rank2classes":
+    struct(
+      version = "1.1.0.1",
+      sha256 =
+        "7c24a53f447fde044a071f0a7bda225a0e2ae76e800daf4b4a3c9fedadea82c7",
+    ),
   "rasterific-svg":
     struct(
-      version = "0.3.3",
+      version = "0.3.3.1",
       sha256 =
-        "4add8e22fda66dc2c3b6cdcd07800aa016a79f5310c7dfba46e907e387c30d4b",
+        "d6b5ea1318b6cca165fee1fae91116878ef72918eca6e7a118624bf56add1184",
     ),
   "ratel":
     struct(
-      version = "0.3.10",
+      version = "1.0.5",
       sha256 =
-        "167d3c8e0d74ce41357ce756113f1d4488b4333f83c30df229dda19cb3789881",
+        "993ce9a8d58619802d286e3be152e295cb38c9dba85ffa0904ed6044972bc52a",
     ),
   "ratel-wai":
     struct(
-      version = "0.3.2",
+      version = "1.0.3",
       sha256 =
-        "ea721c46a5833be2f4ee7cc16ad313bff29c0a3223e51605002ca6c077ec68b8",
+        "04558e3e91e873080810f4441940293ef0874cf2b330bdb4518000307120732e",
     ),
   "ratio-int":
     struct(
@@ -11584,9 +10047,9 @@ packages = (
     ),
   "rattletrap":
     struct(
-      version = "3.1.2",
+      version = "4.1.2",
       sha256 =
-        "48d14db74d73e11100a6c0696fd4d5cd4a5cd585f67154c7c3265504272d0e2c",
+        "62cdbb4d34e5b90ab7a2e3bcf2114990e40f9f7c7bce9cebb6b5cce05a67aa7e",
     ),
   "raw-strings-qq":
     struct(
@@ -11606,6 +10069,12 @@ packages = (
       sha256 =
         "11a177bb7d685fb6a98390630196bd544e877b7460648e61a2905c21a71268fe",
     ),
+  "rcu":
+    struct(
+      version = "0.2.2",
+      sha256 =
+        "93264621dc372c6180aa12324435deeac36946cdca7f77270ef0a3e162474852",
+    ),
   "rdf":
     struct(
       version = "0.1.0.2",
@@ -11618,11 +10087,11 @@ packages = (
       sha256 =
         "54c9a925f68d6c60b405e92f9d3bd9ebfc25cce0c72d2313a6c7e1b7cc2ed950",
     ),
-  "reactive-banana":
+  "re2":
     struct(
-      version = "1.1.0.1",
+      version = "0.2",
       sha256 =
-        "ac0e96ff640d9d2453fd35336a278159263b5e8b40c5ce27a221bdcd46fe70c3",
+        "6906d80ed6834162f74ceb056230f7b1d1cd3423f05f67c65107b1493c8fd561",
     ),
   "read-editor":
     struct(
@@ -11644,45 +10113,33 @@ packages = (
     ),
   "rebase":
     struct(
-      version = "1.1.1",
+      version = "1.2.4",
       sha256 =
-        "5e8e15b84ab8f4c606c95f0133b10dbee9218c8f53d2b8ae00ca568860bb0e66",
+        "ca6be557b4437d43d25133c566024c7bbf66b625b0b035a3ad8affeb381650bd",
+    ),
+  "record-dot-preprocessor":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "35e9162b2ef895253574d953686a86a57bcbf7568c943d2828c319fb5e0566d1",
     ),
   "recursion-schemes":
     struct(
-      version = "5.0.2",
+      version = "5.0.3",
       sha256 =
-        "3a4965bbcc10eb1d1d8dfd51771d7f20c164a1de5711333b1d5cd268a7f6aad2",
-    ),
-  "redis-io":
-    struct(
-      version = "0.7.0",
-      sha256 =
-        "1f68cb184f29fd4dc27b7034ee6dd2c53a952fbda1084ba25afd83952518e619",
-    ),
-  "redis-resp":
-    struct(
-      version = "0.4.0",
-      sha256 =
-        "8bc0d592843e05c37a3fda22255daca74f1c17c4e4a7951531accd45cd2a9232",
+        "db207037a5a89eb0002df1fe878d8b84bf20bc4703ad4a86e856613fa89ca09f",
     ),
   "reducers":
     struct(
-      version = "3.12.2",
+      version = "3.12.3",
       sha256 =
-        "c5d03608b7217e8690a884014dfe03dc4c882ac1a481c5e85c76af4f7a516abd",
+        "7186733767405984c1eda96b18908f458b379f116a1589cd66f4319fe8458e27",
     ),
   "ref-fd":
     struct(
       version = "0.4.0.1",
       sha256 =
         "e416f1afba149e3af9cbe1011381d0b89609c240d812127bd03b8a922a5f6037",
-    ),
-  "ref-tf":
-    struct(
-      version = "0.4.0.1",
-      sha256 =
-        "fcb522c5dca437fbd0c0132c56664a71c48fe2c06b150fcfa77d3bad5ce4be0e",
     ),
   "refact":
     struct(
@@ -11698,45 +10155,15 @@ packages = (
     ),
   "refined":
     struct(
-      version = "0.1.2.1",
+      version = "0.2.3.0",
       sha256 =
-        "156e08b286b3c433d40ca39160b7f1ecec6072c138ca48f6d90d3d0cb808e777",
+        "664abf6de7c010416cfe2666c61b910c155dae1652f2662690c2add8c5c384f5",
     ),
   "reflection":
     struct(
-      version = "2.1.3",
+      version = "2.1.4",
       sha256 =
-        "88f81923abd7211e51de7071cd5800b30784e374c193de8cdd7b1c201f8de405",
-    ),
-  "reform":
-    struct(
-      version = "0.2.7.1",
-      sha256 =
-        "59be2189906788ee4ecf82559aea2e7159a7a0c716c129cccce97e9d89819230",
-    ),
-  "reform-blaze":
-    struct(
-      version = "0.2.4.3",
-      sha256 =
-        "11bcf127356bf5840a0947ea1058cbf1e08096ab0fc872aa5c1ec7d88e40b2e4",
-    ),
-  "reform-hamlet":
-    struct(
-      version = "0.0.5.3",
-      sha256 =
-        "512729389fc3eec118a8079486eb2319e1e8eaecdeecafdd6b36205373ce3466",
-    ),
-  "reform-happstack":
-    struct(
-      version = "0.2.5.2",
-      sha256 =
-        "260f00d9a71a9081b33aac883249d721db993134216cca55acf01de20128dc34",
-    ),
-  "reform-hsp":
-    struct(
-      version = "0.2.7.1",
-      sha256 =
-        "48edd2a1322bacfb2d8574222c194cfa4ffdce135f4dff851d9d5e6fe3008d20",
+        "f22fc478d43a36ec3d6c48c57ec53636c0bf936f3733b9a2b34e1a2e6351c44d",
     ),
   "regex-applicative":
     struct(
@@ -11794,9 +10221,9 @@ packages = (
     ),
   "regex-tdfa":
     struct(
-      version = "1.2.2",
+      version = "1.2.3.1",
       sha256 =
-        "cb12d675be7b31ed8086d8d022023d03eb553e55dbee6e1b7a4154933d471d39",
+        "8aaaeeecf050807c7c514d4dd1763ac63bd121782de5a0847bef5d48a095ea50",
     ),
   "regex-tdfa-text":
     struct(
@@ -11812,33 +10239,27 @@ packages = (
     ),
   "relational-query":
     struct(
-      version = "0.11.0.0",
+      version = "0.12.0.1",
       sha256 =
-        "5fd5cd6f9fadef2995ffc8c5e4dd76d7b31125900dcef892c6bcf2a758f61a6c",
+        "1ff2055d892fb9c89013a4cdb90070f6bac15e9ac43730eac6299104c4b8555a",
     ),
   "relational-query-HDBC":
     struct(
-      version = "0.6.6.1",
+      version = "0.7.0.1",
       sha256 =
-        "4fecb13ef0150f2f067f8b3df7cbe6a65528f0ce8035f7a2b04ac4b4a75c44a9",
+        "a05ed895ccc4bcb35055a646833e60be8ef183d6b0e72d98c8d20328a7278f36",
     ),
   "relational-record":
     struct(
-      version = "0.2.1.2",
+      version = "0.2.2.0",
       sha256 =
-        "5ead1f9de164cbf674ec268fdd613dcfbbc87f5069e53007837ea5db93320d19",
+        "0bbd2663c394a39a7b3d9bcd257d91e3312be7f3c8df562b6868e82c0b96b3da",
     ),
   "relational-schemas":
     struct(
-      version = "0.1.6.1",
+      version = "0.1.6.2",
       sha256 =
-        "01ed4c898224e163d88b59ab66ebf50c710d6a4b968f8f3d6da2b6eca05278d2",
-    ),
-  "rematch":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "f996de29c0e7a47484a16113129166f7df12567d3ca3ea24c5c97e98a8225c51",
+        "5522efa683c5da8c37b09d2ebc636bc8d60804ed2372912ca7cc80793e45a7b0",
     ),
   "renderable":
     struct(
@@ -11852,18 +10273,6 @@ packages = (
       sha256 =
         "3e32d7b2964994d6edd3eabcce38f0c08ff474b3d4acb0d9b3f3b75c76e67a70",
     ),
-  "repa-algorithms":
-    struct(
-      version = "3.4.1.2",
-      sha256 =
-        "07b597e071759e3708bbd8487ce0111949ed3e74b5187f486be19e4764c19886",
-    ),
-  "repa-io":
-    struct(
-      version = "3.4.1.1",
-      sha256 =
-        "b5dbca96a988fb8bd918288ea1cfcf215fe46062e45001b209603b63a39ba9da",
-    ),
   "repline":
     struct(
       version = "0.1.7.0",
@@ -11872,9 +10281,9 @@ packages = (
     ),
   "req":
     struct(
-      version = "1.0.0",
+      version = "1.1.0",
       sha256 =
-        "0701964278654bc8d2c96f550da1a11de78d42e4f85ce53ba5260c7e83695ee8",
+        "87cd886d295e2df38baebd63045be306e07bb910cf11aed9a1a734ac5dc04e22",
     ),
   "req-conduit":
     struct(
@@ -11882,11 +10291,23 @@ packages = (
       sha256 =
         "1da764e4bdc5454aef3d79cff2d72c9fa393a8d049ab14c3ba2be77325d96ba4",
     ),
-  "reroute":
+  "req-url-extra":
     struct(
-      version = "0.4.1.0",
+      version = "0.1.0.0",
       sha256 =
-        "34a83f0d0240610b3e6867f02859d77a8255783e2225389bf025865d5d4c2508",
+        "b3de266ad49fb3c03ff26d589d89f81ddea7f319900b07e59843e57986d37d84",
+    ),
+  "require":
+    struct(
+      version = "0.2.1",
+      sha256 =
+        "a2b79c763f85ac22a436104c11cf5a467da48f59623027fe03c5e22a594dc131",
+    ),
+  "resolv":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "49b12ed2b175cca3f885c06ca6906cde1245c02b6f98f2a95fc20d6a8ae40772",
     ),
   "resource-pool":
     struct(
@@ -11896,57 +10317,15 @@ packages = (
     ),
   "resourcet":
     struct(
-      version = "1.1.11",
+      version = "1.2.1",
       sha256 =
-        "346ed5c3eca87e1b2df5ca97419bd896e27ad39d997b8eea5b62f67c98a824d9",
-    ),
-  "rest-client":
-    struct(
-      version = "0.5.1.1",
-      sha256 =
-        "5da423c9f2c87b9b9797ea331c5f248408e5f863d460dfd94b3408249729f663",
-    ),
-  "rest-core":
-    struct(
-      version = "0.39",
-      sha256 =
-        "d760d0547fc1a99cd949dde08b7945fb93af24f4e55d45ecf410c352d5005404",
-    ),
-  "rest-gen":
-    struct(
-      version = "0.20.0.1",
-      sha256 =
-        "61f462755edb12996f49a1a7723cdc7e01e0a5c2e3c8f01805c6bbdcceaf4439",
-    ),
-  "rest-happstack":
-    struct(
-      version = "0.3.1.1",
-      sha256 =
-        "794f06eb2c96b995397e21f4578bd7094a20334f43883e97af81dbe60b394ff6",
-    ),
-  "rest-snap":
-    struct(
-      version = "0.3.0.0",
-      sha256 =
-        "ce4584bc1e9473e524782c6adf8771af1ddc1d2f6e865f7b06c883f46aee68e8",
+        "e765c12a6ec0f70efc3c938750060bc17569b99578aa635fd4da0c4d06fcf267",
     ),
   "rest-stringmap":
     struct(
-      version = "0.2.0.6",
+      version = "0.2.0.7",
       sha256 =
-        "66e5a32f04cfcf9826296b3c053c22caa745fd890ccc6ea9199c34529507524a",
-    ),
-  "rest-types":
-    struct(
-      version = "1.14.1.1",
-      sha256 =
-        "b7e08e65bbae20bd891f0905c9c785184182172094673ab13e66499e4fe3969a",
-    ),
-  "rest-wai":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "38205eb7b85a4e052f11db099dd65e9d952b8533d1a35001f0b1958b443c0d02",
+        "62d4644f5f7e4ad85688feafaea48b577907a382729f11e1c1fde21a98215450",
     ),
   "result":
     struct(
@@ -11962,9 +10341,9 @@ packages = (
     ),
   "retry":
     struct(
-      version = "0.7.6.0",
+      version = "0.7.6.2",
       sha256 =
-        "f6cc3eb256f1ab523ebacad7ab9804fae77ff3f133b57e07707a33d36433dddc",
+        "4d99f0598762de530200477efdba80a51cde2316a698a64f8683b86ba0b8b92e",
     ),
   "rev-state":
     struct(
@@ -11978,17 +10357,35 @@ packages = (
       sha256 =
         "e38dab28a5625774be60545c8c99e647b79bbc0ac0bc9c65fe6b2ebef160642b",
     ),
+  "rhine":
+    struct(
+      version = "0.4.0.1",
+      sha256 =
+        "d21b320095c36c43a76b76f5f510089854e73e18304bbb27fa04e1b782c1b503",
+    ),
   "riak":
     struct(
-      version = "1.1.2.3",
+      version = "1.1.2.5",
       sha256 =
-        "b60409a13902fb0097b7ba329ea7fb0cd673f16a6fc3d2f078f54c41d1db31e8",
+        "c752fee9859c0c45daae4e0a3c6a231c625b25983781109823d9229a4dc5c7d2",
     ),
   "riak-protobuf":
     struct(
       version = "0.23.0.0",
       sha256 =
         "5dcbd06bdb66a1e43881a62a44d92e47d3f16f9ea1b4d53e4a92622faecdca33",
+    ),
+  "rio":
+    struct(
+      version = "0.1.4.0",
+      sha256 =
+        "0fce0a8f903658c429da6a88c67a2544c260520a3332a9e6fe122fb0ebe8521a",
+    ),
+  "rio-orphans":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "7e8d2c6df6e7afdbca5b344c6e57c754e2d6b9c0cfb4f00e1df88dad1bd48b4e",
     ),
   "rng-utils":
     struct(
@@ -12002,17 +10399,17 @@ packages = (
       sha256 =
         "e29d2f31b21b2d8ce3507e17211e70a61d2e434a8e19f80b2e4898bdabac34a0",
     ),
-  "rose-trees":
-    struct(
-      version = "0.0.4.4",
-      sha256 =
-        "2313133d29286e1e4f1f0b1d6ec0fba852bc5537d5b062c1b8fe0a6aa79b72cd",
-    ),
   "rot13":
     struct(
       version = "0.2.0.1",
       sha256 =
         "e026d418cc6a1ce83ba11e811387e62ad49ffb1cbd6ae7f58b72fd179fccd4dc",
+    ),
+  "rss-conduit":
+    struct(
+      version = "0.4.2.1",
+      sha256 =
+        "b8f52cc3e899477c6f2642ea6d4abc6fa9c74fc6c08a8f990d50a79aff605712",
     ),
   "runmemo":
     struct(
@@ -12028,21 +10425,21 @@ packages = (
     ),
   "s3-signer":
     struct(
-      version = "0.3.0.0",
+      version = "0.5.0.0",
       sha256 =
-        "89e957f81211a417c425214d3d7eafb0f15f695ffe0002f4198f2e34b43bc494",
+        "d73671d5bda0f5f627bbd876916341985c281c3572e6f8406cdf2f14ed9188e4",
     ),
   "safe":
     struct(
-      version = "0.3.15",
+      version = "0.3.17",
       sha256 =
-        "a35e4ae609aabd568da7e7d220ab529c34040b71ae50df1ee353896445a66a2d",
+        "79c5c41e7151906969133ea21af9f7e8d25c18315886e23d0bdf6faa8b537e5c",
     ),
   "safe-exceptions":
     struct(
-      version = "0.1.6.0",
+      version = "0.1.7.0",
       sha256 =
-        "71d47ce1049465b02d89231f2931e7a1d22b6960e85fca5281162e979cf08d1c",
+        "18cddc587b52b6faa0287fb6ad6c964d1562571ea2c8ff57a194dd54b5fba069",
     ),
   "safe-exceptions-checked":
     struct(
@@ -12050,17 +10447,41 @@ packages = (
       sha256 =
         "d807552b828de308d80805f65ee41f3e25571506b10e6b28b0b81de4aec0ca3f",
     ),
+  "safe-foldable":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "ca7f2ecc0e799c239df8ce56e8592fb8b8264c229ab4e1c66e0f821d299007d1",
+    ),
+  "safe-money":
+    struct(
+      version = "0.6",
+      sha256 =
+        "f9fccbbce2b81d8b54c920156ed9b77298598a7242bad98216e959a677b20fd1",
+    ),
   "safecopy":
     struct(
-      version = "0.9.3.3",
+      version = "0.9.4.1",
       sha256 =
-        "cb2272648a2e1e924b3f4f7f73c475ab70c661c8967246acae1b47f0fa57ba9e",
+        "1476c8c135baaca93ba232495b8d2a86047954e7f4439eafa28ee0763a500e84",
     ),
   "safeio":
     struct(
       version = "0.0.5.0",
       sha256 =
         "d5799b6a6cd36e8f5442d991ed3a2076b10e0e3131269a2090b8c9c5c001e311",
+    ),
+  "saltine":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "85290686e6482fdef5af566e7f51142e6d28bcb03f9ffb211f13da153be0a316",
+    ),
+  "salve":
+    struct(
+      version = "1.0.4",
+      sha256 =
+        "6d4b6b0e58c009b182897f1c762f0b67c38670864fa084e9188e0eadab3e3f61",
     ),
   "sample-frame":
     struct(
@@ -12076,15 +10497,15 @@ packages = (
     ),
   "sampling":
     struct(
-      version = "0.3.2",
+      version = "0.3.3",
       sha256 =
-        "a66156e4600ffb15bde127a841251d49f2d0ff67a85e05961b91839b4769824e",
+        "c8bedc93d61e6b1939f6802d7e21003e9e36abdd6f21a9651179d4d82aa00e0d",
     ),
   "sandi":
     struct(
-      version = "0.4.1",
+      version = "0.4.2",
       sha256 =
-        "722492c2db14a18ed643d5b10532c1a82787f6ab9a952e15a9389d8a7e48c623",
+        "2bc1fc4f8e71009adc9f38304f63684f2795c31077670214147f261bd2bc7337",
     ),
   "sandman":
     struct(
@@ -12100,15 +10521,9 @@ packages = (
     ),
   "sbp":
     struct(
-      version = "2.3.6",
+      version = "2.3.16",
       sha256 =
-        "13da29c591f54cc958f1c25e26847ccc250c5be3577999394b83873c0e0dc816",
-    ),
-  "sbv":
-    struct(
-      version = "7.4",
-      sha256 =
-        "ec3d3922a0da061513b1eedc96ede24a06a6202b2d7d5ae1641fb3dcbe78d47b",
+        "e3b9aec3bd3caeece563cce902862ceac9f50f55131a7ccb7591fe75882d1155",
     ),
   "scalendar":
     struct(
@@ -12134,23 +10549,17 @@ packages = (
       sha256 =
         "3a020d68a0372a5211c72e55eeb299738ea608d17184bc68f74d31ebe667a5e9",
     ),
-  "schematic":
-    struct(
-      version = "0.4.2.0",
-      sha256 =
-        "c48af3110e8d1f67011230a910abbc9ab445043fb6e8218c9de8c68ab6bdc34c",
-    ),
   "scientific":
     struct(
-      version = "0.3.5.2",
+      version = "0.3.6.2",
       sha256 =
-        "5ce479ff95482fb907267516bd0f8fff450bdeea546bbd1267fe035acf975657",
+        "278d0afc87450254f8a76eab21b5583af63954efc9b74844a17a21a68013140f",
     ),
   "scotty":
     struct(
-      version = "0.11.0",
+      version = "0.11.2",
       sha256 =
-        "892203c937ccf1279f5005ddb78ebea84629b80687a1e38fc118b38011a386ed",
+        "1dd86f545e415baa6780fef3be8b3a68d8267e5c042972ef9990dc02a47d9da2",
     ),
   "scrypt":
     struct(
@@ -12160,9 +10569,9 @@ packages = (
     ),
   "sdl2":
     struct(
-      version = "2.3.0",
+      version = "2.4.1.0",
       sha256 =
-        "446ddadc9ed93138d5e69b15b8ba9dd2e9e40401e9b30b1279838d54cb25672b",
+        "21a569c0c19f8ff2bbe1cf1d3eb32f65e8143806de353cedd240df5e9d088b5c",
     ),
   "sdl2-gfx":
     struct(
@@ -12178,15 +10587,15 @@ packages = (
     ),
   "sdl2-mixer":
     struct(
-      version = "0.1",
+      version = "1.1.0",
       sha256 =
-        "d924f31d9e1c87eed92d357ce20273dba44637861927188b8a44db2c0b2e2bc0",
+        "0f4c15a1bda7b265923278641d686756292fc2a8f1c5ced7f98916cc98df0acd",
     ),
   "sdl2-ttf":
     struct(
-      version = "2.0.2",
+      version = "2.1.0",
       sha256 =
-        "0dc6ca8459c463a06e8a59a4cb2039a9a08bd62a04b59efc035a31554b950ae4",
+        "c7656fe923e618d3919d47ac753451b08e6d709372380e15bd3d75b39f2c80f7",
     ),
   "search-algorithms":
     struct(
@@ -12196,21 +10605,21 @@ packages = (
     ),
   "securemem":
     struct(
-      version = "0.1.9",
+      version = "0.1.10",
       sha256 =
-        "feb60dc542ea3ce9cdb449093b85dc69e43df310aab4fd161e4cdaa3ba847036",
+        "32895a4748508da58207b4867266601af6259b7109af80bbf5d2e9e598e016a6",
     ),
   "selda":
     struct(
-      version = "0.1.12",
+      version = "0.2.0.0",
       sha256 =
-        "a9896a55fcd34e208495b77feb7e054bb8590e7334924f43924fc87103096edd",
+        "d226aff054c80864ffab2b50898a6109d0d8adeaee42f06074d4831a1a692ad1",
     ),
   "selda-postgresql":
     struct(
-      version = "0.1.7.1",
+      version = "0.1.7.2",
       sha256 =
-        "42b42c981d2734a569b9c558dea8576cbd8b5e4a5c7258ab848da6d8f811ecc7",
+        "ff781255b5faa9e9197fd3d298e8e11f81c13a0f01d072c72028003563fee51b",
     ),
   "selda-sqlite":
     struct(
@@ -12226,15 +10635,15 @@ packages = (
     ),
   "semigroupoids":
     struct(
-      version = "5.2.1",
+      version = "5.2.2",
       sha256 =
-        "79e41eb7cbcb4f152343b91243feac0a120375284c1207edaa73b23d8df6d200",
+        "e4def54834cda65ac1e74e6f12a435410e19c1348e820434a30c491c8937299e",
     ),
   "semigroups":
     struct(
-      version = "0.18.4",
+      version = "0.18.5",
       sha256 =
-        "589e3042329a6bcffb5c0e85834143586db22eb7a2aae094d492cd004f685d27",
+        "ab2a96af6e81e31b909c37ba65f436f1493dbf387cfe0de10b6586270c4ce29d",
     ),
   "semiring-simple":
     struct(
@@ -12254,23 +10663,11 @@ packages = (
       sha256 =
         "102fdf6db8c00f5a5981c6eed5acba1368a2d79b2970ce5b22ceb180aa0fdc42",
     ),
-  "sensu-run":
-    struct(
-      version = "0.4.0.4",
-      sha256 =
-        "bee065757a9c68d4a7863c8a003a57863fb19ce43fe2d359c1ee186d8d72ffdd",
-    ),
   "seqalign":
     struct(
       version = "0.2.0.4",
       sha256 =
         "4ea194658d865890157d3df882ed21b0c089cdff7f80ea613ae25c5f3d744305",
-    ),
-  "seqloc":
-    struct(
-      version = "0.6.1.1",
-      sha256 =
-        "4435e76ba86417612b6bd6a173dc99444d5fe9184a9822b1edf13c808d4f55c3",
     ),
   "serf":
     struct(
@@ -12280,27 +10677,51 @@ packages = (
     ),
   "servant":
     struct(
-      version = "0.11",
+      version = "0.14.1",
       sha256 =
-        "c5b3f7af140fdafd3f646dcea6720c1b3b8a376f1f19a020b200acde64846b03",
+        "a7fa2f19dd8af4deec873290c29fac46cdfe716347cc44fcc0949a83b7577420",
     ),
   "servant-JuicyPixels":
     struct(
-      version = "0.3.0.3",
+      version = "0.3.0.4",
       sha256 =
-        "60f9c098c1f446338000dad50fb82ff914664d955c1964c09e940da0e81c654d",
+        "7b02f00ac8b78ffda49a96f2d1f39619ec19f244822d177928e75cd533cb9981",
     ),
-  "servant-auth-cookie":
+  "servant-auth":
     struct(
-      version = "0.5.0.5",
+      version = "0.3.2.0",
       sha256 =
-        "6a5b9ffabfc48a908bd91ade7c0b5ef7704eab033a4bb5abffdccd280a7187d6",
+        "7bb4d5118c072cb3845aaba4287b2d5e34e5ccca96916895456a828bf7a9418b",
+    ),
+  "servant-auth-client":
+    struct(
+      version = "0.3.3.0",
+      sha256 =
+        "490ac57150b59c567ef567120a6704cfc2184f7be8e6edaab26ad818dee5b3df",
+    ),
+  "servant-auth-docs":
+    struct(
+      version = "0.2.10.0",
+      sha256 =
+        "adf3c33ce4134a78ae7a5c06092ea5812c99d4b942ff2dd685995eb3b2b53e48",
+    ),
+  "servant-auth-server":
+    struct(
+      version = "0.4.0.0",
+      sha256 =
+        "37122dc5e51a7ead49d6e8e727ec6df3d5026754c0697273e719fa69cf1e8a3b",
+    ),
+  "servant-auth-swagger":
+    struct(
+      version = "0.2.10.0",
+      sha256 =
+        "50a783639eb882fd5047d69245f7770817658814d8c409b547ebdddae05acd12",
     ),
   "servant-blaze":
     struct(
-      version = "0.7.1",
+      version = "0.8",
       sha256 =
-        "90ed1c7a22b83bee344ef3896203f3699b7633bf986ffa064752c3596c072646",
+        "46ea88550123d765b2d09073370d0530a51878e7fdf2cf20b070be1f2f10ae94",
     ),
   "servant-cassava":
     struct(
@@ -12310,27 +10731,45 @@ packages = (
     ),
   "servant-checked-exceptions":
     struct(
-      version = "0.4.1.0",
+      version = "2.0.0.0",
       sha256 =
-        "6fbc80f2939ad2f9d6b728ca4d65edcf50f2f35944cd2b5b0d641948b9df00a6",
+        "a7f282857e56d5d1a59d055cf1936cab96a2cdc2f94a79ff736f7ef1cf56f688",
+    ),
+  "servant-checked-exceptions-core":
+    struct(
+      version = "2.0.0.0",
+      sha256 =
+        "aad3513403241bb06aadc605e6af88a5f3aaa0f1f208aafed6d69e15a23ab248",
     ),
   "servant-client":
     struct(
-      version = "0.11",
+      version = "0.14",
       sha256 =
-        "ea6d2ba8183a9cc721e944659fc175a1e81ecac11dfcea9544ef07f7ccc92afa",
+        "c6860bd46c2ee52412cc8c080091a9d8da28d5e44a47cba468e6eee34f01224b",
+    ),
+  "servant-client-core":
+    struct(
+      version = "0.14.1",
+      sha256 =
+        "c24e7b6d1a9d6b33ca35fcea671791f5dbb381fe49f19497a0467a43f954d761",
+    ),
+  "servant-dhall":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "940eca05ad268137082478009c752c6333c0b1d92e57b13770046eeaac8b31fb",
     ),
   "servant-docs":
     struct(
-      version = "0.11",
+      version = "0.11.2",
       sha256 =
-        "a03aa040ad19478c7f6fef28436c5e3c1fb523c6da5a364167a4b0cd56b87f09",
+        "6b280a8d97d295933f5b4a5442b0c54567299bcc8dd62b7c2890864af7ddd4f4",
     ),
   "servant-elm":
     struct(
-      version = "0.4.0.1",
+      version = "0.5.0.0",
       sha256 =
-        "69b3a5dcbb680fc1e923d76afa8255987d4613e0d4387eb493de071c9842ffc5",
+        "d9d96eeaf209f93791f3c81a5b2afad7be443f9af29f362ec17661436895b950",
     ),
   "servant-exceptions":
     struct(
@@ -12340,99 +10779,105 @@ packages = (
     ),
   "servant-foreign":
     struct(
-      version = "0.10.1",
+      version = "0.11.1",
       sha256 =
-        "88f2f5bc2293585e6dcf5f544bdbf871090389b0402ead403abf6013c3aec9c8",
+        "659cb1033b022869bb5b725cfbb82c02ab0424ca9130e4aeb2fb6bb2d0489805",
     ),
-  "servant-generic":
+  "servant-github-webhook":
     struct(
-      version = "0.1.0.1",
+      version = "0.4.1.0",
       sha256 =
-        "2ef213c2f72eb5d1c3da06f5b8e7537128ea96fe54bb086d5ade91ce872cfcfd",
+        "8bbe9bfe7b7f256fd3e40bcbf36ab9a11ba68aadacac85f5e8a850c8f569cf6c",
     ),
   "servant-js":
     struct(
-      version = "0.9.3.1",
+      version = "0.9.3.2",
       sha256 =
-        "31873c5c5eed6c0c306e36c6dd52da48d8e11844c528f8f93ecf4adb8d1e5605",
-    ),
-  "servant-kotlin":
-    struct(
-      version = "0.1.0.3",
-      sha256 =
-        "ed9579d151a9ba420b1d67753f4c183d3ecb8a4a19d1dbac46f07ae1f689b3c5",
+        "02e0ec27a44a1e5794aacfbf745a815a68854d077e7d056d3e2f17d4812867dc",
     ),
   "servant-lucid":
     struct(
-      version = "0.7.1",
+      version = "0.8.1",
       sha256 =
-        "ec26ba7d159b09be10beacf6242f6ae1bd111e9c738bfbf3cf2f560f48e0fe40",
+        "6671d5d5e29b05911bb8855f42168839c2dbb8ee113a10cef6dd372fc267113d",
     ),
   "servant-mock":
     struct(
-      version = "0.8.3",
+      version = "0.8.4",
       sha256 =
-        "b56080e50ec74f02b759b5ebd7f07f5ac34efc52475e85b4c728f54cf6f3933b",
+        "d9d6392461f57324208e3a227c88e81da35686a38d5d1f783afc673a0c77059c",
     ),
   "servant-pandoc":
     struct(
-      version = "0.4.1.4",
+      version = "0.5.0.0",
       sha256 =
-        "d2a42add37ea494542a951cf089ea02c7469efc5880a59b8e3eb9b786c5e5543",
-    ),
-  "servant-purescript":
-    struct(
-      version = "0.9.0.2",
-      sha256 =
-        "f72839cd6b956b6b2ac2adfd2da237ffee63180c43281e3b109e59925526b2ab",
-    ),
-  "servant-rawm":
-    struct(
-      version = "0.2.0.2",
-      sha256 =
-        "a266877a434f2177049f71ac4b7c4a5e4be77acafb2b779ce61075dea5897c5a",
+        "12d709fced47bb3e017b83dcc5dafb1186720e5318c1b5ebeb886d4439540463",
     ),
   "servant-ruby":
     struct(
-      version = "0.5.1.0",
+      version = "0.8.0.1",
       sha256 =
-        "d2145df940bc8cc6281e26c115d1b418e432661e81fe1364e4147d16a8473848",
+        "a5047e8f7b957f12a8112461a53f779f721f976460f495e32e8174d5bef9ed1e",
     ),
   "servant-server":
     struct(
-      version = "0.11.0.1",
+      version = "0.14.1",
       sha256 =
-        "e25c1cb6c55b9b5f66aa73f59fbcab25d94e4645256aed9b8bbf1edf63d02c7b",
+        "024010b1ef238099d4e8dc1cf000bb5de5bbed149d305506088156308dafddba",
     ),
   "servant-static-th":
     struct(
-      version = "0.1.0.6",
+      version = "0.2.2.0",
       sha256 =
-        "5d45a91c2c9de7a4fa15354887c937cbc49ccd2aee19ecdfe44853eb6a3f2ba7",
+        "5bec0129407580bde3b5bc49fc75737c916b6eaf0ea421bf72f5bf029342741b",
     ),
-  "servant-subscriber":
+  "servant-streaming":
     struct(
-      version = "0.6.0.1",
+      version = "0.3.0.0",
       sha256 =
-        "3da1856b47c03ffa1d1c107267e7f18ef5207e6bb2d104788f60b14f01ac7839",
+        "980d486577658697891360479195ed493859e2279f76334101a45c880f7c5a4c",
+    ),
+  "servant-streaming-client":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "42e2b229fa37538466dafa1992ab735c8342801dc07e1fff2706d460345770c0",
+    ),
+  "servant-streaming-server":
+    struct(
+      version = "0.3.0.0",
+      sha256 =
+        "c6e0a846e0156e097bb6a60710009fb4935241a3e7ce5b12b867ae094d1f5053",
     ),
   "servant-swagger":
     struct(
-      version = "1.1.4",
+      version = "1.1.5",
       sha256 =
-        "710481116ef49a80cc0925a72073b6a38554245ebf04558c50aa4eb053009a75",
+        "4f7a442bccf2df8a9980129d83bbcd3e73cfec374919ecb8389709c5df0ca50a",
     ),
   "servant-swagger-ui":
     struct(
-      version = "0.2.4.3.4.0",
+      version = "0.3.0.3.13.2",
       sha256 =
-        "316f6d5b5754615bb57dbcb27f2a16c716e0a7f847826e6e58d04b09cf5d61ed",
+        "b6dcb349d845e5a4fa357cb358f44814f30ba23129abd64cb41bda959e629352",
+    ),
+  "servant-swagger-ui-core":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "ab379f8dec934c573c62c72ad49cc04c7e3c77a93fb8f375cfa965836eaa9616",
+    ),
+  "servant-tracing":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "3edf2e58c60b6624a81c57bbc606889d779ba0cc57fc785240cb353f9caaea62",
     ),
   "servant-websockets":
     struct(
-      version = "1.0.0",
+      version = "1.1.0",
       sha256 =
-        "623112456c7095c38a43a0351997bafad299a96f8d7fe769eb29b1f2b2f7c917",
+        "63384c89db83bd03e00f2f6796c391fc133ffb3c2bc72976778d476ed82f0a51",
     ),
   "servant-yaml":
     struct(
@@ -12440,23 +10885,17 @@ packages = (
       sha256 =
         "c917d9b046b06a9c4386f743a78142c27cf7f0ec1ad8562770ab9828f2ee3204",
     ),
+  "serverless-haskell":
+    struct(
+      version = "0.6.2",
+      sha256 =
+        "659390e33b14506aad035c4dd76a0a514a1a93675f534e5da37172640df08bda",
+    ),
   "serversession":
     struct(
       version = "1.0.1",
       sha256 =
         "3ffbefd87017e8d46fbbe380f59e24672aa9c06b999da5f9ae0b052094d94822",
-    ),
-  "serversession-backend-persistent":
-    struct(
-      version = "1.0.4",
-      sha256 =
-        "c7f2d6fe08d13269ed4834ccf186926dc6c3815011bc456e77ce481fb6eb971c",
-    ),
-  "serversession-backend-redis":
-    struct(
-      version = "1.0.3",
-      sha256 =
-        "ce4b0a3741da3842fe4b5008b51894251ac59b3530babd5ce58b915ec2543615",
     ),
   "serversession-frontend-wai":
     struct(
@@ -12464,17 +10903,11 @@ packages = (
       sha256 =
         "0b48130e3d3915dc46ec2392984e7862d066f6ddd454127a98b0c21c2574b167",
     ),
-  "serversession-frontend-yesod":
-    struct(
-      version = "1.0",
-      sha256 =
-        "063946df7bf693e26973f81dd72b3586115dfac6b358421e4a7ada48e47c6753",
-    ),
   "servius":
     struct(
-      version = "1.2.0.3",
+      version = "1.2.1.0",
       sha256 =
-        "47621f01e55cf4e69aeea80104a8a99e87c3a9ad13a5f144da7acd38370563f0",
+        "040c2870673998716fe90ff9d4a08e7b942dcb613ff38e352a26221963948741",
     ),
   "ses-html":
     struct(
@@ -12484,15 +10917,9 @@ packages = (
     ),
   "set-cover":
     struct(
-      version = "0.0.8",
+      version = "0.0.9",
       sha256 =
-        "186d3a1b6e824e3bd1d479347d8310dba9f1cba98e90bc03d885c42558ea95d1",
-    ),
-  "set-monad":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "eb2b4312c4a71024ea1c85683065c1052b0065b7d96df68cd1c4390c1ab2afdb",
+        "afebfd20c00ff68cd99c7e457d15542003228a56d98af63565549a77852f73e1",
     ),
   "setenv":
     struct(
@@ -12502,27 +10929,27 @@ packages = (
     ),
   "setlocale":
     struct(
-      version = "1.0.0.5",
+      version = "1.0.0.6",
       sha256 =
-        "57438491475004eda12d7a73eea0ab1c5fb28774027626e5bbcb142fe57d9ff0",
+        "587af63153c1f3642de2c2f526b3a3c82c46ece3bd09ffd96a0eedbfd1c288e6",
     ),
-  "sets":
+  "sexp-grammar":
     struct(
-      version = "0.0.5.2",
+      version = "2.0.1",
       sha256 =
-        "be20d5b7b4a5770b7089879f3ef7226c485f4d5bb17e87f979f3bb6475e48713",
+        "babe1c38e7ce20c6158b12ebf3cc31a2ca5c777ba37ebee40315fa0360ecdf7e",
     ),
   "shake":
     struct(
-      version = "0.16",
+      version = "0.16.4",
       sha256 =
-        "8f35ea18ed8bffd11dcbadc17384948866c191631f2a0786f253db73b3472b0d",
+        "b732a3a46ceb3b4545a78c3733e0a7904763e7cd3ee8bf4fe2e1e91f2c9b1436",
     ),
   "shake-language-c":
     struct(
-      version = "0.11.0",
+      version = "0.12.0",
       sha256 =
-        "2174ad269b5fc3bb09054b0289697ce052b1cd3fc3393f6ad00181f1870f931d",
+        "661e350179e55c930c3c36f53853db2bc2697d88c5265049085cea09f5aa1ab0",
     ),
   "shakespeare":
     struct(
@@ -12532,9 +10959,9 @@ packages = (
     ),
   "shell-conduit":
     struct(
-      version = "4.6.1",
+      version = "4.7.0",
       sha256 =
-        "86d161f8b05ae72e5464fe4ade42443d750fc9ffbd5ba98d7d5587287076ad42",
+        "6f31c5b6fb46219c4da575b4405f1a5af51eed1f22073d315df80c8a40ddbe30",
     ),
   "shell-escape":
     struct(
@@ -12542,17 +10969,17 @@ packages = (
       sha256 =
         "e23c9ba94a27e45430cb39e6bb236557e789d24129257c3def377f441b2cba4a",
     ),
+  "shelltestrunner":
+    struct(
+      version = "1.9",
+      sha256 =
+        "cbc4358d447e32babe4572cda0d530c648cc4c67805f9f88002999c717feb3a8",
+    ),
   "shelly":
     struct(
-      version = "1.7.0.1",
+      version = "1.8.1",
       sha256 =
-        "0343758a6f01472341eed2bfd38f8e43543c933bdfc75723c44c332c917f9628",
-    ),
-  "shikensu":
-    struct(
-      version = "0.3.8",
-      sha256 =
-        "9043593a661b738752686e5d8c1e39db22104832b647ea67d212a91a380d516a",
+        "de8814879c7a5e7f1f7f0d9c56c1dfee30d6d63ba1140946e5ed158dd75e6e08",
     ),
   "shortcut-links":
     struct(
@@ -12566,11 +10993,23 @@ packages = (
       sha256 =
         "f538ac70ce07679bc2e6c1651db82a86866664ab995665fdc78e6cb12bd8d591",
     ),
+  "show-combinators":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "22c45747c79055b5310c1da2af717bffded65ea39479c61783f8c1a22e953086",
+    ),
   "show-prettyprint":
     struct(
-      version = "0.2",
+      version = "0.2.2",
       sha256 =
-        "5c1019ad399085e3175f15da98471276175176b0c2fdc11558b5a929b173d293",
+        "f07d860b9bb4176a4e46038c5100ecf07d443daa1b15455ca4c2bd4d10e9af55",
+    ),
+  "siggy-chardust":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "9f730c3cc04ea629e0b655bfff66f83e146eb3b9f0908d5dc00b4c558d5f5a43",
     ),
   "signal":
     struct(
@@ -12584,23 +11023,11 @@ packages = (
       sha256 =
         "cef625635053a46032ca53b43d311921875a437910b6568ded17027fdca83839",
     ),
-  "simple":
-    struct(
-      version = "0.11.2",
-      sha256 =
-        "ef53672eded47626cd125dc0759628fcfead2f2e271a0cae1092d4ff244e0614",
-    ),
-  "simple-log":
-    struct(
-      version = "0.9.3",
-      sha256 =
-        "f012ff48e7a93645f0952562e65455f57073552921a7ee8f6a2f3caddee8a844",
-    ),
   "simple-reflect":
     struct(
-      version = "0.3.2",
+      version = "0.3.3",
       sha256 =
-        "38224eb3d0d5eafc7101ad48fa92001c3e753a015d53bb12753a3836b871ecb6",
+        "07825ea04c135298008cf080133e3bfc8e04cbacd24719c46ac6a2ca4acfdb2b",
     ),
   "simple-sendfile":
     struct(
@@ -12608,35 +11035,41 @@ packages = (
       sha256 =
         "f68572592099a2db3f7212ac7d133447ae5bbb2605285d3de1a29a52d9c79caf",
     ),
-  "simple-session":
+  "simple-vec3":
     struct(
-      version = "0.10.1.1",
+      version = "0.4.0.7",
       sha256 =
-        "8a9c9cb7a80080b6440a80549919d3cee3409af6c516b3d10d1392708b48e7c1",
+        "596d0f3c0e11fc93230528fb242b42387d9eee60101b498d9a26726a93dfd0ea",
     ),
-  "simple-templates":
+  "simplest-sqlite":
     struct(
-      version = "0.8.0.1",
+      version = "0.1.0.0",
       sha256 =
-        "28e10f916320bb5097d9ed323a1726d88d17a51b0ac0290a91806d97840bca8e",
+        "5f0bdee8a4ba2b5dea03ff8ecfc91827602624a91d62eb2b4ce90b4d57005d6e",
+    ),
+  "since":
+    struct(
+      version = "0.0.0",
+      sha256 =
+        "7aa713c0fc0b2a748c9b5ddc413b918f77335e45b56d3968100428a42cdfc1ff",
     ),
   "singleton-bool":
     struct(
-      version = "0.1.2.0",
+      version = "0.1.4",
       sha256 =
-        "33bbd0460a5363260f56b29b130babfc16921ba87cb4576569ecc0a0664d449d",
+        "0195c6e2be1e149e5b687ec3be84fd5089b377345fddd333a9d681eacdfafb2a",
     ),
   "singleton-nats":
     struct(
-      version = "0.4.0.4",
+      version = "0.4.1",
       sha256 =
-        "045e7880bf761ecaaed8b738ff5ecec62604925c354cc1845587c3b023de3fb2",
+        "5a5328dd7b33bebbb90d19ef5db273798603da7194ddfc790ee397011f3e68b9",
     ),
   "singletons":
     struct(
-      version = "2.3.1",
+      version = "2.4.1",
       sha256 =
-        "ca8de4df85d50e9363b3f1715a23c9456d2a57e5e145343693714cecc4afaec4",
+        "5d7a200c814a5f1ac16db04456fdafbdea39fc0ee6c934a9ef7bcd2d6da2f9cf",
     ),
   "siphash":
     struct(
@@ -12644,29 +11077,35 @@ packages = (
       sha256 =
         "cf81ce41c6ca40c4fec9add5dcebc161cb2d31f522f9ad727df23d30ac6a05f3",
     ),
+  "size-based":
+    struct(
+      version = "0.1.1.0",
+      sha256 =
+        "71f66046e46c8754b9f7ae1ef63b2d85aa62a1fe6901bd1ef18691d11b1edcfc",
+    ),
   "skein":
     struct(
       version = "1.0.9.4",
       sha256 =
         "f882ca0cc5ed336ef898fb3c89579e392900259296b2320edf968b9fc16cb8c9",
     ),
-  "skeletons":
-    struct(
-      version = "0.4.0",
-      sha256 =
-        "3dd5045d09131434a794b9452980b4a54da4312d2e1116ac455bbc9bdf6fbcc6",
-    ),
   "skylighting":
     struct(
-      version = "0.5.1",
+      version = "0.7.2",
       sha256 =
-        "afbda861a98bc1bc9e829b43452e9a5fd559c41a76d87bb40b58398a3184b450",
+        "90b57eb1fe55b9077948139c783d87ca4ddc61bd1407def4dc94117554f803e6",
+    ),
+  "skylighting-core":
+    struct(
+      version = "0.7.2",
+      sha256 =
+        "7832e5976f321cbaf45b969a789241b703fce98f623a1b29dfac9fa679e5ce18",
     ),
   "slack-web":
     struct(
-      version = "0.2.0.1",
+      version = "0.2.0.6",
       sha256 =
-        "295f4958c55708b28597f1d90b9e9fd6117eeedca41c637a7b9878c9be363cec",
+        "4ac076f713d66aabbe0fc069ba352baa345acdb01edba3bd8d161f65c3e1cde7",
     ),
   "slave-thread":
     struct(
@@ -12674,23 +11113,17 @@ packages = (
       sha256 =
         "e47120598dd65ebee33253911a31518021323a5ccfa52588e13c44fd5f5b4b13",
     ),
-  "slug":
-    struct(
-      version = "0.1.7",
-      sha256 =
-        "d76f8243fd8b45d02c0731962ceddcd96154473d6f7c5cbf36ab921bc5627dde",
-    ),
   "smallcheck":
     struct(
-      version = "1.1.3.1",
+      version = "1.1.5",
       sha256 =
-        "9ff5f16ffa4c4ab57c0f22fcada1825aa250c03f1559aae851d96738bb06bdd2",
+        "9020e67895a57bde02d7df2c0af06a4c769eff56d48b6a830f6d803df891aea4",
     ),
   "smoothie":
     struct(
-      version = "0.4.2.7",
+      version = "0.4.2.9",
       sha256 =
-        "84561c3463d870312fafb48680ef0122688814fcbb2eb605570c48cceb64deb2",
+        "d3cafbc34a5d03363ddd41e59bd681168cd2d0aa8be4678db9ae1904ad202a4f",
     ),
   "smtp-mail":
     struct(
@@ -12706,15 +11139,21 @@ packages = (
     ),
   "snap-core":
     struct(
-      version = "1.0.3.1",
+      version = "1.0.3.2",
       sha256 =
-        "0749f0d52e415627411adfa90d78ee04b63aa51f7aa19c0a9a94b692cf5f5754",
+        "4c4398476fe882122ce8adc03f69509588d071fc011f50162cd69706093dd88c",
     ),
   "snap-server":
     struct(
-      version = "1.0.3.3",
+      version = "1.1.0.0",
       sha256 =
-        "745adbc5f8966deff4e84c873f86ad1d19ca306dfd6ddd2a39892640d9bb4eee",
+        "249ea390a4e54899b310c0dd13b91af007a2b685bd0d9769c3e208dd914d7c6f",
+    ),
+  "snappy":
+    struct(
+      version = "0.2.0.2",
+      sha256 =
+        "0565df326a87c6ea67f8fb638e01acb0562cabd16a67fc6f9ea9cd191de8cd91",
     ),
   "snowflake":
     struct(
@@ -12722,17 +11161,11 @@ packages = (
       sha256 =
         "f156ca321ae17033fe1cbe7e676fea403136198e1c3a132924a080cd3145cddd",
     ),
-  "snowtify":
-    struct(
-      version = "0.1.0.3",
-      sha256 =
-        "588c86910eb26f551b9916aca4e60ed60d7ef9b850eb5a920caac67e2b487dd0",
-    ),
   "soap":
     struct(
-      version = "0.2.3.5",
+      version = "0.2.3.6",
       sha256 =
-        "ba0bf7d1d65a594cf4407e70da5baaa2a2ba341b7e1d01a9a2ea01ff32cbb707",
+        "cdfc8ee01d3adb0334521a954e32e64f52a3e404fb469679e39904d4ed52b176",
     ),
   "soap-openssl":
     struct(
@@ -12742,15 +11175,9 @@ packages = (
     ),
   "soap-tls":
     struct(
-      version = "0.1.1.2",
+      version = "0.1.1.4",
       sha256 =
-        "e43abafb0ed390b9f5f99cc957973367d40e91c8d3ae7e22b3250a08ebe7df76",
-    ),
-  "socket":
-    struct(
-      version = "0.8.0.1",
-      sha256 =
-        "745f6d1ef2299e321ad646918b9b733c82b4ded51b3b6aab6755c85182ab09a2",
+        "ce8b33cd4bb2cc60093df4de231967edd789fd9da44a261a539a221116853a14",
     ),
   "socket-activation":
     struct(
@@ -12772,9 +11199,9 @@ packages = (
     ),
   "sorted-list":
     struct(
-      version = "0.2.0.0",
+      version = "0.2.1.0",
       sha256 =
-        "cc52c787b056f4d3a9ecc59f06701695602558a4233042ff8f613cdd4985d138",
+        "b4e476157cf0df745eb3c39921357ffb2bf411cd169e755e99536031e07c5ef4",
     ),
   "sourcemap":
     struct(
@@ -12784,9 +11211,9 @@ packages = (
     ),
   "sox":
     struct(
-      version = "0.2.2.7",
+      version = "0.2.3",
       sha256 =
-        "7dcdf728381dc508640ea3d7c0c5d1024950205d4ebde2ee40c5187b6cc6d2fc",
+        "6075a191c7715cc27be60a21d5fcdfcbcfb54eb659b5d86ce6a8c89d24abad90",
     ),
   "soxlib":
     struct(
@@ -12796,15 +11223,9 @@ packages = (
     ),
   "sparse-linear-algebra":
     struct(
-      version = "0.2.9.8",
+      version = "0.3.1",
       sha256 =
-        "9031afeda59d0117db3e13f394342dab935a47e32984d5a227ce9a4eb36530a7",
-    ),
-  "spdx":
-    struct(
-      version = "0.2.2.0",
-      sha256 =
-        "17ab832cf40cd9df7c1d290e3726c457eb3336c61027e35b245d7e48fb8ebdcb",
+        "c762778b2e45bdba24336be58375871963d4c2ad76cb03c548f0fe0b72f3dcc9",
     ),
   "special-values":
     struct(
@@ -12850,9 +11271,15 @@ packages = (
     ),
   "splitmix":
     struct(
-      version = "0",
+      version = "0.0.1",
       sha256 =
-        "f13aa0689625b1d02cf47c748ea8858898bbdb24324f1419de68074e5d344861",
+        "2a6c8003a941640ceab9dc358aadf69e08800e2cb10a267422e4436fe1e8772f",
+    ),
+  "spoon":
+    struct(
+      version = "0.3.1",
+      sha256 =
+        "b9b350b6730e34c246bbf7e228a86b3d4925b52c95542f7676d719ef2a9881d4",
     ),
   "spreadsheet":
     struct(
@@ -12862,33 +11289,33 @@ packages = (
     ),
   "sql-words":
     struct(
-      version = "0.1.5.1",
+      version = "0.1.6.2",
       sha256 =
-        "ed738e4342060c86f781a2c9c9053262ce21d0ea5a96d09a47c40e6d52a3245b",
+        "3f6a5a0cf8f8aaf452caa2389db54e09494be3fd9dce111fbf06df2b7eddeb38",
     ),
   "sqlite-simple":
     struct(
-      version = "0.4.14.0",
+      version = "0.4.16.0",
       sha256 =
-        "49fab62beb96032bfa35cd1b103d08bd6156d68e94b4508df42e2b6a7673a47f",
+        "60d2a188d1967ebc0d3ec9175776c45a6e1e6e7a4d44567548cb7fe6961d30de",
     ),
   "sqlite-simple-errors":
     struct(
-      version = "0.6.0.0",
+      version = "0.6.1.0",
       sha256 =
-        "e697ba5ff6b4df227d782cb2d2327ce5df4282acdb17e8087ae76adbfabfd980",
+        "5101f84a6d74d658398cc4ef557ad3c6158d53e9c948301cc47ed0cc3eaa716f",
     ),
   "squeal-postgresql":
     struct(
-      version = "0.1.1.4",
+      version = "0.3.1.0",
       sha256 =
-        "50ac7094068d8318c495d29becd514c4387ff0442f2f7f864ab1af6f28a10d68",
+        "179d88ece27e247d42573cb75568c19b5da666b74fe768170590cc62c61c1fec",
     ),
   "srcloc":
     struct(
-      version = "0.5.1.1",
+      version = "0.5.1.2",
       sha256 =
-        "3148a6c6997b0cb92a0c698f4cb362deee6946ce61235c9dbd5cadf56ff61a17",
+        "069edbce6bb72e0771cece3aa5a6b67b9e0b0bd0148e9404842fa43035fec06e",
     ),
   "stache":
     struct(
@@ -12898,33 +11325,21 @@ packages = (
     ),
   "stack":
     struct(
-      version = "1.6.3",
+      version = "1.7.1",
       sha256 =
-        "72b134b52e2f351f48ed0003d4e930949c077394fd10c80f904f1d878d9a917a",
+        "19c4f2e02975bb797a339cfe2893c9e1f40241a910da45be34c5c2f05d62329f",
     ),
-  "stack-type":
+  "starter":
     struct(
-      version = "0.1.0.0",
+      version = "0.3.0",
       sha256 =
-        "f310965736f096cdf099e0a61c5fad39b066692d72643da989b64e61ae196c8e",
-    ),
-  "stackage-curator":
-    struct(
-      version = "0.15.1.0",
-      sha256 =
-        "57264391591dd1db80ef96b4a0f0d3f5c5d2a22379e3566d1a81adf0caec0b95",
+        "fd569cd27cfd62fb9d3e544e222450ec2734c44a3293994f35a26af982ce3d93",
     ),
   "state-codes":
     struct(
       version = "0.1.3",
       sha256 =
         "1667dc977607fc89a0ca736294b2f0a19608fbe861f03f404c3f8ee91fd0f4a1",
-    ),
-  "stateWriter":
-    struct(
-      version = "0.2.10",
-      sha256 =
-        "68093c0f3ccecf2708831cdf5e42a77ec2a198cfb2c6852b4f7e4215ec3f393c",
     ),
   "stateref":
     struct(
@@ -12938,11 +11353,35 @@ packages = (
       sha256 =
         "f4eadcf9b08c14cb084436f81e16edf78d6eeda77a3f93e38ba5d7e263ea5f66",
     ),
+  "static-canvas":
+    struct(
+      version = "0.2.0.3",
+      sha256 =
+        "370824df08cedef2aacbbc8b855fd5cd3c80cfcc07ae2931e0f25397a61dd749",
+    ),
+  "static-text":
+    struct(
+      version = "0.2.0.1",
+      sha256 =
+        "ed5d12d1bc9d6c91241007278746be07fcdcf30babc4d0705a2253b646499229",
+    ),
   "statistics":
     struct(
       version = "0.14.0.2",
       sha256 =
         "3495df2da42c9fcc5b594b97f16c02353bfd6616d6e134ac031dac389d7a4778",
+    ),
+  "stb-image-redux":
+    struct(
+      version = "0.2.1.2",
+      sha256 =
+        "3bf41af8950ecf0ac5645634fdd233f941a904c6c56222ff4efb03f5d17043e8",
+    ),
+  "step-function":
+    struct(
+      version = "0.2",
+      sha256 =
+        "d260fcb72bd3afe3c2b0a80f3f3a5c7afae63d98138d137a80ed8ba131fee7d5",
     ),
   "stm":
     struct(
@@ -12958,9 +11397,9 @@ packages = (
     ),
   "stm-conduit":
     struct(
-      version = "3.0.0",
+      version = "4.0.0",
       sha256 =
-        "cf6f663c069fb8991831ed792e5d22b8786966740797306c9391e610651da809",
+        "ffe46c8848f002b016c86f76155b4523b2af35b2c027847afe0edb6325bd4a5d",
     ),
   "stm-containers":
     struct(
@@ -12992,17 +11431,11 @@ packages = (
       sha256 =
         "0a4f39b1e9fffe50d6dfaa9c0b04977e510fae8b6bd3d7abb7076e8aa8f01345",
     ),
-  "stm-supply":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "f839ada6e5ac9549731086ed13fcf4c9f03a6ff93d64c0a857148820864f388c",
-    ),
   "stopwatch":
     struct(
-      version = "0.1.0.4",
+      version = "0.1.0.5",
       sha256 =
-        "b9f4c22f93359491c9fd20a0bd1ff9abd7e077aadfce1a213293e7e124b1b5c2",
+        "461ed69edf8d68cdadd8d0c6159e9c2fef71d1a440c6feded0b07c77d9113461",
     ),
   "storable-complex":
     struct(
@@ -13018,9 +11451,9 @@ packages = (
     ),
   "storable-record":
     struct(
-      version = "0.0.3.1",
+      version = "0.0.4",
       sha256 =
-        "74e5ceee49e0b7625d13759597d21e714843406b8b80e9168a0bb1199ffdadba",
+        "ceffb2f08d8abc37e338ad924b264c230d5e54ecccaf1c22802c3107ea0c5a42",
     ),
   "storable-tuple":
     struct(
@@ -13030,51 +11463,63 @@ packages = (
     ),
   "storablevector":
     struct(
-      version = "0.2.12.1",
+      version = "0.2.13",
       sha256 =
-        "a2e1402b5a045125350fe01237991a7141ff433ff25e14dad53debc9dd2c0579",
+        "f83742d572aca9431f8ee6325d29169bc630beb2d8ab1957f7165abed138b9fe",
     ),
   "store":
     struct(
-      version = "0.4.3.2",
+      version = "0.5.0",
       sha256 =
-        "eca47c14b14ce5a6369a4b09a048b5a7fe7574d3f1b1099bc03449416c80308e",
+        "32ee23c58cf8fbc6250dc38d719baffb90b668da9217612ea45728e9f61579c7",
     ),
   "store-core":
     struct(
-      version = "0.4.1",
+      version = "0.4.4",
       sha256 =
-        "145285f9f26a64e9611e01749a0d569691a70fa898f5359bedcfca9dacb064b4",
+        "5baecf8c074ff8dca4633630adc979696d7e8ee0a58e143e4d6d0f5c79f30991",
     ),
   "stratosphere":
     struct(
-      version = "0.14.0",
+      version = "0.24.3",
       sha256 =
-        "1ae41b6565390ccfb1c662c28f2e1fa121852425111b1126444b798d013dc987",
+        "bfed5d9bf3af64b77e4cdc9239ae65ba9ea947c2b03e3527a433b2ef12626ab7",
     ),
   "streaming":
     struct(
-      version = "0.2.0.0",
+      version = "0.2.1.0",
       sha256 =
-        "76cab21889b60a56dbd657918d417c559a1a749dd69272f62d444dbdd8e88722",
+        "e11d5e38c4c350cc95180cb0cf80efc0a6051ee8dd17c54961b837112c135075",
+    ),
+  "streaming-attoparsec":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "ff28925269ed98f03ef10a482980030dd7c8ef4c05ef6e32d147db9331df6102",
     ),
   "streaming-bytestring":
     struct(
-      version = "0.1.5",
+      version = "0.1.6",
       sha256 =
-        "12356f6add66c08064d3c89a9f1fbc6f38f0c0c214867f2219c8beb8f0b30746",
+        "c1d723fc9676b85f62f9fc937d756af61d81f69c9c6591e5d38c9b09b7a253d3",
     ),
   "streaming-commons":
     struct(
-      version = "0.1.19",
+      version = "0.2.1.0",
       sha256 =
-        "43fcae90df5548d9968b31371f13ec7271df86ac34a484c094616867ed4217a7",
+        "d8d1fe588924479ea7eefce8c6af77dfb373ee6bde7f4691bdfcbd782b36d68d",
+    ),
+  "streaming-wai":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "35b4182386cc1d23731b3eac78dda79a1b7878c0b6bd78fd99907c776dbfaf30",
     ),
   "streamly":
     struct(
-      version = "0.1.0",
+      version = "0.3.0",
       sha256 =
-        "f12f6d92b19e11c3ad3191ab1da8b23870d0a86a7a9db537e93127638349fcaa",
+        "33d4b3d03e6e7b66a25c3259b0c80a51a0366e6bfb35686eeacb2d8cb831576b",
     ),
   "streamproc":
     struct(
@@ -13096,9 +11541,9 @@ packages = (
     ),
   "strict-base-types":
     struct(
-      version = "0.5.0",
+      version = "0.6.1",
       sha256 =
-        "febcadf3d7f97f9c8c161a98e2537ba83a8adc4e4f6015e65430d7367104a1cb",
+        "f8866a3acc7d61f1fbffc2823c24d35b4f63f90612bf0c63292f3d25a3dc307a",
     ),
   "strict-concurrency":
     struct(
@@ -13106,17 +11551,11 @@ packages = (
       sha256 =
         "bf5ad5d14134b57908966322d6b4a07925569b1f351ffe47644233ac4183f86f",
     ),
-  "strict-types":
-    struct(
-      version = "0.1.2",
-      sha256 =
-        "9106620f42690a5877b7d5ee6d58c4c3b0677ea8695e56f793afd2a4a2ae5779",
-    ),
   "string-class":
     struct(
-      version = "0.1.6.5",
+      version = "0.1.7.0",
       sha256 =
-        "821dc13ee0521e0bee335e689c88596efb193130835a6edc45f94dcc9f72237a",
+        "8e5b00563ec2a62120036ab5e06cade5eb7ff8c9caa86f42213c66be39900be8",
     ),
   "string-combinators":
     struct(
@@ -13144,21 +11583,15 @@ packages = (
     ),
   "string-transform":
     struct(
-      version = "0.1.0",
+      version = "1.1.0",
       sha256 =
-        "64e91c0ceb35dd7282c917d6de09b0814a7851d4afd9011ded2f002b7a0d8bc1",
-    ),
-  "stringable":
-    struct(
-      version = "0.1.3",
-      sha256 =
-        "e7af961e1eb52c89330aeb5434d7cfdebd3b712dd39812f68dcbd685e3da5a82",
+        "4d7daffe1d58671af5111c7179905653d692884cac21f09061768a5a6354e6b8",
     ),
   "stringbuilder":
     struct(
-      version = "0.5.0",
+      version = "0.5.1",
       sha256 =
-        "8966882622fc06fd4e588da626a558b54daa313f2328c188d9305b0c6f2fe9aa",
+        "d878bdc4da806dbce5ab684ef13d2634c17c15b991d0ed3bb25a331eba6603ba",
     ),
   "stringsearch":
     struct(
@@ -13166,53 +11599,35 @@ packages = (
       sha256 =
         "295f1971920bc52263d8275d7054ad223a7e1aefe75533f9887735c9644ffe4a",
     ),
-  "stripe-core":
-    struct(
-      version = "2.2.3",
-      sha256 =
-        "bbc5242d07beac17d3404d8a7a7dcf9bab8e8bfc771c2324a65b3581c1afd86f",
-    ),
-  "stripe-haskell":
-    struct(
-      version = "2.2.3",
-      sha256 =
-        "5df82ed8931ba39ce0c5b65993d1f232ea43fa8c226ebc8b63eadfe41256cb20",
-    ),
-  "stripe-http-streams":
-    struct(
-      version = "2.2.3",
-      sha256 =
-        "57006c2c5325ffae1f2dff5021ff7e6b7c510cb1728326dc0cd59fca7b41b42d",
-    ),
-  "stripe-tests":
-    struct(
-      version = "2.2.3",
-      sha256 =
-        "1a1eb1a9d41c897c947990997530e1e1fa2bc04853141522243847bc14177afa",
-    ),
   "strive":
     struct(
-      version = "4.0.3",
+      version = "5.0.6",
       sha256 =
-        "d821a6b2e4bebd2c1d1412e7508cbf0298c0a98b6d8c1c174bdddb2f01863aac",
+        "67a4db92a419f027e4af0545f8ecb72089eff138c008da0e91e5eb650d4aee36",
     ),
-  "structured-haskell-mode":
+  "structs":
     struct(
-      version = "1.1.0",
+      version = "0.1.1",
       sha256 =
-        "c5517a56ebf64134b4b0f0d866357ab498a81d90469985fbeacc458c5ada38b4",
+        "df60ac419775ad96959338c7f14e93a3d47b82728234df206b0145d33694aa41",
     ),
   "stylish-haskell":
     struct(
-      version = "0.8.1.0",
+      version = "0.9.2.0",
       sha256 =
-        "8757c7400477507f9428658650631de2c8d843ea354ead3ea2ded9fb2bbd1f23",
+        "db9f10056a949ad361b5fe3c6fc189601eec2c0058ff2b705ebe68e043b5229b",
     ),
   "sum-type-boilerplate":
     struct(
       version = "0.1.1",
       sha256 =
         "3169da14c604e19afdcbf721ef1749b9486618ba23bbec14e86ae9862bf0ab9f",
+    ),
+  "summoner":
+    struct(
+      version = "1.0.4",
+      sha256 =
+        "d64359adcfef8e422d5fbacfe2f4e0d1e32dcee81bd4a20e1626bd4d4da78fbf",
     ),
   "sundown":
     struct(
@@ -13228,15 +11643,15 @@ packages = (
     ),
   "svg-builder":
     struct(
-      version = "0.1.0.2",
+      version = "0.1.1",
       sha256 =
-        "81490cf0c843d6d7795ba32ac6cb05acf4a92431fe7702aa634ec52d60bfee54",
+        "4fd0e3f2cbc5601fc69e7eab41588cbfa1150dc508d9d86bf5f3d393880382cc",
     ),
   "svg-tree":
     struct(
-      version = "0.6.2.1",
+      version = "0.6.2.2",
       sha256 =
-        "3839209076dbf5ee2a3aa391215496f65966b90cb44f3d5b4e21ba919fe8bc0f",
+        "3a6840993765dc235322c51c9de6adfe3b06e1fa6140ba9f57547c73d62e6ac7",
     ),
   "swagger":
     struct(
@@ -13244,35 +11659,23 @@ packages = (
       sha256 =
         "c7144fb22a0d223eb2463a896200936eab665dc01f39affc103d2ee6a38f54d0",
     ),
-  "swagger-petstore":
-    struct(
-      version = "0.0.1.8",
-      sha256 =
-        "07a683d97fddf18fea68141208c010aab2f1e634cb7bb4b6614e9e4783d854e7",
-    ),
   "swagger2":
     struct(
-      version = "2.2",
+      version = "2.2.2",
       sha256 =
-        "c6f9d37157c4e4d8b2f3775601adccdce50bd7209acc7a7565ddae2aca77df2f",
+        "82d352881041baaaa1ed63cc3262953df101dad5e401272dc62ee346b3ab6eca",
     ),
   "swish":
     struct(
-      version = "0.9.1.10",
+      version = "0.9.2.1",
       sha256 =
-        "ecb4268e4e55b159c5259cfaf4a704be7fc746df469c86216b3adf6dfa46dd82",
+        "ef43bedf12c4f9c9b379a8aa00f339d9487769e4388a57ff108f16cb1f8c3f7f",
     ),
   "syb":
     struct(
       version = "0.7",
       sha256 =
         "b8757dce5ab4045c49a0ae90407d575b87ee5523a7dd5dfa5c9d54fcceff42b5",
-    ),
-  "syb-with-class":
-    struct(
-      version = "0.6.1.8",
-      sha256 =
-        "e34749a776da057eabf7895742987c55263bbf7e45cff7093de73a08e5416105",
     ),
   "symbol":
     struct(
@@ -13310,12 +11713,6 @@ packages = (
       sha256 =
         "1656ce3c0d585650784ceb3f794748286e19fb635f557e7b29b0897f8956d993",
     ),
-  "system-posix-redirect":
-    struct(
-      version = "1.1.0.1",
-      sha256 =
-        "53535011e64c1792052987bc1e8799222286c30c349dd36d3fc08c8612fa6ef2",
-    ),
   "tabular":
     struct(
       version = "0.2.2.7",
@@ -13346,11 +11743,23 @@ packages = (
       sha256 =
         "916dd7fdd15452f3d760c345e023ce99496806b813ab01b03ff1b240bbd50210",
     ),
+  "tagged-transformer":
+    struct(
+      version = "0.8.1",
+      sha256 =
+        "a0ff6121e852c78f6428e583c18e90e3bf899f59a529fb2076236e1146eedcb9",
+    ),
+  "tagshare":
+    struct(
+      version = "0.0",
+      sha256 =
+        "d2314bae2e6820700f2a61db9c9f7976e1b53547a49cdd3352bdf29ac3856ce0",
+    ),
   "tagsoup":
     struct(
-      version = "0.14.3",
+      version = "0.14.6",
       sha256 =
-        "c9fd9f70d08df9a8e53123563b1375d8a349be138088374db05e83ae45cd4202",
+        "4b4ed4db1428e859389d628dd5755074f659a424ec49934ec53e44b0fc6a63fb",
     ),
   "tagstream-conduit":
     struct(
@@ -13358,17 +11767,29 @@ packages = (
       sha256 =
         "b296e8f0ba18ae951b5bb3fc2d9d964954666df61ea9363d667f251af17134ab",
     ),
+  "tao":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "0b0a1e9606b15eb3bd334eaaf09f01a52f5cb086e5947959116d1d4409541a47",
+    ),
+  "tao-example":
+    struct(
+      version = "1.0.0",
+      sha256 =
+        "65de395b78e922d95ce7badf6588c00c6d01ea5c14b33c062cde19229f4b00b2",
+    ),
   "tar":
     struct(
-      version = "0.5.0.3",
+      version = "0.5.1.0",
       sha256 =
-        "d8d9ad876365f88bdccd02073049e58715cd5ba94de06eb98e21d595244918a3",
+        "c89d697b6472b739db50e61201251fcaf8a8f5b595b1d9a488d395d7d5ce4b68",
     ),
   "tar-conduit":
     struct(
-      version = "0.1.1",
+      version = "0.2.3.1",
       sha256 =
-        "3945132514c11f1825b9be9eaeac8c14c300d966922a3eb2ac84303164f02da1",
+        "ec72cd49a921a145df15be8da2fc8492f8059719b45f357d3b2813b8ff45207c",
     ),
   "tardis":
     struct(
@@ -13378,75 +11799,57 @@ packages = (
     ),
   "tasty":
     struct(
-      version = "0.11.3",
+      version = "1.1.0.2",
       sha256 =
-        "2bc8f3ec494f0b6857d646e61cc41410334593c31cb3b346f247123c1549a3bc",
+        "473745a8af7042c98a881f8c68158c55f105420d171250c7b31d61a382d770e0",
     ),
   "tasty-ant-xml":
     struct(
-      version = "1.1.3",
+      version = "1.1.4",
       sha256 =
-        "96cc9575a3179d6f575598e72e80feed9b1270108f6beea14f62d78166dfb95b",
-    ),
-  "tasty-auto":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "b24e6f45aca98bc83316261d21ac5d9094aede0c5c7179c16ef2f69dfa3cf65a",
+        "a88aee8127f424155d8cb0237b9c378cfba935579fb2d51fe5d0c009d2d20f6c",
     ),
   "tasty-dejafu":
     struct(
-      version = "0.7.1.1",
+      version = "1.2.0.7",
       sha256 =
-        "54dfa72d0491f04180d25c2e7b2ed74c455f950b472eddd05a6e896fea7e1513",
+        "8c0bbf8636fa8c00c450d051278ee7ba81488cd90a84bca4e285d29cb85ae6f1",
     ),
   "tasty-discover":
     struct(
-      version = "4.1.3",
+      version = "4.2.1",
       sha256 =
-        "acd4145540cac887994483dba39ed84c095f880c9e5c2e794bcbc197e839818f",
+        "be6c5b384614a592fb056e2e4f7806416aa37f114db77d0f8986938ba7cc1d3e",
     ),
   "tasty-expected-failure":
     struct(
-      version = "0.11.0.4",
+      version = "0.11.1.1",
       sha256 =
-        "41ed5a34e250ee5dc78daf93aa02a25d751b2c6423302faf49f28986822ba564",
-    ),
-  "tasty-fail-fast":
-    struct(
-      version = "0.0.3",
-      sha256 =
-        "84a75750a28dfad8d3007ebf9a99789a36e304f737752d9ef1953e19d65078de",
+        "519a5c0d2ef9dd60355479f11ca47423133364f20ad3151f3c8b105313405ac4",
     ),
   "tasty-golden":
     struct(
-      version = "2.3.1.2",
+      version = "2.3.2",
       sha256 =
-        "691e1ff7f3b773d1c9fdbc2dc5813c874a1fe0adc37afa476492a35877de1921",
+        "04103d2a2fd6acc8f66b67d943060e88a2ea36b799502bf3e76c2726a15c714c",
     ),
   "tasty-hedgehog":
     struct(
-      version = "0.1.0.1",
+      version = "0.2.0.0",
       sha256 =
-        "81fe35b6c5e9ea5e3227bf6c0784e32c84dc66e5f80ae8516659b0fa77911ceb",
+        "5a107fc3094efc50663e4634331a296281318b38c9902969c2d2d215d754a182",
     ),
   "tasty-hspec":
     struct(
-      version = "1.1.3.3",
+      version = "1.1.5",
       sha256 =
-        "ad208527a00fb155d0be81cae2f51326d625b9a5def9acc6ab558700a92cd503",
-    ),
-  "tasty-html":
-    struct(
-      version = "0.4.1.1",
-      sha256 =
-        "0eea1c9fcf1ef3aeb94b811086e11d87ce59f90bb91afa8765152b943c591f1a",
+        "db0cdcf71d534cfa32a1698f1eb6be03192af09a5dd63177b697bc4ca8b81154",
     ),
   "tasty-hunit":
     struct(
-      version = "0.9.2",
+      version = "0.10.0.1",
       sha256 =
-        "ae1efc2a750dfc09f9276d3a57e6a8f8b30f1a6932e81c53fcd67132b8ea1623",
+        "8f903bef276ef503e4ef8b66a1e201c224588e426bc76f7581480f66d47b7048",
     ),
   "tasty-kat":
     struct(
@@ -13462,15 +11865,9 @@ packages = (
     ),
   "tasty-quickcheck":
     struct(
-      version = "0.9.1",
+      version = "0.10",
       sha256 =
-        "aabf97cf8e852d18be7ffea9a337f7a70c3416ec14255b49a02d976aa732ab0d",
-    ),
-  "tasty-rerun":
-    struct(
-      version = "1.1.10",
-      sha256 =
-        "2ba4afeecc30f34bf1c7fea73fc6f3a213022de9033660af4e8c72004e77e69c",
+        "10fd30cef4a0c2cefb70afecef5adcee1f32f0fd287f108321458fbfd6d7266f",
     ),
   "tasty-silver":
     struct(
@@ -13486,15 +11883,9 @@ packages = (
     ),
   "tasty-stats":
     struct(
-      version = "0.2.0.3",
+      version = "0.2.0.4",
       sha256 =
-        "2bf0a21f0f3f616de2a2d8cccf42371b63779640eca789dccee0089d9de3decb",
-    ),
-  "tasty-tap":
-    struct(
-      version = "0.0.4",
-      sha256 =
-        "c85ee6356f7bcdf3756add5baca06d942656400c3e9765e5087229b53d2eff75",
+        "a64d018056c746efde87e830ff2e7bcd0b65b6582de96d493ca706ea0325447c",
     ),
   "tasty-th":
     struct(
@@ -13522,27 +11913,27 @@ packages = (
     ),
   "tdigest":
     struct(
-      version = "0.1",
+      version = "0.2.1",
       sha256 =
-        "0036b3aebe6556ced3a108579846346c9123d65c9dcd09c1d44435a64e3dc54b",
+        "d46e38067c4d064f3c9c77219f570ba4e9dbbd7273a5edc4860610cde4afb84e",
     ),
   "teardown":
     struct(
-      version = "0.3.0.0",
+      version = "0.5.0.0",
       sha256 =
-        "82354f49f7a32d86cd53cf999abe95324fc3ddd904f306f05cd694568741876c",
+        "50eac07b244bd2d662731929e8b1785df3e8a5014b4bb62f6e843e33e896395c",
     ),
-  "template":
+  "telegram-bot-simple":
     struct(
-      version = "0.2.0.10",
+      version = "0.2.0",
       sha256 =
-        "8fd5a321b1c62f8ca5ed68c098e676917a5dac4d65809fceaed4b52c22b4ac82",
+        "8a8cc572880a792d1ed722bd0ac961892d79113c9fa1b2fbdf3019f98f904ea9",
     ),
   "temporary":
     struct(
-      version = "1.2.1.1",
+      version = "1.3",
       sha256 =
-        "55772471e59529f4bde9555f6abb21d19a611c7d70b13befe114dc1a0ecb00f3",
+        "8c442993694b5ffca823ce864af95bd2841fb5264ee511c61cf48cc71d879890",
     ),
   "temporary-rc":
     struct(
@@ -13556,35 +11947,17 @@ packages = (
       sha256 =
         "378217dde895daf6599a8d3fb07ed59de5e2d8024958277558faca190bb44afc",
     ),
-  "termcolor":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "b09d399a733d867cb05dc51de4ee31d5db73cd453099e342973da91c30f21a90",
-    ),
-  "terminal-progress-bar":
-    struct(
-      version = "0.1.1.1",
-      sha256 =
-        "d7a112a15de1ab587d1d66cdfec3e8abadb521c7ec60ac965f4b04b66cbd35f9",
-    ),
   "terminal-size":
     struct(
       version = "0.3.2.1",
       sha256 =
         "b5c23e964756bc13914649a67d63233f59ad0a813abe7cadeb2fc9d586dc9658",
     ),
-  "test-fixture":
-    struct(
-      version = "0.5.1.0",
-      sha256 =
-        "9b1bd8e6984146679f8a86f8d83069fd7a9461107417b657d4fb1d2eba3d5ed6",
-    ),
   "test-framework":
     struct(
-      version = "0.8.1.1",
+      version = "0.8.2.0",
       sha256 =
-        "7883626a5aebb1df327bf26dbd382208946250a79f9cc3bf9a9eb0b0767bb273",
+        "f5aec7a15dbcb39e951bcf6502606fd99d751197b5510f41706899aa7e660ac2",
     ),
   "test-framework-hunit":
     struct(
@@ -13610,23 +11983,29 @@ packages = (
       sha256 =
         "8b780d9e3edd8d91e24f72d9fa1f80420e52959428ad7c22d0694901a43f9c8a",
     ),
+  "testing-feat":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "1904d31ddce611474e8c836582efbca1ae7d1c7dc76083cf4300e8e0eeff58ec",
+    ),
+  "testing-type-modifiers":
+    struct(
+      version = "0.1.0.1",
+      sha256 =
+        "050bdade2c6f0122b1a04a3833ab7eea2399ffda8258bca6d93ba6614bb202f2",
+    ),
   "texmath":
     struct(
-      version = "0.10.1.1",
+      version = "0.11.0.1",
       sha256 =
-        "52c9638e06ea66a6b75d1d3cce4eb0ebad66af5ce3e53c6c90a6b1564ba34e60",
+        "4ec7f6ec41b38d184ca5069440f09ff2b50ff8318809c880f8da79eb6002ac85",
     ),
   "text":
     struct(
-      version = "1.2.2.2",
+      version = "1.2.3.0",
       sha256 =
-        "31465106360a7d7e214d96f1d1b4303a113ffce1bde44a4e614053a1e5072df9",
-    ),
-  "text-all":
-    struct(
-      version = "0.4.1.1",
-      sha256 =
-        "fc7842805af0cf61d7c581cef600b7b3d18c4e68dacd7a6123cf6da3090daea4",
+        "20e0b1627f613b32cc7f2d2e8dcc48a4a61938b24f3d14fb77cee694f0c9311a",
     ),
   "text-binary":
     struct(
@@ -13634,23 +12013,17 @@ packages = (
       sha256 =
         "b697b2bd09080643d4686705c779122129638904870df5c1d41c8fc72f08f4a1",
     ),
+  "text-builder":
+    struct(
+      version = "0.5.1.1",
+      sha256 =
+        "141fa5e134e9765e8ba1e73ad1e0b43522b803e1a51f1ca22adf975a963c020a",
+    ),
   "text-conversions":
     struct(
       version = "0.3.0",
       sha256 =
         "1756be2f6b515fea9e00b383c00d1ee851f8b25ddbc2901dd6be27d9b6292c21",
-    ),
-  "text-format":
-    struct(
-      version = "0.3.1.1",
-      sha256 =
-        "6de112764446a65370204f35a5fc4b1831106049f90918545d5dcd2ddd7fee0b",
-    ),
-  "text-generic-pretty":
-    struct(
-      version = "1.2.1",
-      sha256 =
-        "cff331fdea2f695cf9a2583f4bd7393935b4a6ffa2bd47eb7dd983c6184752c7",
     ),
   "text-icu":
     struct(
@@ -13660,15 +12033,15 @@ packages = (
     ),
   "text-latin1":
     struct(
-      version = "0.3",
+      version = "0.3.1",
       sha256 =
-        "892bbccaed95502faf33dfda612358f24fcaaee521ffa926b34b5236394e40b3",
+        "6c7482ae0cfde06fe6ad8f0e6ea6b0d082d27a075370b5c018c31e53aad9abf3",
     ),
   "text-ldap":
     struct(
-      version = "0.1.1.11",
+      version = "0.1.1.12",
       sha256 =
-        "daddf33568e290014eda3ea101c382bbddb5977807e8a721b06c4f95706341a4",
+        "7d65962e68c52c2785c779679ebd365c7c84b26c640c42a0897f5754ed39d7cd",
     ),
   "text-manipulate":
     struct(
@@ -13684,9 +12057,9 @@ packages = (
     ),
   "text-postgresql":
     struct(
-      version = "0.0.2.3",
+      version = "0.0.3.1",
       sha256 =
-        "e23c7563532ae93aac0bfa541fabb46979437f4bf3d68be3a33aa7368270e436",
+        "c6e26888d2751b78e3102747d0bccedeee4002a1eb6c76dd1fe6c3836b5082e8",
     ),
   "text-printer":
     struct(
@@ -13694,29 +12067,23 @@ packages = (
       sha256 =
         "8f0c01a6a15b4314c2d47ab5f0772d176ec38f1c1fe190b9fa7db5149a6c4a0b",
     ),
-  "text-region":
-    struct(
-      version = "0.3.0.0",
-      sha256 =
-        "cae9417e0ee0368d0c6e47d8c1a3b00446ae43d997c1d31451b41961dba5c977",
-    ),
   "text-short":
     struct(
-      version = "0.1.1",
+      version = "0.1.2",
       sha256 =
-        "55eff9f33471393bfc9b12a790e18e9170c8f1c668359b8f781be31eac1521b1",
+        "b3f2b867d14c7c2586ea580028606b6662293ad080726d5241def937e5e31167",
     ),
   "text-show":
     struct(
-      version = "3.7.1",
+      version = "3.7.4",
       sha256 =
-        "29214d9016f384320a29d3ba1cf9c468d443e3487ff30aaf245ba4df2f1b6e3d",
+        "3efb643349e288f0d92dc2fd26a76d38d08686e827db1d99df707932c9b91e19",
     ),
   "text-show-instances":
     struct(
-      version = "3.6.2",
+      version = "3.6.5",
       sha256 =
-        "259f90f83de40524a7e8563c25faa01a56e23c5134c3458a2350fcfbf78ac430",
+        "14b3f03f14b61bcbb633bf6c95eb279221e5d97b30b27b114f298c1a06c49242",
     ),
   "text-zipper":
     struct(
@@ -13744,21 +12111,21 @@ packages = (
     ),
   "th-abstraction":
     struct(
-      version = "0.2.6.0",
+      version = "0.2.8.0",
       sha256 =
-        "e52e289a547d68f203d65f2e63ec2d87a3c613007d2fe873615c0969b981823c",
+        "ca136bd3fa76230a288ba0a3a65c36a555f32c179369a258b4a04d2f30e12758",
     ),
   "th-data-compat":
     struct(
-      version = "0.0.2.5",
+      version = "0.0.2.6",
       sha256 =
-        "1aafbc567069748daf49334cf3ee91e673e5dc2fac0238ac9e49a71fd97b4fe0",
+        "422fa20a0df78a5c47d0867d3094e4f0a5ba9b3f7118300af7c580156fce78bd",
     ),
   "th-desugar":
     struct(
-      version = "1.7",
+      version = "1.8",
       sha256 =
-        "52b31ca68f27cd9d73c4def58ce12350ec525c6bbeed00d37e5085ae9ac214c7",
+        "bb4d1f1f4f63b77f8b0fdb545f0fd90a4183c80f4bb61edc2052d64e877b7a59",
     ),
   "th-expand-syns":
     struct(
@@ -13774,9 +12141,9 @@ packages = (
     ),
   "th-lift":
     struct(
-      version = "0.7.8",
+      version = "0.7.10",
       sha256 =
-        "2cf83385e848d9136a1d6e49ca845fd1d09935f2ff658c6f4e268d8ece02c12b",
+        "b9ce47a1e5e50d273606e826c1210b724f1af2f302a1de71cd5c9297724d888d",
     ),
   "th-lift-instances":
     struct(
@@ -13784,17 +12151,29 @@ packages = (
       sha256 =
         "1da46afabdc73c86f279a0557d5a8f9af1296f9f6043264ba354b1c9cc65a6b8",
     ),
+  "th-nowq":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "0112f4385eb0856fd186b43a491c6538331d74ca6f86d5dfef4d15ae86e438e5",
+    ),
   "th-orphans":
     struct(
-      version = "0.13.5",
+      version = "0.13.6",
       sha256 =
-        "95644d4b7914317e1dd31095947b8371f1a18be0c09e75f0e29203eb774a25ad",
+        "7745e6b93a73cbc0a6aa0da0a7b7377f0be4fffb4fd311e5502de199ec1dd469",
+    ),
+  "th-printf":
+    struct(
+      version = "0.5.1",
+      sha256 =
+        "86921f308a9446da5fa0e87b25c2f397d4ab8c85df56d9750c91fdb1ee48f135",
     ),
   "th-reify-compat":
     struct(
-      version = "0.0.1.3",
+      version = "0.0.1.4",
       sha256 =
-        "1f41be23a2935c9ffcd1d832749ef2ec23bef91227a8e9a7e8bb14498115d42f",
+        "089f9dda73744c533badcf13bc8e7c6dece4518a3a0b3eb5309cf55808a28a22",
     ),
   "th-reify-many":
     struct(
@@ -13807,12 +12186,6 @@ packages = (
       version = "0.1.0.1",
       sha256 =
         "c3fad31e4b657047d8dd248803e2206c6a5b7375e22d3940714d0cc42d93aa4a",
-    ),
-  "th-to-exp":
-    struct(
-      version = "0.0.1.1",
-      sha256 =
-        "867f213987ed37798e209fd7adf2d29f1eb7789dc605e0f362cf67f576965825",
     ),
   "th-utilities":
     struct(
@@ -13834,15 +12207,15 @@ packages = (
     ),
   "thread-local-storage":
     struct(
-      version = "0.1.2",
+      version = "0.2",
       sha256 =
-        "85c271438bb702698cb010ec1fb9c63641b1b6519208a4520a5f34f05204d459",
+        "d648e01631189036a386d91de22f2b862e830ad0625b1f6096b347974f465294",
     ),
   "threads":
     struct(
-      version = "0.5.1.5",
+      version = "0.5.1.6",
       sha256 =
-        "a15d7ef6b4914e1e97e212c8abadcc84cde137638d9a0d8de1668a89ead50b5e",
+        "139ac3c067fcbb392b5b9c2feaa98184b75ebe7f2e580726eea6ce812d94562e",
     ),
   "threads-extras":
     struct(
@@ -13850,23 +12223,11 @@ packages = (
       sha256 =
         "4defab98b8a767b9580413d530e6823e53f6169671e53b6f8b6bfea89fde2575",
     ),
-  "threepenny-editors":
-    struct(
-      version = "0.5.6",
-      sha256 =
-        "dc56e12c5ecc7cfcc862461747a9cdfe6bfb79b07615d6919bd3f7a186fbcb3e",
-    ),
   "threepenny-gui":
     struct(
-      version = "0.8.2.0",
+      version = "0.8.2.4",
       sha256 =
-        "1955acaf333663b876c5cd349b4f9c5a3f5d849c6d43b4db04c321a3e0ccbbe2",
-    ),
-  "threepenny-gui-flexbox":
-    struct(
-      version = "0.4.2",
-      sha256 =
-        "86862538c0e8448ee7fc9b0b8c47e912587f26db6d1178660d74bf44dca9f0f5",
+        "cb1ba01dea20537ec85b924e998adceae432514cec4533033c0c1d481eafc83b",
     ),
   "throttle-io-stream":
     struct(
@@ -13886,35 +12247,11 @@ packages = (
       sha256 =
         "3ab23c1dd24036a5d1229bed2b140ef50259e365e74c97face9d837c50c769a9",
     ),
-  "thumbnail-plus":
-    struct(
-      version = "1.0.5",
-      sha256 =
-        "81907f62a172f044dbc5c17feb18adee3512eb39c0fd54fb3af42b6d9ff3400c",
-    ),
-  "thyme":
-    struct(
-      version = "0.3.5.5",
-      sha256 =
-        "84c6701fb7b40841d22582202382c362fd9e0d6e5f1c959b7e0f2f91a85c796c",
-    ),
   "tibetan-utils":
     struct(
-      version = "0.1.1.4",
+      version = "0.1.1.5",
       sha256 =
-        "55c93613c6dcfc179e64b431c20b3f2e5f594b61209587912a216160fc0d2377",
-    ),
-  "tidal":
-    struct(
-      version = "0.9.6",
-      sha256 =
-        "a6eba0ff11b056a95ba9ba4efba167b8c295bfd3140fab462fc958f73c888dae",
-    ),
-  "tidal-midi":
-    struct(
-      version = "0.9.5.2",
-      sha256 =
-        "0cff6a95a2eb1674b1616789290f213a44a32b5946024fc5e846722a9ece4b7a",
+        "38007ff5e5ae38bbd68ff2ee6fd850bedb0da2e81891736146494ba1448f7825",
     ),
   "tile":
     struct(
@@ -13936,9 +12273,9 @@ packages = (
     ),
   "time-locale-compat":
     struct(
-      version = "0.1.1.3",
+      version = "0.1.1.4",
       sha256 =
-        "9144bf68b47791a2ac73f45aeadbc5910be2da9ad174909e1a10a70b4576aced",
+        "f2d165557e2bbd014a4d6615b3e6c177adb034179a307a775e06836f91ebbe62",
     ),
   "time-locale-vietnamese":
     struct(
@@ -13954,9 +12291,9 @@ packages = (
     ),
   "timeit":
     struct(
-      version = "1.0.0.0",
+      version = "2.0",
       sha256 =
-        "bd48d90bf96802580d0fa4e9c99150ef3c32cdf97bf345bf40e83633cc5d7236",
+        "a14df4e578db371e5c609f0784209144545f9cae90026d24a3398042f7c591ea",
     ),
   "timelens":
     struct(
@@ -13964,47 +12301,35 @@ packages = (
       sha256 =
         "f4e6fa016ec37f79c96a62cff174929f04152831c308ab1f9a797f5b5674a764",
     ),
-  "timemap":
-    struct(
-      version = "0.0.6",
-      sha256 =
-        "f7176a9396cd0dba21e6491f775b043c6108d21ea6afb33587cad2ebc00a6f01",
-    ),
   "timerep":
     struct(
       version = "2.0.0.2",
       sha256 =
         "1d4e417f3ca08921941c16791680e13b66fb1844d94759068846ede78c965339",
     ),
-  "timespan":
-    struct(
-      version = "0.3.0.0",
-      sha256 =
-        "46a51e1e0d776d65d0094bf8158c938255491fbaa4d4f39b0a1477806312851f",
-    ),
   "timezone-olson":
     struct(
-      version = "0.1.8",
+      version = "0.1.9",
       sha256 =
-        "b96b01015ae5191a56d6bbdbbc3d084f0afb9acd72d84c301792f07871dd3747",
+        "32230509029bcf9e1bd95b5ad7ee69b8b0250cffc4bb8f2df88a651b3af74b15",
     ),
   "timezone-series":
     struct(
-      version = "0.1.8",
+      version = "0.1.9",
       sha256 =
-        "8119d90e4e78fdb662e83f2a350e30678e5e9078737ee90b6c121b62c1a3cdf6",
+        "e5d35df5dc2408803120602b0a66ed63439e36b38dd0895f3e2159fcbd7d9cae",
+    ),
+  "tintin":
+    struct(
+      version = "1.9.1",
+      sha256 =
+        "6b0a55f94c51d6bc52aae2a54c3816725885af373367a6a256acefb413a98444",
     ),
   "tinylog":
     struct(
-      version = "0.14.0",
+      version = "0.14.1",
       sha256 =
-        "322f56178011707436a8e5234a879c5254a468f789ad8db635c98adf752a73ea",
-    ),
-  "tinytemplate":
-    struct(
-      version = "0.1.2.0",
-      sha256 =
-        "30c73964f575bd139ccb214b1123caa99bc330d1904c4d3a5e31e33c31d17d0a",
+        "d13e96117dfcedc861185bee5d1d130a92bce7876cc1ffd041ace2426820df07",
     ),
   "titlecase":
     struct(
@@ -14012,17 +12337,11 @@ packages = (
       sha256 =
         "e7731c29509d2b41b1d94b89484edffa10b86689a755c4019617a6c9485e49cc",
     ),
-  "tldr":
-    struct(
-      version = "0.2.5",
-      sha256 =
-        "fc3ff2744e17d8fa2018d23c37dae25503813581b808d77381e71f21f9fc072d",
-    ),
   "tls":
     struct(
-      version = "1.4.0",
+      version = "1.4.1",
       sha256 =
-        "83290896640403b167d3ae4ea6075f69565a98a5198049a6d98ec35d6bf417ba",
+        "bbead1afc0b808bd5cff7bddaeae84ade37f18bbe72bd78d45a2fa4ac41908f8",
     ),
   "tls-debug":
     struct(
@@ -14044,9 +12363,9 @@ packages = (
     ),
   "tmapmvar":
     struct(
-      version = "0.0.3",
+      version = "0.0.4",
       sha256 =
-        "6ebb205344ed65317d0da31ada7346456288dfaff5556c16978c807da075aaf0",
+        "a6e58cfd8bed77c9ec6122d26db79b3d16f139c977a255bd336fe3c53822b4e3",
     ),
   "tmp-postgres":
     struct(
@@ -14054,17 +12373,11 @@ packages = (
       sha256 =
         "2c5d557c53f60179d5e5e8c7fb6e393ff703e45b55c126359b308ab7a82be863",
     ),
-  "token-bucket":
+  "tomland":
     struct(
-      version = "0.1.0.1",
+      version = "0.3",
       sha256 =
-        "312609c0037271b1091f23c2edf467e9449edca5bbed0cfb45c2c93c1bee6ad0",
-    ),
-  "torrent":
-    struct(
-      version = "10000.1.1",
-      sha256 =
-        "2009964210e229ee67254a73fead3413f60299415238887fa7ef30e40e06fa54",
+        "90d34136d8bb4a38f276116484b60c8e90cd6edf42c0ba405946b4e9f7553c33",
     ),
   "tostring":
     struct(
@@ -14072,11 +12385,17 @@ packages = (
       sha256 =
         "efa700d44aec57c82be60c0eabd610f62f2df0d9b06cf41b5fc35a2b77502531",
     ),
+  "transaction":
+    struct(
+      version = "0.1.1.3",
+      sha256 =
+        "d264b1324726e70aceafdc2fa7eef1c863c527c69486a967116dee29aa23c0c5",
+    ),
   "transformers-base":
     struct(
-      version = "0.4.4",
+      version = "0.4.5.2",
       sha256 =
-        "6aa3494fc70659342fbbb163035d5827ecfd8079e3c929e2372adf771fd52387",
+        "d0c80c63fdce6a077dd8eda4f1ff289b85578703a3f1272e141d400fe23245e8",
     ),
   "transformers-bifunctors":
     struct(
@@ -14086,27 +12405,21 @@ packages = (
     ),
   "transformers-compat":
     struct(
-      version = "0.5.1.4",
+      version = "0.6.2",
       sha256 =
-        "d881ef4ec164b631591b222efe7ff555af6d5397c9d86475b309ba9402a8ca9f",
+        "dc06228b7b8a546f9d257b4fe2b369fc2cb279240bbe4312aa8f47bb2752e4be",
+    ),
+  "transformers-fix":
+    struct(
+      version = "1.0",
+      sha256 =
+        "65d1fff36b844d8ac22d47eb47e2c7e9d7ece54fafeeca4d4e38a08910be4a09",
     ),
   "transformers-lift":
     struct(
       version = "0.2.0.1",
       sha256 =
         "0bd8bf23fb29874daf9ff990bf25035e21208cfa292f9f18e8cfdb0b4b1ee09d",
-    ),
-  "transient":
-    struct(
-      version = "0.5.9.2",
-      sha256 =
-        "22b7e4da2f0855c44d642880bfb876f55ffe74afa51973a5ddc9d21f18f34346",
-    ),
-  "transient-universe":
-    struct(
-      version = "0.4.6.1",
-      sha256 =
-        "36cab01053b99b3503ac1a3cbbd8ef5178e442b3169d9f794f49fbb980325daf",
     ),
   "traverse-with-class":
     struct(
@@ -14126,29 +12439,17 @@ packages = (
       sha256 =
         "2ae925f198e9700dedbf809c2b77086fef32f58b4a4adb6c398dca49f4d56f1f",
     ),
-  "tries":
-    struct(
-      version = "0.0.4.2",
-      sha256 =
-        "164c26a8d5efbd669545e1028f06c090554cabbe005a377827cc9a3b9ed15994",
-    ),
   "trifecta":
     struct(
-      version = "1.7.1.1",
+      version = "2",
       sha256 =
-        "61f8753368fa0c7673b44c4e4c4dede00916f68b3f3b68a5fef6d9dedc50c68e",
+        "53972fe9d206eab6ae1a654fe8c57274f01b373b0c8b3882ef01e962226af643",
     ),
   "triplesec":
     struct(
       version = "0.1.2.0",
       sha256 =
         "86b8749e708fd288a874d23ebeb9ff5e3a584ada13bc22c3a9b596418bd57063",
-    ),
-  "true-name":
-    struct(
-      version = "0.1.0.3",
-      sha256 =
-        "c630ef80687e12c092a797229be96e930819c1042c7cc9f755637ef74774e468",
     ),
   "tsv2csv":
     struct(
@@ -14168,6 +12469,12 @@ packages = (
       sha256 =
         "2fcb068ffafbe64170e02094a363f83d1725f44f8af963d9dad943a592e89624",
     ),
+  "tuple-sop":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "f6e18d0f444993c959eaa7d1aca87993c779b929260b1c6dd823715d3e736043",
+    ),
   "tuple-th":
     struct(
       version = "0.2.5",
@@ -14182,57 +12489,9 @@ packages = (
     ),
   "turtle":
     struct(
-      version = "1.4.5",
+      version = "1.5.10",
       sha256 =
-        "7da2fa3b628e9db218774390121880ecb59873c96655f733de3b38b6c0dc5a20",
-    ),
-  "turtle-options":
-    struct(
-      version = "0.1.0.4",
-      sha256 =
-        "c2c76b0bc0bc93397827c12b6f049e682afe702f9f662a1b0818e8e221d51ace",
-    ),
-  "twitter-conduit":
-    struct(
-      version = "0.2.3",
-      sha256 =
-        "69c70d99c44125e3539356b32f9c15ecd78f9a046918077ceac21f245ef457f7",
-    ),
-  "twitter-types":
-    struct(
-      version = "0.7.2.2",
-      sha256 =
-        "768ee869fc5dc95cf4073ec27862060e6dc6ad7234511d0c6b59cc49841c6d58",
-    ),
-  "twitter-types-lens":
-    struct(
-      version = "0.7.2",
-      sha256 =
-        "4ffeabee70234e0969a0581489473380ebf93de504f7b24f9bc024571acfb212",
-    ),
-  "type-aligned":
-    struct(
-      version = "0.9.6",
-      sha256 =
-        "1b877271cbfc365563f2dc779dc2ee4820be144e1708318882a3cd11786ade55",
-    ),
-  "type-assertions":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "aac74571c99fa0170970716385570cf0e0bbb18fc93f1d7ad372824fe7a679bb",
-    ),
-  "type-combinators":
-    struct(
-      version = "0.2.4.3",
-      sha256 =
-        "1f0ccb6929f53b676e6582141c9423458468eec98be62acc8dc3bab0d52337f6",
-    ),
-  "type-combinators-singletons":
-    struct(
-      version = "0.1.0.0",
-      sha256 =
-        "b00a14cf74372f151e4b85f33fe4d19c30d47fdf64ae32bc2be3de4ba5034c87",
+        "3a93a9aa84e7c04f57d1398b7b1d4ff21a13cc7869922c27d1c3dd201d774b30",
     ),
   "type-fun":
     struct(
@@ -14266,9 +12525,15 @@ packages = (
     ),
   "type-of-html":
     struct(
-      version = "1.3.3.0",
+      version = "1.4.0.1",
       sha256 =
-        "5b471b9c6a1ca78ef00e1b0f32f7e78f4c853b28081b8e003ddb0e936b147960",
+        "e3992f60601f8624a13cb686d400f9be843e33c20223a2ce7af51e85f3bc92ad",
+    ),
+  "type-of-html-static":
+    struct(
+      version = "0.1.0.2",
+      sha256 =
+        "29b3d951eed5498e8011db25996660a5aa0895e1e25fc12da7522fdae74f6200",
     ),
   "type-operators":
     struct(
@@ -14284,15 +12549,21 @@ packages = (
     ),
   "typed-process":
     struct(
-      version = "0.2.1.0",
+      version = "0.2.2.0",
       sha256 =
-        "d214d88575dc0fe919d23eacd91a212ed7bf5b1dbb4360038e99926ff9bcdcd0",
+        "42ed06889c15aa07577a0e8e3632659e343be95b77afa252b48b592ff7dbcf30",
     ),
   "typelits-witnesses":
     struct(
-      version = "0.2.3.0",
+      version = "0.3.0.2",
       sha256 =
-        "a56e92f9c1be1a3063ae3ba3c55c9715ad298b8c5ff8fcf293cf6eabc6ff210c",
+        "6e26c69ff347d138568e6c7e3fc5b256fc3fa3d54c563c2423443dc3428ee64c",
+    ),
+  "typenums":
+    struct(
+      version = "0.1.1.1",
+      sha256 =
+        "9b80a0f187a34df8d1d8bbac3c0064b427405a40f55b60a8ae04f2c62108757e",
     ),
   "typography-geometry":
     struct(
@@ -14302,21 +12573,15 @@ packages = (
     ),
   "tz":
     struct(
-      version = "0.1.3.0",
+      version = "0.1.3.1",
       sha256 =
-        "9710886137db6cbd32d5f7337f23d23b2cb7a19def76306abbdf2ec7f54d5cc0",
+        "0b54729c7b60e90e00ee8e78190d4e86b3fb02d24ef4e393383df800faccfff9",
     ),
   "tzdata":
     struct(
-      version = "0.1.20170320.0",
+      version = "0.1.20180122.0",
       sha256 =
-        "3a86d45b1a183ec22220e6208285dc35efe3f31055061e02aa7a6f762392ce85",
-    ),
-  "ua-parser":
-    struct(
-      version = "0.7.4.1",
-      sha256 =
-        "2ed79b0ae9f3d60d1aeeeb45a9229840708f009ca34752a9787134b8b0d094df",
+        "a31bd845e94fd50d0e97d6d23a0ae39511cdf144075f4978579ede55b714db9d",
     ),
   "uglymemo":
     struct(
@@ -14324,17 +12589,11 @@ packages = (
       sha256 =
         "fe89ef49c0cb15867c58815b050b33f17d394d4c48a9b7240a39780a5a79b847",
     ),
-  "unagi-chan":
-    struct(
-      version = "0.4.1.0",
-      sha256 =
-        "6bab58226a7647fb18bb58274f1175c686135ba5388e1a2508ee48abb336ca5b",
-    ),
   "unbound-generics":
     struct(
-      version = "0.3.1",
+      version = "0.3.3",
       sha256 =
-        "1f85672c8edfc8cbea638bcbf1e29d04934d79470177cb59e6dba0f9bb7a6440",
+        "7fedc5b19dfb4a20d280a4ae538d89cf3482ad30ac77ee1bd2aaa35a6519ad1a",
     ),
   "unbounded-delays":
     struct(
@@ -14354,17 +12613,17 @@ packages = (
       sha256 =
         "6f67855ed4799e0c3465dfaef062b637efc61fbea40ebc44ced163028a996ff2",
     ),
-  "unexceptionalio":
+  "unconstrained":
     struct(
-      version = "0.3.0",
+      version = "0.1.0.2",
       sha256 =
-        "927e2be6bb9ced73c1c17d79c981cadef4039d9ee45d2d3d6b4c133ff93ff0b8",
+        "d2717a66a0232ce454740f45c74645af5ef052e23ba81195ce6c3a06a10e010d",
     ),
   "unfoldable":
     struct(
-      version = "0.9.5",
+      version = "0.9.6",
       sha256 =
-        "766979eb6db59fdcd0c8468ce3445e0987b5dee7bf666631c410c11f774b8252",
+        "cd90eae9ba258cfaf2554b4946c9b60def83c92548bbeb7269fec97a8657eaa1",
     ),
   "unfoldable-restricted":
     struct(
@@ -14374,9 +12633,9 @@ packages = (
     ),
   "unicode":
     struct(
-      version = "0.0",
+      version = "0.0.1",
       sha256 =
-        "d41708f5800a83a2b7f44d10f74371625fbc50dd4a9520dd6fc53762904cc83b",
+        "49bde95d4df4ebed755b10860aeb92f9cf0a3be8127d39a95f480036e6449b81",
     ),
   "unicode-show":
     struct(
@@ -14386,9 +12645,9 @@ packages = (
     ),
   "unicode-transforms":
     struct(
-      version = "0.3.3",
+      version = "0.3.4",
       sha256 =
-        "59748accedb5d8eacf787781c681371ae5fae0955acc38783aa2a7af6133ea11",
+        "829eaccba7d2e3d642d0cf60bbab403a6a5673db64284c02abf3ee3e8d5c0852",
     ),
   "unification-fd":
     struct(
@@ -14414,6 +12673,12 @@ packages = (
       sha256 =
         "fcc60bc6b3f6e925f611646db90e6db9f05286a9363405f844df1dc15572a8b7",
     ),
+  "uniprot-kb":
+    struct(
+      version = "0.1.2.0",
+      sha256 =
+        "d40c80522f9e70e6fe97234f362e503736ae9f520f1e10e9ab249a5cad750642",
+    ),
   "uniq-deep":
     struct(
       version = "1.1.0.0",
@@ -14431,12 +12696,6 @@ packages = (
       version = "0.0.0",
       sha256 =
         "446de8480016c9db75676445477b5ce1ff5c6d486d6708c55b06de7cbd845e59",
-    ),
-  "units-parser":
-    struct(
-      version = "0.1.1.2",
-      sha256 =
-        "0a63f8b62a5d48e6c7126970cc0c6c350711b1d55ccb8182567a47ca35ce751a",
     ),
   "universe":
     struct(
@@ -14476,9 +12735,9 @@ packages = (
     ),
   "universum":
     struct(
-      version = "1.0.0",
+      version = "1.2.0",
       sha256 =
-        "bc0ce6c1aa925917ba62318185e7b0d3edce7fd11f8e987b775889c694a34ff3",
+        "37a10c85d0b4812a9687846cdfe20a61eb102839318149ad036d8c1be47e8518",
     ),
   "unix-bytestring":
     struct(
@@ -14494,15 +12753,15 @@ packages = (
     ),
   "unix-time":
     struct(
-      version = "0.3.7",
+      version = "0.3.8",
       sha256 =
-        "1131301131dd3e73353a346daa04578ec067073e7674d447051ac1a87262b4e1",
+        "dca1bd332f4690f667570868c91c1270083428067e0e20b88a9d9516efa33a14",
     ),
   "unliftio":
     struct(
-      version = "0.2.4.0",
+      version = "0.2.7.0",
       sha256 =
-        "3ff5fe8b0627dcfeac17ca769a819f08d7fe1a26da3a1cff32eb17ac7865f66e",
+        "5adaf4c623914ec027760259042059326c14831e8c9142287cf8f082e9481463",
     ),
   "unliftio-core":
     struct(
@@ -14518,15 +12777,15 @@ packages = (
     ),
   "unordered-containers":
     struct(
-      version = "0.2.8.0",
+      version = "0.2.9.0",
       sha256 =
-        "a4a188359ff28640359131061953f7dbb8258da8ecf0542db0d23f08bfa6eea8",
+        "6730cb5c4a3e953e2c199d6425be08fd088ff0089a3e140d63226c052e318250",
     ),
   "unordered-intmap":
     struct(
-      version = "0.1.0.0",
+      version = "0.1.1",
       sha256 =
-        "99cb542dcd38400b83acc3462c8984c7df8969a2a2f896f4c05c8ae19dfa8a2c",
+        "d8faaf0c23ed143942ba7948616c73134c78e02aa4cf252605c73fb2412876ef",
     ),
   "unsafe":
     struct(
@@ -14536,15 +12795,9 @@ packages = (
     ),
   "uri-bytestring":
     struct(
-      version = "0.3.1.0",
+      version = "0.3.2.0",
       sha256 =
-        "09573fb60332d91cea46944b56f286ca76bf2d86e98224d028af65ff74d81213",
-    ),
-  "uri-bytestring-aeson":
-    struct(
-      version = "0.1.0.4",
-      sha256 =
-        "888ce719e3188df28b3471ad500db4653a85ac3818093fdf93399b82fb68a9da",
+        "acecd68b9d3128d6b6de99580664ab1e7cbaa0e7722e50c5fc67ccbd7c9104e0",
     ),
   "uri-encode":
     struct(
@@ -14558,35 +12811,17 @@ packages = (
       sha256 =
         "21e665ff2600b3de42b6ad01ef342b6165859dc6e66897f84a9075649f1c49c2",
     ),
-  "url":
-    struct(
-      version = "2.1.3",
-      sha256 =
-        "5af27e3f8c0a27e52d0dcb98ef06a0fdd01efe8bb21242c29432e1bc380a4f61",
-    ),
   "urlpath":
     struct(
-      version = "7.0.1",
+      version = "9.0.0",
       sha256 =
-        "ff6690f68602df8bf12efaf27b950da4c0ace58963e5079fa0e1b4865aa5c116",
-    ),
-  "userid":
-    struct(
-      version = "0.1.3.1",
-      sha256 =
-        "695947ef255f9bcfce062363230c796570e73a2a91edf54aab25fc00ffce5489",
+        "90bf89265f5ae94d55e395e199a1b9205d4c56720f1edf9390644c2dc88252fb",
     ),
   "users":
     struct(
       version = "0.5.0.0",
       sha256 =
         "6761ac937b0d4c13c5158239a0c51199c394facb72cc734ada90a391f01e53d4",
-    ),
-  "users-persistent":
-    struct(
-      version = "0.5.0.2",
-      sha256 =
-        "f860936c9eaca82353979c70344576964319d241e3c74caf0a55cd3c9918944c",
     ),
   "users-postgresql-simple":
     struct(
@@ -14612,6 +12847,12 @@ packages = (
       sha256 =
         "fb0b9e3acbe0605bcd1c63e51f290a7bbbe6628dfa3294ff453e4235fbaef140",
     ),
+  "util":
+    struct(
+      version = "0.1.10.1",
+      sha256 =
+        "04056d473579dff21aebb40db9947eebf27b1aead8b6c447b91286ab4c3773fc",
+    ),
   "utility-ht":
     struct(
       version = "0.0.14",
@@ -14630,113 +12871,95 @@ packages = (
       sha256 =
         "9276517ab24a9b06f39d6e3c33c6c2b4ace1fc2126dbc1cd9806866a6551b3fd",
     ),
-  "vado":
-    struct(
-      version = "0.0.9",
-      sha256 =
-        "5ae8e162eba0f2ef45bebea623ea0497ae048a922e1bf1ad6cbea3b379b48878",
-    ),
-  "validate-input":
-    struct(
-      version = "0.4.0.0",
-      sha256 =
-        "20fae24b17429df923b835968720b76c581dc2c5037a2df9374b98a3fa41a1f9",
-    ),
   "validation":
     struct(
-      version = "0.6.2",
+      version = "1",
       sha256 =
-        "f9c055ba78d277b50bc2bf90192e7ef48e70862289237fa1790fb2eedc786118",
-    ),
-  "validationt":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "3e665cedffa1e45632ee9b1439e6a86e97a5f037be941c9b6fdba192663d513f",
+        "70455a22637983dbcf7a688ff80c05bb8bf2690d9e4523d6ca4ebcef77abb921",
     ),
   "validity":
     struct(
-      version = "0.4.0.3",
+      version = "0.7.0.0",
       sha256 =
-        "7a7b9bb6e27de86839533b3f6c84abee303f0f723199884ae3596d371a467797",
+        "ae2409c221d5c9839fb4991ab1123f3747bacd94aab583388c4e5585125f3177",
     ),
   "validity-aeson":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.2",
       sha256 =
-        "2f4eb3a1ab7817bd6311b89ac9df97f8d443697506ac5d2bd676e48298f1f8af",
+        "fac03d29cf3d6f72c288111b68feb3c656574a1ac616b49f40426a9daf0e1d04",
     ),
   "validity-bytestring":
     struct(
-      version = "0.2.0.0",
+      version = "0.3.0.2",
       sha256 =
-        "873e9a37af525591a1895751d6d63af47dae7730c4e3d0225f6ecf11b43a0f85",
+        "62e1a00e9cc12af6451d4484f392d593a628687a7ff78996f1982ee6d2ed912f",
     ),
   "validity-containers":
     struct(
-      version = "0.2.0.0",
+      version = "0.3.1.0",
       sha256 =
-        "f0e991152eb3dceb11cbeeaa75630403b6e66b8fd4edaf4b87e3ce88cecf7f0a",
+        "39096c06200f3ce670c89d557def5dbdd0ba3f608bdc7587b057c2344b3f20b2",
     ),
   "validity-path":
     struct(
-      version = "0.2.0.2",
+      version = "0.3.0.1",
       sha256 =
-        "de6c96c98c0fa85f7f5037b52a80002112a443bae6b716e7edcfa194dab70130",
+        "7e06ff1aab574b7b2b03e69dc41ca59ea6138ecc0628f22d1e06f2748501cdd5",
     ),
   "validity-scientific":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.1",
       sha256 =
-        "ec17870364bfaf40f2d9adfed314379a5577cec87c28bc7946925bb49a9ca55d",
+        "5ce509c4a3ce6b4d098ad4b0c6561af5337cdf797af41a6a0c45e19d60fbf0c6",
     ),
   "validity-text":
     struct(
-      version = "0.2.0.0",
+      version = "0.3.0.1",
       sha256 =
-        "5069db595d2d714ca85398d74efcfed0d5c82c3d41e802e86835ea05911e22c0",
+        "aeb10cb317e198a002cf5b30e2ad81bc2b90c38dad552670baf8751ac4329e31",
     ),
   "validity-time":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.1",
       sha256 =
-        "5f8cdd1fc63891306dc5cb38f204bd1bf3bdb9f20e6f52aed0054bb745829ed7",
+        "6e113bd05c43416c325e98f2173f4b13047051ae4be38142579c1d7d52d51cd5",
     ),
   "validity-unordered-containers":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.1",
       sha256 =
-        "2dbd007dc722a48a8296b838b02233dc742bd9d57af553ade888e623c8ece5b3",
+        "821cc8d4c7514ffe57b1d9f2003c79b9efffeeebdf604c0377aef52543cbfc86",
     ),
   "validity-uuid":
     struct(
-      version = "0.0.0.0",
+      version = "0.1.0.1",
       sha256 =
-        "6ee5f62bbe400afd7e972cc1c08bde5611a16890780e8d9a658acca945ca618b",
+        "362d8cc2dbfbd54bc14061f1c7ecce1472e7f7e550d4b3c287dd48f022249396",
     ),
   "validity-vector":
     struct(
+      version = "0.2.0.1",
+      sha256 =
+        "640e25f047b83becc8ebafa9f383eec08135dc8b3c0d070961a2ac86cd845152",
+    ),
+  "valor":
+    struct(
       version = "0.1.0.0",
       sha256 =
-        "011e1104312392997914567b2804a5cef4b0e7baaf7f5382494e249e55a8e47c",
-    ),
-  "varying":
-    struct(
-      version = "0.7.0.3",
-      sha256 =
-        "6cd417fad6b30d8f9bd5a01dd21d059ecbc26cd1faf27bb7973eea43b5640309",
+        "04ce514f40ef954cdd4b45acb6b2bf6228a30e905fdce0b671df3bf789d6bae6",
     ),
   "vault":
     struct(
-      version = "0.3.0.7",
+      version = "0.3.1.1",
       sha256 =
-        "9e9189da0821d68fc8f85aab958bbec141635858a7aeb8178e1eec5872a366f0",
+        "b2a4150699db8a45d189cc93c34c36c3bfc1082b4ca94612e242aefd4e8e2e28",
     ),
-  "vcswrapper":
+  "vec":
     struct(
-      version = "0.1.6",
+      version = "0.1",
       sha256 =
-        "2eba26a2fd5bc53fff4a7d1bb3ba831f3d188c6f9cd8a2ca97d59b7002b53b3e",
+        "be54ef0a53ff4f27a7a0f14b249d1fd47ede63c085d4c68962db24bf4ba3e054",
     ),
   "vector":
     struct(
@@ -14768,11 +12991,11 @@ packages = (
       sha256 =
         "d1649096abdcc96894031292a63dfc0b36be4ab004a00f91f08aa5bc4c65ebb7",
     ),
-  "vector-fftw":
+  "vector-bytes-instances":
     struct(
-      version = "0.1.3.8",
+      version = "0.1.1",
       sha256 =
-        "e64a333a46c323aa69f5cce08a6e45cb4a93d41066e66fe3b5d440684c219976",
+        "7666e6ff4553a97727625178a6902f8d23d8e94af5f4701b2d1a1394eaeb8c44",
     ),
   "vector-instances":
     struct(
@@ -14788,15 +13011,15 @@ packages = (
     ),
   "vector-sized":
     struct(
-      version = "0.6.1.0",
+      version = "1.0.4.0",
       sha256 =
-        "4d6e3e1292955778b6fa14b2f57f3417c7884e90d56b494b5d6b09dde7f67821",
+        "64be9a8eb50a7ee912b2f7429fc1eb9184283a2b09a9d19fbc6de3e90bf3b9e5",
     ),
   "vector-space":
     struct(
-      version = "0.12",
+      version = "0.13",
       sha256 =
-        "237e4f1581b2c0fd72a8507098a76cf2c804804a9b94da8eb878b16baab8df9a",
+        "0291d5778378acbbb1d6709ba57238f3d6ad551b8b2c6ca2b8177e68f748d617",
     ),
   "vector-split":
     struct(
@@ -14812,9 +13035,9 @@ packages = (
     ),
   "vectortiles":
     struct(
-      version = "1.2.0.6",
+      version = "1.4.0",
       sha256 =
-        "c7f6d58441ae7d14a691d9ab7ebee8c87dea9ab5c97fc770a7a9b3cb426b7ad0",
+        "393cc4f3d0f16c8cbf3c1fda99a6823463d4a855b77babae41249d4175e915c0",
     ),
   "verbosity":
     struct(
@@ -14824,27 +13047,21 @@ packages = (
     ),
   "versions":
     struct(
-      version = "3.3.1",
+      version = "3.4.0.1",
       sha256 =
-        "0482876527577fac5cceb6a074c70fcb6b5f376f5117c02b193c2cd4e17c2435",
-    ),
-  "vhd":
-    struct(
-      version = "0.2.2",
-      sha256 =
-        "7c678f076395f44d853f87a4538635bc83d7a10319933dec9e06b40ce409ea7c",
+        "af46d833929f36757e0a50a733b06aa7fce72663c73d3a944f3752faadccec64",
     ),
   "viewprof":
     struct(
-      version = "0.0.0.13",
+      version = "0.0.0.19",
       sha256 =
-        "9f9c78da656a1ac0fd38dc3a096d9ea2743f768f3a80895972618a009c6390c5",
+        "8cd64535b7cd95353b0b3739618e587f1707497f9f0c4533b79f4e6507b314ed",
     ),
   "vinyl":
     struct(
-      version = "0.7.0",
+      version = "0.8.1.1",
       sha256 =
-        "fa3a1628d6c459a709de35c942cbf052a73734e8041fe99990c610103a0b90bd",
+        "d03a3c53026b91160b30f4f65db1e29bed157ca67f676674488218d7cfd48f3f",
     ),
   "vivid":
     struct(
@@ -14872,21 +13089,21 @@ packages = (
     ),
   "vty":
     struct(
-      version = "5.19.2",
+      version = "5.21",
       sha256 =
-        "bf1f88e97439f3c176d484867a88b6f7f7940e4662cac3e5f20773f61f730a95",
+        "5a79b8b5f3a2ead0db01cfbc34e145cfa8ff36315f0bb075e6d364ae0a937a5b",
     ),
   "wai":
     struct(
-      version = "3.2.1.1",
+      version = "3.2.1.2",
       sha256 =
-        "5d80a68f5d8806682d8267b7dacc383d094e3ef7ecd705f20e42c91cad564e21",
+        "282351461f19fbac26aa0a7896d7ab583b4abef522fcd9aba944f1848e58234b",
     ),
   "wai-app-static":
     struct(
-      version = "3.1.6.1",
+      version = "3.1.6.2",
       sha256 =
-        "b318acf31e2e809411f119744a016ba0a78f52554ac7321a3a1410a218886668",
+        "d0b0a566be61ef4c8f800922a71dbc4de64287f8f73782b1461cd5d294c1dc3e",
     ),
   "wai-cli":
     struct(
@@ -14896,9 +13113,9 @@ packages = (
     ),
   "wai-conduit":
     struct(
-      version = "3.0.0.3",
+      version = "3.0.0.4",
       sha256 =
-        "e49720a7c7b58e78a56991e42fa550a722936af274dc27755a735781258f7aff",
+        "2790093bd52892b8087c295044573c720773144f4061ccc72d6d6a617320d61f",
     ),
   "wai-cors":
     struct(
@@ -14914,27 +13131,21 @@ packages = (
     ),
   "wai-extra":
     struct(
-      version = "3.0.22.0",
+      version = "3.0.23.0",
       sha256 =
-        "62943d71071cbc557686ccb00b4c64383c24b8839b838841686fc2290bd59367",
+        "88cf1fa003d4e85070185f461c534ccecd82a55975f94f58c0a7002f8b8c9081",
     ),
   "wai-handler-launch":
     struct(
-      version = "3.0.2.3",
+      version = "3.0.2.4",
       sha256 =
-        "6dd00e0b703fad0880c69a40f39daff61a3106d7242d9bd0f7ff9f7e97ef61d3",
+        "0e9d9c61310890380dc87807ba1285bc1ab185914be6367ea4bb0a05d3df2900",
     ),
   "wai-logger":
     struct(
-      version = "2.3.1",
+      version = "2.3.2",
       sha256 =
-        "3736875b91eb1da4714167e83f8d26d61caf65e13abcac2913ea8183a34cbd51",
-    ),
-  "wai-middleware-auth":
-    struct(
-      version = "0.1.2.1",
-      sha256 =
-        "4199220758290dd22136fd9f53a8e0a856c217c0b8b26eb6dbf41d2ad81e7d74",
+        "8dd4ff875d9ac2c115f5d45cc4375635a6c3e55a75c632ff3781d1fb086eb470",
     ),
   "wai-middleware-caching":
     struct(
@@ -14947,12 +13158,6 @@ packages = (
       version = "0.1.0.0",
       sha256 =
         "377dc842f5ad77b98e8a817e092c891ccfd0da978fb9f69a380f001a95da28d3",
-    ),
-  "wai-middleware-caching-redis":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "6ff53783db20d8f0ff00514ea2679f7022ca59eb20ffad22628ac17c13bf7c4c",
     ),
   "wai-middleware-consul":
     struct(
@@ -14972,29 +13177,17 @@ packages = (
       sha256 =
         "e73685a748f0ba6d16956b500cdc23f3802f794f5259a3d6b8a5b885e928ec74",
     ),
-  "wai-middleware-prometheus":
-    struct(
-      version = "0.3.0",
-      sha256 =
-        "cec4403e54456e0b885d7ace402ea1eb64f0eb50e1db35de0366dee09752d513",
-    ),
-  "wai-middleware-rollbar":
-    struct(
-      version = "0.8.3",
-      sha256 =
-        "75f35dcfbc832aabe6c92fc3b301a4f66c31f10744cc74a05c1a28775b3bda9f",
-    ),
   "wai-middleware-static":
     struct(
-      version = "0.8.1",
+      version = "0.8.2",
       sha256 =
-        "e0b5f13f410f81897759acf43198a08101d2af4c9d506164367c7d1a96d55375",
+        "0be4e9fd5252d526334e4e5885a2a75269aaaad560282b5c383c49e4d855befc",
     ),
-  "wai-middleware-throttle":
+  "wai-middleware-travisci":
     struct(
-      version = "0.2.2.0",
+      version = "0.1.0",
       sha256 =
-        "6ab783fa8ad1fe16fa69edd532140783efc94934bd859a1dd3eb181cff36b84c",
+        "bbc9f2fea4c0ee3d9a73fd13dd1a2a7ef85fc294bd311ed519c1e41a1fada828",
     ),
   "wai-predicates":
     struct(
@@ -15002,23 +13195,11 @@ packages = (
       sha256 =
         "b7b3f6d147bbbf7a959c84235d0533763eda8fc4973b42f131fd47fe8ffbd7c2",
     ),
-  "wai-route":
-    struct(
-      version = "0.3.1.2",
-      sha256 =
-        "01517d2cb005deeead0e3e99ffe33b7b105bb6b5f651ed9466f128856ec131ae",
-    ),
-  "wai-routing":
-    struct(
-      version = "0.13.0",
-      sha256 =
-        "f4841b028e20f49e3617d13247c04f457c850421321a92e7ab4e372ee85cde8f",
-    ),
   "wai-session":
     struct(
-      version = "0.3.2",
+      version = "0.3.3",
       sha256 =
-        "83739ca93cf1db1e5b54dec7e2590dabfcc77a97ac1388f2f2f18840917c8326",
+        "d2392702446b9af8d45b83b2ce1bbb9937024c2d65fcf943ab51a7d52c7e0053",
     ),
   "wai-session-postgresql":
     struct(
@@ -15034,27 +13215,33 @@ packages = (
     ),
   "wai-transformers":
     struct(
-      version = "0.0.7",
+      version = "0.1.0",
       sha256 =
-        "1a1801a2048eb84808a09e44cb899d6cc689948619eeeea005e312ea5a2fe32c",
+        "17a330c80bad8a95add5d6efb0a12c774c197a2d19f83e6b9dc08ab73d8c8592",
     ),
   "wai-websockets":
     struct(
-      version = "3.0.1.1",
+      version = "3.0.1.2",
       sha256 =
-        "6abeafea574d9e8f4d41de091afec4594489877aa8717f97e91af5543fd38a31",
+        "917cceb08f296d7dc6b6cafb66133ae53888b2c98b8fb2a2d7fa629d75ab5d2c",
     ),
   "warp":
     struct(
-      version = "3.2.13",
+      version = "3.2.23",
       sha256 =
-        "92395bf42d012e5c4deaea7f9e1fc2271a63c5380b4c5bc1cf16b7c53aa2c424",
+        "a0aaff3afbda9675b61ec5725ced21fd48694257ba350fd2d2e07a4822c4698b",
     ),
   "warp-tls":
     struct(
-      version = "3.2.4",
+      version = "3.2.4.3",
       sha256 =
-        "05d1aad58fa1a16a652369d7247d4c68b86af0b8febaea9ab7969c121f956e17",
+        "84cd511e32019ba5bef07b0e8a3550b2da06d534bf3df1673d14a5ec4a12f29d",
+    ),
+  "warp-tls-uid":
+    struct(
+      version = "0.2.0.5",
+      sha256 =
+        "b856932108364220abbba3cdebc86740a9b7436684f39936c6dda6a8d6ed73ac",
     ),
   "wave":
     struct(
@@ -15062,11 +13249,11 @@ packages = (
       sha256 =
         "250a08b0c36870fb7fd0de7714818784eed0c4ff74377746dc1842967965fe0f",
     ),
-  "wavefront":
+  "wcwidth":
     struct(
-      version = "0.7.1.1",
+      version = "0.0.2",
       sha256 =
-        "dc1dee258bf97fd7e22b07ba626ebc0f51c6c6e598dae405598bbb11f58030b5",
+        "ffc68736a3bbde3e8157710f29f4a99c0ca593c41194579c54a92c62f6c12ed8",
     ),
   "web-plugins":
     struct(
@@ -15076,21 +13263,9 @@ packages = (
     ),
   "web-routes":
     struct(
-      version = "0.27.14",
+      version = "0.27.14.2",
       sha256 =
-        "53e523a6b4eb6c3270ae07957251780cb77f0061f867bf3c3a6427263ce6bed4",
-    ),
-  "web-routes-boomerang":
-    struct(
-      version = "0.28.4.2",
-      sha256 =
-        "7ea892cd6e8c25e4adabf999d2332248a7b458662479a28a812bafd8dd2b7827",
-    ),
-  "web-routes-happstack":
-    struct(
-      version = "0.23.11",
-      sha256 =
-        "3ef98ced2c3f198ac4a91072cbe338343b489237882f0939f1c59b372067fd4b",
+        "af8b349c5d17de1d1accc30ab0a21537414a66e9d9515852098443e1d5d1f74a",
     ),
   "web-routes-hsp":
     struct(
@@ -15098,17 +13273,17 @@ packages = (
       sha256 =
         "ca7cf5bf026c52fee5b6af3ca173c7341cd991dcd38508d07589cc7ea8102cab",
     ),
-  "web-routes-th":
-    struct(
-      version = "0.22.6.2",
-      sha256 =
-        "48bec573204c12f6b2edd3b471ad979fa9bf7c4b28eafd045067d942db0ac6c8",
-    ),
   "web-routes-wai":
     struct(
       version = "0.24.3.1",
       sha256 =
         "8e1fd187686452af39929bc6b6a31319001859930744e22e2eee1fa9ad103049",
+    ),
+  "web3":
+    struct(
+      version = "0.7.3.0",
+      sha256 =
+        "af821da95766fcfc74a2dd3cfac867e651443011c2c8251dfad46f63f314c5b9",
     ),
   "webdriver":
     struct(
@@ -15116,17 +13291,23 @@ packages = (
       sha256 =
         "a8167a8b147411a929e81727a77bc31fcd7d93424442268913fb522e1932c1be",
     ),
-  "webdriver-angular":
+  "webex-teams-api":
     struct(
-      version = "0.1.11",
+      version = "0.2.0.0",
       sha256 =
-        "5ebb650cdd9d0815ec897b4972cb0ab7f93d223e8f810e9bf30d6e1fd2ff49f6",
+        "7756e38bd54d4dae1f70e7343259438f98bf58ff484ebc1c798166904178a40b",
     ),
-  "webpage":
+  "webex-teams-conduit":
     struct(
-      version = "0.0.5",
+      version = "0.2.0.0",
       sha256 =
-        "213e92ff931d7f58becb532a70cb958a691b216fa85c43f950b429ffad3d1aad",
+        "0d7c7db689092656653d687adadeb92669b647b1d7adc2493d8ca08a87742e5d",
+    ),
+  "webex-teams-pipes":
+    struct(
+      version = "0.2.0.0",
+      sha256 =
+        "77fad574346613e4989997852ca5972185a6321290caa718ce081be985a33100",
     ),
   "webrtc-vad":
     struct(
@@ -15136,45 +13317,33 @@ packages = (
     ),
   "websockets":
     struct(
-      version = "0.12.3.1",
+      version = "0.12.5.1",
       sha256 =
-        "69fc697f27ce55a6945ef8168b80a7b59062dad50678fc19979b17bdea9e3205",
-    ),
-  "websockets-rpc":
-    struct(
-      version = "0.6.0",
-      sha256 =
-        "efcd5b6d39506fc591863d10d2e179603a004f7730bc1424920c69d7412b31ce",
-    ),
-  "websockets-simple":
-    struct(
-      version = "0.0.6.3",
-      sha256 =
-        "2f71348c842ca065df3da61cd1005182dc430977242a0debcaa4635b0aaaef14",
+        "3fb7c1d0a60f647d3e509bb6846f93a5853b77b0c4396905f000d64546ab3fed",
     ),
   "websockets-snap":
     struct(
-      version = "0.10.2.4",
+      version = "0.10.3.0",
       sha256 =
-        "294d9b4f774659318197a37c0d25862ba858e799da68af76ba41c96365ba7600",
+        "b34a40583a2111bb44233b728095fac38b8de1ab74c027fc4ee92a65af373be4",
     ),
   "weeder":
     struct(
-      version = "0.1.13",
+      version = "1.0.6",
       sha256 =
-        "de1dc36c3b635ad2c7f59af93f0b1e404eeb802a5a8646f64803d6f2c2751f28",
+        "326e943c5c49e298856d95d6255aafd40ccaa29e4af8b299b33858b0ae27281e",
     ),
   "weigh":
     struct(
-      version = "0.0.7",
+      version = "0.0.12",
       sha256 =
-        "e3d270b95c86c2345ea93a692ad48d04833c9d26330219180d5d20cbc0ecb5cc",
+        "fdc8b86edac17d57a56a04f149f796f55bfffa04e3c8d32afeedf5775252827f",
     ),
   "wide-word":
     struct(
-      version = "0.1.0.5",
+      version = "0.1.0.6",
       sha256 =
-        "ad523811267cf915d2f846eec09ad59bb3ca84a1e6b0d6f66fce102ee495402a",
+        "1d8c0998b70af7b850a9d22642a50c6334ec47acdb8a31a90de7533d4b6b7c78",
     ),
   "wikicfp-scraper":
     struct(
@@ -15184,15 +13353,15 @@ packages = (
     ),
   "wild-bind":
     struct(
-      version = "0.1.1.0",
+      version = "0.1.2.1",
       sha256 =
-        "3aea009877701655f52cd9595813fa3dda7769699775666474dd0e45178e32fd",
+        "ae76ece570252bfd9b1fdc86f998f95d935bdce7e77c96f5ef22a6fd9c7274ca",
     ),
   "wild-bind-x11":
     struct(
-      version = "0.1.0.7",
+      version = "0.2.0.4",
       sha256 =
-        "0d015d316e78299af919d807ef22581ebe420ceb0a67887b103c017fa7acb06d",
+        "bfc09fcf7e0c3c4c48250bc2049e8ee0894ecfad1b3e42ad71d3cbd987dad071",
     ),
   "wire-streams":
     struct(
@@ -15230,12 +13399,6 @@ packages = (
       sha256 =
         "4ba12c726d60688b8173db3891aa1dce7f57c6364c40ba2f1c2c8d16404bd30b",
     ),
-  "wl-pprint":
-    struct(
-      version = "1.2",
-      sha256 =
-        "198003fa7edd3a2d625ec54402cdc5645434b60ad5983e93525f58fec9dcdf98",
-    ),
   "wl-pprint-annotated":
     struct(
       version = "0.1.0.0",
@@ -15262,9 +13425,9 @@ packages = (
     ),
   "wl-pprint-text":
     struct(
-      version = "1.1.1.0",
+      version = "1.2.0.0",
       sha256 =
-        "2960c8201c05d912a1df748a3ceeadc7525905ff1c371d7b4972f4011eca0acd",
+        "40dd4c2d2b8a2884616f3a240f01143d0aadd85f5988e5ee55a59ba6b2487c3c",
     ),
   "word-trie":
     struct(
@@ -15290,23 +13453,23 @@ packages = (
       sha256 =
         "2630934c75728bfbf390c1f0206b225507b354f68d4047b06c018a36823b5d8a",
     ),
+  "world-peace":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "737685799cdd97c2178c749a60906d15548b040570b90f1bbb4f259ba0e756a5",
+    ),
   "wrap":
     struct(
       version = "0.0.0",
       sha256 =
         "f8bbc4b417b2291532784d0c7940c0f1a24d054e6012963f7d727ad13977f50e",
     ),
-  "wrecker":
-    struct(
-      version = "1.2.4.0",
-      sha256 =
-        "c89b388a1dbe0cfe6210b751cac8fafd722a8f7acff9a92c6bbc730f6bc832fb",
-    ),
   "wreq":
     struct(
-      version = "0.5.2.0",
+      version = "0.5.2.1",
       sha256 =
-        "713a60156fec01b5bb131145eeda291f742696a0db8108b20e971e686f03671b",
+        "b3d069b38d709becdd5ebc75859ff46833419d25f6168367e672243f29491237",
     ),
   "wreq-stringless":
     struct(
@@ -15344,11 +13507,17 @@ packages = (
       sha256 =
         "8aa22832fdb413c706a6862b83ad4a4ef8dd61ae8658aca6e5076cf2a5cd4aae",
     ),
+  "ws":
+    struct(
+      version = "0.0.4",
+      sha256 =
+        "d88080c45551cccb8e8de012795852d9ca3c98b97519f2b2e81118d18f3a5f02",
+    ),
   "wuss":
     struct(
-      version = "1.1.6",
+      version = "1.1.10",
       sha256 =
-        "3e7917beb72938dbf8026200b5e9416b2026d3c8b2c6b999c90ebd672b2253bc",
+        "097c1186006e8a4168a7ba868d6bffb0cbbb80052e8f552de9cda23572a59550",
     ),
   "x11-xim":
     struct(
@@ -15358,15 +13527,15 @@ packages = (
     ),
   "x509":
     struct(
-      version = "1.7.2",
+      version = "1.7.3",
       sha256 =
-        "dc0315a9e2bbfb2b3b6746b83cde901c0cc6aca5a3983f129c6f1cbe0ee0ce7b",
+        "41740f949bb773dc721d342a85587a512658c81ee8cd38f102473b315e127356",
     ),
   "x509-store":
     struct(
-      version = "1.6.5",
+      version = "1.6.6",
       sha256 =
-        "1aaab11da87f8c27b7475c4b0789823864e5f215fd5bf7c8a455feba807fe9d1",
+        "6a276f595cf91c9688129cad4c9c6be9c349ffc0de22300eeb3dfa6a2b6e7635",
     ),
   "x509-system":
     struct(
@@ -15376,9 +13545,9 @@ packages = (
     ),
   "x509-validation":
     struct(
-      version = "1.6.9",
+      version = "1.6.10",
       sha256 =
-        "8470cead7cf0c8cd93137f1edeb1603805d54f50647b15331d9d952fbb2cb500",
+        "761c9d77322528259b690508e829cb360feb1fc542951a99f3af51ae980e45d7",
     ),
   "xdg-basedir":
     struct(
@@ -15388,9 +13557,9 @@ packages = (
     ),
   "xeno":
     struct(
-      version = "0.3.2",
+      version = "0.3.4",
       sha256 =
-        "e9de672191e7c2e8a2d7749265d7ed615b4bc0a97b51f97505eaf6ece0747c93",
+        "5a2a56d969a6410b65150bc4254f343c6bbe585e60eb4890d2bc0ac6c1f334eb",
     ),
   "xenstore":
     struct(
@@ -15400,9 +13569,9 @@ packages = (
     ),
   "xhtml":
     struct(
-      version = "3000.2.2",
+      version = "3000.2.2.1",
       sha256 =
-        "e47c0d0b75ed973928ffb423fa8b571138dfc4ad66ce80b2c4dfcbed64a9647c",
+        "5cc869013ecc07ff68b3f873c0ab7f03b943fd7fa16d6f8725d4601b2f9f6924",
     ),
   "xls":
     struct(
@@ -15412,15 +13581,9 @@ packages = (
     ),
   "xlsx":
     struct(
-      version = "0.6.0",
+      version = "0.7.2",
       sha256 =
-        "93f8636732ff2be1669c3e2dc7feb49aa03ff24e078970eac85853b0d0dcdda8",
-    ),
-  "xlsx-tabular":
-    struct(
-      version = "0.2.2",
-      sha256 =
-        "d4d95c3f6ead3af2185f22d7bd1ab0f0fb972864553f1edde6eb2fbb4ef75556",
+        "b2560467ea5639d7bbd97ecf492f2e2cc9fa34e0b05fc5d55243304bbe7f1103",
     ),
   "xml":
     struct(
@@ -15430,15 +13593,15 @@ packages = (
     ),
   "xml-basic":
     struct(
-      version = "0.1.2",
+      version = "0.1.3",
       sha256 =
-        "f888a53aac0ea68f05934a24e42ac220f2f945da6ad6bc5635f517235f0904e9",
+        "98d8d1263462c7880afefff15957affe969d202bd3716f5bb553c6ada55c4355",
     ),
   "xml-conduit":
     struct(
-      version = "1.7.1.2",
+      version = "1.8.0",
       sha256 =
-        "5a40e6273e5c3b5ef8ef1ef16b7a999ee2581feaab27b9db4c8c159970069358",
+        "0382bfd3627be4970b11228948274faef51ca9a2590a7723b5787a7205a52036",
     ),
   "xml-conduit-parse":
     struct(
@@ -15454,9 +13617,9 @@ packages = (
     ),
   "xml-hamlet":
     struct(
-      version = "0.4.1.1",
+      version = "0.5.0",
       sha256 =
-        "4d6c5d2229b4bee69040b0c04954b7cedd552df8cfa7585e48129cd7e098d02d",
+        "7bcec0aad83e72c2870efd3327553b3d78f6332cf01c12ad4b67c02f499015a3",
     ),
   "xml-html-qq":
     struct(
@@ -15472,9 +13635,9 @@ packages = (
     ),
   "xml-isogen":
     struct(
-      version = "0.2.1",
+      version = "0.3.0",
       sha256 =
-        "d4d86df194a5b4efa867ec9c015d9cf2432c2246c1c45548c3cda43f7d02dbcd",
+        "9f812d7bb5dd280e62f5013fd77af27e3710fb1a76dcf7a12f0abbfae5400a17",
     ),
   "xml-lens":
     struct(
@@ -15506,53 +13669,29 @@ packages = (
       sha256 =
         "9937d440072552c03c6d8ad79f61e61467dc28dcd5adeaad81038b9b94eef8c9",
     ),
+  "xmlbf":
+    struct(
+      version = "0.4.1",
+      sha256 =
+        "189a02e8b54c3576c3a919799def7b83c0e602b222264901c644c941c34fdc75",
+    ),
+  "xmlbf-xeno":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "6c1c4e419240c1e480d5543e89883cd2a356c1bb470a452f935424a80367dd32",
+    ),
   "xmlgen":
     struct(
-      version = "0.6.2.1",
+      version = "0.6.2.2",
       sha256 =
-        "9027a17e7ae648997a0e8279d7c01aa6615adda8b93f753b907a01dd797abae6",
-    ),
-  "xmlhtml":
-    struct(
-      version = "0.2.5.2",
-      sha256 =
-        "64818617644bfc7c3c9fe561435af9929ef60310627b0796c78b4b99240b5bdc",
-    ),
-  "xmonad":
-    struct(
-      version = "0.13",
-      sha256 =
-        "f9f81b63569f18c777a939741024ec3ae34e4ec84015e5cc50f6622034a303ca",
-    ),
-  "xmonad-contrib":
-    struct(
-      version = "0.13",
-      sha256 =
-        "a760827fe5b1f99d783f52ccbb72b272d02d53daa26757363cde3ceba014476e",
-    ),
-  "xmonad-extras":
-    struct(
-      version = "0.13.2",
-      sha256 =
-        "5d9222b7d4a424bc6ca29419d566517daa9df3ce229b6a967aa9fafaccc9b6c7",
+        "926fa98c77525f5046274758fcebd190e86de3f53a4583179e8ce328f25a34d6",
     ),
   "xss-sanitize":
     struct(
-      version = "0.3.5.7",
+      version = "0.3.6",
       sha256 =
-        "955856413e70375c794766d04ac9ab7f0d3337dbb04a412c9b7ff5c415acac00",
-    ),
-  "xturtle":
-    struct(
-      version = "0.2.0.0",
-      sha256 =
-        "43180537377db24e446f83bddd6f0c7ceadeb871c793e046bddeab433e24ce22",
-    ),
-  "xxhash":
-    struct(
-      version = "0.0.2",
-      sha256 =
-        "4f5cc71564d71b7ab1e9f70ce9b8d32a3d73cb0b1e08ff96bc54298b21eb2f27",
+        "b385eea5652c798b701c627dce8b327c3d6cbfd8c92e1e18e7118862d4d0e2b4",
     ),
   "xxhash-ffi":
     struct(
@@ -15562,9 +13701,9 @@ packages = (
     ),
   "yaml":
     struct(
-      version = "0.8.28",
+      version = "0.8.32",
       sha256 =
-        "f702b6a489ad94cda3c0cb15db34a30356d7b2cdc86a4d0f5340f2ece69f8f6b",
+        "dc20f863deb4ee75395bf1f78268781db76be6209af67b70c05f6e1a09f47a31",
     ),
   "yes-precure5-command":
     struct(
@@ -15574,57 +13713,63 @@ packages = (
     ),
   "yeshql":
     struct(
-      version = "3.0.1.3",
+      version = "4.1.0.0",
       sha256 =
-        "376126afd611d84599fd9c0f9f50c27bea8b9b8630e608bda424555829765b13",
+        "d89fe3285de21f3ba1b40c701ea4a0b2535ae4897d772abb34b089ad52157113",
+    ),
+  "yeshql-core":
+    struct(
+      version = "4.1.0.0",
+      sha256 =
+        "fc8c01606c55a00a4628839a11b6e9145b92f887e556e9cb0f85d46d52d4c2ff",
+    ),
+  "yeshql-hdbc":
+    struct(
+      version = "4.1.0.0",
+      sha256 =
+        "6482254c550bbd7a17c444760ab5a99af22723873c52ccfd406a4a7338154a94",
     ),
   "yesod":
     struct(
-      version = "1.4.5",
+      version = "1.6.0",
       sha256 =
-        "267c8780b27cc0ae8199f80b3063683fb2cd62eeb9696c4b155a298fb035e6e9",
+        "8a242ffe1df10bc2c5dffb6e255ad21b11e96a9c4794bac20504b67f973da773",
     ),
   "yesod-alerts":
     struct(
-      version = "0.1.1.0",
+      version = "0.1.2.0",
       sha256 =
-        "5aab2c14142113da4eed98405e827d445a5dcfb59af4a41dae5c0e2c55627f97",
+        "8e52c8a7ec9cdbe7cdc06f39ea4e27b852be0391cf78652e349f0f2c169b146f",
     ),
   "yesod-auth":
     struct(
-      version = "1.4.21",
+      version = "1.6.4.1",
       sha256 =
-        "0811e2f21121f599c85ccf70c1c45d2b978561b42b64f0111d38d562687a1ce3",
-    ),
-  "yesod-auth-basic":
-    struct(
-      version = "0.1.0.2",
-      sha256 =
-        "aaaf330bc05b86ddd53cf092d48df1279e4bea47f67cbc6a8b67f1308ef39b2c",
+        "f2d493f4fb9f52c958757ca98056011e980857a111f012fc3de56a76641a3fe8",
     ),
   "yesod-auth-fb":
     struct(
-      version = "1.8.1",
+      version = "1.9.0",
       sha256 =
-        "efb7196b4e8d1df83cde8913a3d139661441010aea426176e3820f1843a2fb78",
+        "e8751b7703b2bc73eb37ec3ed03f3afec552cbc3933dff25fa0d899dcfea46c2",
     ),
   "yesod-auth-hashdb":
     struct(
-      version = "1.6.2",
+      version = "1.7",
       sha256 =
-        "ae85e0df9d48d1cda57a86153559da908e6b41c7c3ce318bf2e197883cbfcdb3",
+        "65b9a941a9eb87421dfc57f817a7e4dd46bb204b0f27438084f7417805434f1c",
     ),
   "yesod-bin":
     struct(
-      version = "1.5.3",
+      version = "1.6.0.3",
       sha256 =
-        "b8ee66539c027716de15522ea53cd596abf4c59d7499e644a517223cb2a5011b",
+        "e4db295b4c651c205a1730df38501c217d9b600f3dbc1eea21d5fa47e832aedc",
     ),
   "yesod-core":
     struct(
-      version = "1.4.37.3",
+      version = "1.6.6",
       sha256 =
-        "e06997fdf9314c8f1140c19e922e0ccbd83b8c4cef77f8faf132e972051881cb",
+        "6b8ac48c3178b913caac9d7391201d9af0b238f1353e70c9a1b31e56aa715075",
     ),
   "yesod-csp":
     struct(
@@ -15634,141 +13779,93 @@ packages = (
     ),
   "yesod-eventsource":
     struct(
-      version = "1.4.1",
+      version = "1.6.0",
       sha256 =
-        "4019782d074ed5c23719e8e96f604b63990d9fd49255e14b7f5b769e7f3d3e13",
+        "6fceeca34d5e80c8a0d65ab95fab3c53807d1f18eb506abdef67a8f70d0e418b",
     ),
   "yesod-fb":
     struct(
-      version = "0.4.0",
+      version = "0.5.0",
       sha256 =
-        "95dd01bf20fc5eed60960106621d5f8212bdab985a6e92b05f51fabf7f267310",
+        "de375004c12e89eec47738d60465c7c63b5f0c7bfc3591c70a35522fdc0841db",
     ),
   "yesod-form":
     struct(
-      version = "1.4.16",
+      version = "1.6.2",
       sha256 =
-        "52dcd4ab2b6c73c1ec01a37ef565e5b2d63ec0842d6484bc81db22bb4b1d3252",
+        "a780ce27d19d59e8eeef7ba1e3f0c33a966b6a3eb34d2f10a337abed1c0c3ddc",
     ),
   "yesod-form-bootstrap4":
     struct(
-      version = "0.1.0.2",
+      version = "1.0.2",
       sha256 =
-        "8e191fcdc948b890701ab1ab010f9eb59ce13c74543142f28dc7eb3e86de4d53",
-    ),
-  "yesod-form-richtext":
-    struct(
-      version = "0.1.0.2",
-      sha256 =
-        "96794a462402b50c66873faad7897102bb70fb45d07a562c04a6370dbcf3a346",
+        "98695338541fab09f27c4df2083ed15f257307d315b0c084e227a265bb99c878",
     ),
   "yesod-gitrepo":
     struct(
-      version = "0.2.1.0",
+      version = "0.3.0",
       sha256 =
-        "6e6e0f37771f888c687bbc2dff24228ea0461829de8c1b714da10dbe9f6987ec",
+        "b03c67c506bc3fc402cb41759d69f2c3159af47959cbd964cb6531996084981e",
     ),
   "yesod-gitrev":
     struct(
-      version = "0.1.0.0",
+      version = "0.2.0.0",
       sha256 =
-        "30e63c0ea5aec72eed0cd1d9e4dccf242e749c9740e5d67887cac02728628f49",
+        "df9f374e6099e55eb62cc273451605ce8746785a293e76115d25002355fee052",
     ),
   "yesod-newsfeed":
     struct(
-      version = "1.6",
+      version = "1.6.1.0",
       sha256 =
-        "4e6dbc06002fe7fd13701941c036c51cf9407c35b28473ed509424bfc0b67516",
+        "6d0b97592d74ca45e204f1876fb113a4830c5f35612b876175169af3d2f79615",
+    ),
+  "yesod-paginator":
+    struct(
+      version = "1.1.0.0",
+      sha256 =
+        "1640cc7e7cbe708ba0de02731ccd84cbd53a4734a332e01aa38b3e4deffd090e",
     ),
   "yesod-persistent":
     struct(
-      version = "1.4.3",
+      version = "1.6.0",
       sha256 =
-        "48ce484db879e14875dd1064ad3474a6a17e6f9e1709caa34f9c236608d7334e",
+        "42be2b4277fb265e18273503f3592259feb69ce5bfa2d2a862639b755c4fa5bd",
     ),
   "yesod-recaptcha2":
     struct(
-      version = "0.2.3",
+      version = "0.2.4",
       sha256 =
-        "3686e459c1cddef30f331bbed09cfdf3e1fa42b3c4a8554cdf9fd9a4e9b5eae0",
+        "2848ecd3fd581cb3beba406640417add2def248c1fc7f20b6ba6a62d220181ab",
     ),
   "yesod-sitemap":
     struct(
-      version = "1.4.0.1",
+      version = "1.6.0",
       sha256 =
-        "008449fd90899f1988f32a1341f5be87a73cb6b0e100494525f659e9473e2666",
+        "e5fa06abdcd57772fc74707ae663c63b45b172bce48117b70a4a9af15131dbd6",
     ),
   "yesod-static":
     struct(
-      version = "1.5.3.1",
+      version = "1.6.0",
       sha256 =
-        "544bf84638c8cb1f2d1a869800516bdb826cc1a4f534e15a5f558299cafb3937",
-    ),
-  "yesod-static-angular":
-    struct(
-      version = "0.1.8",
-      sha256 =
-        "97b3ef260a7e6c70b811cbf3b2b3532a003c5028bd6a0df52fc14bd45ce03beb",
-    ),
-  "yesod-table":
-    struct(
-      version = "2.0.3",
-      sha256 =
-        "363a70fe6def770776e1e0e777651c66e4849e4d95e853956a2f2ae1be80189b",
+        "bd0bf5924bb9c27fe24047816018158e92fc687053c190221af2f03bac94880e",
     ),
   "yesod-test":
     struct(
-      version = "1.5.9.1",
+      version = "1.6.5",
       sha256 =
-        "7ee4d486765d8d9044d672ac6079fec5c51460f8bb9fa877c806aeaf90b08516",
+        "be0246f7f7a003b280c8744675d1bbd38df3c23ad9ea881cddafc7d4f38103d8",
+    ),
+  "yesod-text-markdown":
+    struct(
+      version = "0.1.10",
+      sha256 =
+        "3cee8b3d8d84f30e8b825076d650afb05e79ebd22f34a21fc7ad7f45e1637ddc",
     ),
   "yesod-websockets":
     struct(
-      version = "0.2.6",
+      version = "0.3.0",
       sha256 =
-        "98111901a0f33f4c43459a20310dbf20a3fda142c5d42c30cfe9c53eeabeee29",
-    ),
-  "yi-core":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "17d0b84a1db3d122d76c5658ad9c5dd80df38f0cbd877376b75cce93ed3768e3",
-    ),
-  "yi-frontend-vty":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "06a6eb58d438bdb2404da48818c6d2ce318ebfe0d97174e0c3ddc87ffea80044",
-    ),
-  "yi-fuzzy-open":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "506e2cc5420c58339cf9f6a6bbc3c280c0e75cb50c8c30662e77c2635ae0a1f1",
-    ),
-  "yi-ireader":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "fec8c8d03976e20c8a4e17443f50417fd69d396388a37f561dfc644ce15c6a89",
-    ),
-  "yi-keymap-cua":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "52f128c4a75fd1a0fbf17b10ba5071a01f38e3581b21448caa5c2072c3227c14",
-    ),
-  "yi-keymap-emacs":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "3ceb457c7c78edb5f0ab8a32f2aa332a2fc6dd202b089df3b828817d2edca7cb",
-    ),
-  "yi-keymap-vim":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "1c916d810d270edc0e9ce6d6695b5cb45c2a687c93746054c7cc94a98c076dff",
+        "4a642982209e27e3b1dac0f29c2c86c4ac39e5109483fa8274e97cd8a574e446",
     ),
   "yi-language":
     struct(
@@ -15776,41 +13873,11 @@ packages = (
       sha256 =
         "4aee628b278e9d6b2b2e92a8974696ce6de10c30ef137ababb709bdca193b69e",
     ),
-  "yi-misc-modes":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "e0a9cf8541370407dccfc4afe13f1d10e2b5d0025dfd7b9294ecc25dcc45db7b",
-    ),
-  "yi-mode-haskell":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "dddff698eae295238fd599ddcd684c50fa673df5e730636f65801123769d89ba",
-    ),
-  "yi-mode-javascript":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "2448556c225eec9b707aa0ee3c0fdbbc3e53e5e110bc9c18db440ea73bf77e1c",
-    ),
   "yi-rope":
     struct(
-      version = "0.10",
+      version = "0.11",
       sha256 =
-        "4933721b7ca34068035d13485097012da7dabc9b8dabbc9a697f476b85626a52",
-    ),
-  "yi-snippet":
-    struct(
-      version = "0.17.1",
-      sha256 =
-        "cbbc4f742e0a0b4f3fbeae72f342a3e499021c3a48356df0bc16d72f59fc2cdf",
-    ),
-  "yjsvg":
-    struct(
-      version = "0.2.0.1",
-      sha256 =
-        "f737b7d43b7b3fd3237d07761c672569a2b5d0c1e1b26d48097b9e96b1262e7e",
+        "9a9318693501bdbb3e8f3c19b0acd6c3cbd607a6e9d966201b613c41a1b71008",
     ),
   "yjtools":
     struct(
@@ -15842,6 +13909,12 @@ packages = (
       sha256 =
         "58d4504ee607cb681fc3da2474ed92afaefdb2dc34752b145aa9f746ab29079f",
     ),
+  "zeromq4-patterns":
+    struct(
+      version = "0.3.1.0",
+      sha256 =
+        "74f3a82a72a22684449103c0786e290be2c14de9d48a3ea9d64a7cc063b33ed9",
+    ),
   "zim-parser":
     struct(
       version = "0.2.1.0",
@@ -15850,15 +13923,21 @@ packages = (
     ),
   "zip":
     struct(
-      version = "0.2.0",
+      version = "1.1.0",
       sha256 =
-        "59ef91fa09f56976a401b5e423c752f1563b48fe872c06c775c8324570b023a3",
+        "65942d6a2ccef6d2b78183f250a6d8b6c04d081ab3df1f39215de0a76a26d9dc",
     ),
   "zip-archive":
     struct(
-      version = "0.3.2.2",
+      version = "0.3.3",
       sha256 =
-        "2c5571390503615551e9bfd8148dff56c3ae17ebce5f2e31cae098c1aa5acaf7",
+        "988adee77c806e0b497929b24d5526ea68bd3297427da0d0b30b99c094efc84d",
+    ),
+  "zip-stream":
+    struct(
+      version = "0.1.1",
+      sha256 =
+        "b88ce2ad46b218a7f0f31ffe02f61105c0ad2b35bf3a171a8e44f8727590d2f2",
     ),
   "zippers":
     struct(
@@ -15866,23 +13945,11 @@ packages = (
       sha256 =
         "2d127772564655df0cb99d5191b91a555797e66e535d0b8b4f5ed4d54097c085",
     ),
-  "ziptastic-client":
-    struct(
-      version = "0.3.0.3",
-      sha256 =
-        "af089d94fff3245377d696bd9723f4e93fa07694e4a799d65ac8d4d50e111c5e",
-    ),
-  "ziptastic-core":
-    struct(
-      version = "0.2.0.3",
-      sha256 =
-        "8e63eecfb02a86575a6ea5ee7d2ac8c3ea78246878f002c2c08d4c0ce9824ab0",
-    ),
   "zlib":
     struct(
-      version = "0.6.1.2",
+      version = "0.6.2",
       sha256 =
-        "e4eb4e636caf07a16a9730ce469a00b65d5748f259f43edd904dd457b198a2bb",
+        "0dcc7d925769bdbeb323f83b66884101084167501f11d74d21eb9bc515707fed",
     ),
   "zlib-bindings":
     struct(
@@ -15896,23 +13963,23 @@ packages = (
       sha256 =
         "e5a563453899e0896cfa3aed22a2fbfc67012990ace6d14631f31b704ff766eb",
     ),
-  "zm":
-    struct(
-      version = "0.3.2",
-      sha256 =
-        "a03795ccdeb55022f3fd19b020d25237b05ee3b7b043c0cdbeadf64147c5c709",
-    ),
   "zot":
     struct(
       version = "0.0.3",
       sha256 =
         "c8a9091b939e3f74aca6be3007a0066c8a1de69da4b62e22891bed543f8a2b32",
     ),
+  "zstd":
+    struct(
+      version = "0.1.0.0",
+      sha256 =
+        "0875840799d987cf8f8dd5e0a7686978084b3088c07123e66f6f88561f474bff",
+    ),
   "ztail":
     struct(
-      version = "1.2",
+      version = "1.2.0.2",
       sha256 =
-        "13b314c992597118de1bfe0b866ef061237910f77bd35fb258e42d21182a3a4f",
+        "a14341d51da6dbef9f0edcdefe185dbd7726880ec4e230855fb9871de7c07717",
     ),
 }
 )

--- a/third_party/cabal2bazel/src/Google/Google3/Tools/Cabal2Build/Description.hs
+++ b/third_party/cabal2bazel/src/Google/Google3/Tools/Cabal2Build/Description.hs
@@ -187,7 +187,10 @@ instance Exprable RepoType where
     expr e = stringE $ show e
 
 instance Exprable BuildType where
+#if MIN_VERSION_Cabal(2,2,0)
+#else
     expr (UnknownBuildType s) = stringE s
+#endif
     expr e = stringE $ show e
 
 instance Exprable RepoKind where


### PR DESCRIPTION
This probably isn't in a state to be merged (feel free to close if it's out-of-scope), but I got this stuff building with GHC 8.4.3 and LTS 12.1