### PR TITLE
Fix CC configuration for Mac and latest rules_haskell.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,7 @@ cc_configure_custom(
 )
 
 
-RULES_HASKELL_SHA = "4964f8309a9f28b4a13340d22198e54926d3fa7e"
+RULES_HASKELL_SHA = "f724288c61ea637e53561208d021df79d003c537"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ nixpkgs_package(
 
 cc_configure_custom(
     name = "local_config_cc",
-    gcc = "@compiler//:bin/gcc",
+    gcc = "@compiler//:bin/cc",
     ld = "@binutils//:bin/ld",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,9 +19,9 @@ nixpkgs_git_repository(
 
 load("//:cc_configure_custom.bzl", "cc_configure_custom")
 nixpkgs_package(
-    name = "gcc",
+    name = "compiler",
     repository = "@nixpkgs",
-    attribute_path = "gcc",
+    nix_file = "//:compiler.nix",
 )
 
 nixpkgs_package(
@@ -32,12 +32,12 @@ nixpkgs_package(
 
 cc_configure_custom(
     name = "local_config_cc",
-    gcc = "@gcc//:bin/gcc",
+    gcc = "@compiler//:bin/gcc",
     ld = "@binutils//:bin/ld",
 )
 
 
-RULES_HASKELL_SHA = "f724288c61ea637e53561208d021df79d003c537"
+RULES_HASKELL_SHA = "4964f8309a9f28b4a13340d22198e54926d3fa7e"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/compiler.nix
+++ b/compiler.nix
@@ -7,7 +7,7 @@ let
     phases = [ "installPhase" ];
     installPhase = ''
         mkdir -p $out/bin
-        cat > $out/bin/gcc << EOL
+        cat > $out/bin/cc << EOL
         #!/bin/sh
         ${pkgs.clang}/bin/clang \
             -Wno-unused-command-line-argument \
@@ -20,7 +20,7 @@ let
             \''$@
         EOL
 
-        chmod +x $out/bin/gcc
+        chmod +x $out/bin/cc
         '';
   };
 in if pkgs.stdenv.isDarwin then overrideClang else pkgs.gcc

--- a/compiler.nix
+++ b/compiler.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  frameworks = pkgs.darwin.apple_sdk.frameworks;
+  overrideClang = pkgs.stdenv.mkDerivation {
+    name = "enhanced-clang";
+    phases = [ "installPhase" ];
+    installPhase = ''
+        mkdir -p $out/bin
+        cat > $out/bin/gcc << EOL
+        #!/bin/sh
+        ${pkgs.clang}/bin/clang \
+            -Wno-unused-command-line-argument \
+            -I${pkgs.libcxx}/include/c++/v1 \
+            -L${pkgs.libcxx}/lib \
+            -F${frameworks.CoreFoundation}/Library/Frameworks \
+            -F${frameworks.CoreServices}/Library/Frameworks \
+            -F${frameworks.Security}/Library/Frameworks \
+            -F${frameworks.Foundation}/Library/Frameworks \
+            \''$@
+        EOL
+
+        chmod +x $out/bin/gcc
+        '';
+  };
+in if pkgs.stdenv.isDarwin then overrideClang else pkgs.gcc
+

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,2 @@
+# Use the overrides from @local_config_cc on MacOS as well:
+build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1


### PR DESCRIPTION
This matches up the C compiler that Nix's GHC was built against.
On Linux it's just gcc, but on Mac it's clang -- and also
needs some extra command-line flags similar to what's
done in rules_haskell:
https://github.com/tweag/rules_haskell/blob/258b3c962c4661f9425530c92b01c2135ff0500e/shell.nix#L16