### PR TITLE
Fix `all_hazel_packages`

### DIFF
--- a/hazel.bzl
+++ b/hazel.bzl
@@ -165,7 +165,7 @@ def hazel_repositories(
 
   _all_hazel_packages(
       name = "all_hazel_packages",
-      files = ["@haskell_{}//:files".format(p) for p in pkgs])
+      files = ["@haskell_{}//:files".format(_fixup_package_name(p)) for p in pkgs])
 
 def hazel_library(name):
   """Returns the label of the haskell_library rule for the given package."""


### PR DESCRIPTION
The `files` attribute did not apply `_fixup_package_name` to package names, causing errors like the following

```
ERROR: Analysis of target '@all_hazel_packages//:all-package-files' failed; build aborted: no such package '@haskell_simple-vec3//': The repository could not be resolved
```