### PR TITLE
Switch to a non-Nix Bazel in Hazel's CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,24 +3,43 @@ version: 2
 jobs:
   build:
     docker:
-      - image: nixos/nix:1.11.14
-    working_directory: ~/rules_haskell
+      - image: circleci/python:3.7.0-stretch-browsers
     steps:
       - checkout
+
       - run:
-          name: System dependencies
+          name: Set up environment
           command: |
-            apk --no-progress update
-            apk --no-progress add bash ca-certificates
-            REVISION=696c6bed4e8e2d9fd9b956dea7e5d49531e9d13f
-            nix-env -f https://github.com/NixOS/nixpkgs/archive/$REVISION.tar.gz \
-              -iA bazel binutils python git
+            echo "export USER=circleci" >> "${BASH_ENV}"
+            echo "export PATH=$HOME/.nix-profile/bin:$HOME/bin:$PATH" >> "${BASH_ENV}"
+
       - run:
-          name: Build
-          command: bazel build --jobs=2 //...
+          name: Install Bazel
+          command: |
+            set -x
+            export USER=circleci
+            VERSION=0.15.2
+            INSTALLER=bazel-$VERSION-installer-linux-x86_64.sh
+            wget https://github.com/bazelbuild/bazel/releases/download/$VERSION/$INSTALLER
+            chmod +x $INSTALLER
+            ./$INSTALLER --user
+
       - run:
-          name: Run tests
-          command: bazel test //...
+          name: Install Nix
+          command: |
+            sudo mkdir -p /nix
+            sudo chown -R circleci /nix
+            NIX_RELEASE=1.11.14
+            ARCH=x86_64
+            wget https://nixos.org/releases/nix/nix-${NIX_RELEASE}/nix-${NIX_RELEASE}-${ARCH}-linux.tar.bz2
+            tar -xjvf nix-${NIX_RELEASE}-${ARCH}-linux.tar.bz2
+            mkdir -p /nix/var/nix/profiles/per-user/${USER}
+            nix-${NIX_RELEASE}-${ARCH}-linux/install
+
+      - run:
+          name: Build and test
+          command: bazel test --test_output=errors --jobs=2 //...
+
       - run:
           name: Test some third-party packages
           command: |

--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ exports_files([
     "hazel.bzl",
     "BUILD.ghc",
     "paths-template.hs",
+    "cc_configure_custom.bzl",
 ])
 
 haskell_doctest_toolchain(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,14 +14,34 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository", "
 
 nixpkgs_git_repository(
     name = "nixpkgs",
-    # A revision of 17.09 that contains ghc-8.2.2:
-    revision = "c33c5239f62b4855b14dc5b01dfa3e2a885cf9ca",
+    revision = "ee80654b5267b07ba10d62d143f211e0be81549e",
 )
 
-RULES_HASKELL_SHA = "3e68a0f3420f7589b1afa6afd3b9e37741978edc"
+load("//:cc_configure_custom.bzl", "cc_configure_custom")
+nixpkgs_package(
+    name = "gcc",
+    repository = "@nixpkgs",
+    attribute_path = "gcc",
+)
+
+nixpkgs_package(
+    name = "binutils",
+    repository = "@nixpkgs",
+    attribute_path = "binutils"
+)
+
+cc_configure_custom(
+    name = "local_config_cc",
+    gcc = "@gcc//:bin/gcc",
+    ld = "@binutils//:bin/ld",
+)
+
+
+RULES_HASKELL_SHA = "f724288c61ea637e53561208d021df79d003c537"
+
 http_archive(
     name = "io_tweag_rules_haskell",
-    urls = ["https://github.com/tweag/rules_haskell/archive/"
+    urls = ["https://github.com/FormationAI/rules_haskell/archive/"
             + RULES_HASKELL_SHA + ".tar.gz"],
     strip_prefix = "rules_haskell-" + RULES_HASKELL_SHA,
 )

--- a/cc_configure_custom.bzl
+++ b/cc_configure_custom.bzl
@@ -1,0 +1,32 @@
+load("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_autoconf_impl")
+
+def _cc_configure_custom(ctx):
+    overriden_tools = {
+        "gcc": ctx.path(ctx.attr.gcc),
+        "ld": ctx.path(ctx.attr.ld),
+    }
+    return cc_autoconf_impl(ctx, overriden_tools)
+
+cc_configure_custom = repository_rule(
+    implementation = _cc_configure_custom,
+    attrs = {
+        "gcc": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_single_file = True,
+            doc = "`gcc` to use in cc toolchain",
+        ),
+        "ld": attr.label(
+            executable = True,
+            cfg = "host",
+            allow_single_file = True,
+            doc = "`ld` to use in cc toolchain",
+        ),
+    },
+    local = True,
+)
+"""Overwrite cc toolchain by supplying custom `gcc` and `ld` (e.g. from
+Nix). This allows to fix mismatch of `gcc` versions between what is used by
+packages that come from Nix (e.g. `ghc`) and what Bazel detects
+automatically (i.e. system-level `gcc`).
+"""


### PR DESCRIPTION
The current rules_haskell setup is heavily Nix-based (including the Bazel
binary) and its usability relies on having Cachix or some other custom Nix
cache.

- Switch to an Ubuntu-based container
- Add and use cc_configure.bzl.
- Update the versions of nixpkgs for consistency
- Use the FormationAI/rules_haskell fork, temporarily