### PR TITLE
Support a GHC 8.4.3 toolchain (Cabal 2.2.0 and base 4.11.0)

### DIFF
--- a/hazel_base_repository/Skylark.hs
+++ b/hazel_base_repository/Skylark.hs
@@ -1,4 +1,5 @@
 -- | Datatypes for constructing and rendering BUILD file contents.
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 module Skylark
@@ -16,6 +17,10 @@ import Text.PrettyPrint
     , (<>)
     , (<+>)
     )
+
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 import qualified Text.PrettyPrint as Pretty
 

--- a/third_party/cabal2bazel/src/Google/Google3/Tools/Cabal2Build/Description.hs
+++ b/third_party/cabal2bazel/src/Google/Google3/Tools/Cabal2Build/Description.hs
@@ -187,8 +187,12 @@ instance Exprable RepoType where
     expr e = stringE $ show e
 
 instance Exprable BuildType where
+#if MIN_VERSION_Cabal(2,2,0)
+    expr e = stringE $ show e
+#else
     expr (UnknownBuildType s) = stringE s
     expr e = stringE $ show e
+#endif
 
 instance Exprable RepoKind where
     expr (RepoKindUnknown s) = stringE s


### PR DESCRIPTION
I saw that `CPP` was used to support some differences in Cabal versions already so extended this out. Depending how stable Cabal proves to be I wonder if it might be more useful to ask `hazel_repositories` to accept a version number and just compile wholly-different versions of `cabal2hazel`, but hopefully this is acceptable for now.