### PR TITLE
Fix conflicts with existing genrule rule

### DIFF
--- a/third_party/cabal2bazel/bzl/alex.bzl
+++ b/third_party/cabal2bazel/bzl/alex.bzl
@@ -30,7 +30,7 @@
 #   )
 def genalex(src, out):
   native.genrule(
-      name=src + ".hs_alex",
+      name=out + ".hs_alex",
       srcs=[src],
       outs=[out],
       tools=["@haskell_alex//:alex_bin"],

--- a/third_party/cabal2bazel/bzl/happy.bzl
+++ b/third_party/cabal2bazel/bzl/happy.bzl
@@ -31,7 +31,7 @@ Example:
 
 def genhappy(src, out):
   native.genrule(
-      name = src + ".hs_happy",
+      name = out + ".hs_happy",
       srcs = [src],
       outs = [out],
       tools = ["@haskell_happy//:happy_bin"],


### PR DESCRIPTION
Previously, the `genalex` and `genhappy` macros would create genrules with names based on the source file. This can cause conflicts when the macros are called on the same source multiple times.

The macros `genalex` and `genhappy` [are called for each `alex` or `happy` source file found in a subdirectory of every entry in the `hs-source-dirs` Cabal section](https://github.com/FormationAI/hazel/blob/ea415332cfd10cf607c386a5103932f731d29bfb/third_party/cabal2bazel/bzl/cabal_package.bzl#L134-L146). Consider the following directory structure.

```
foo
└── bar
    └── baz.x
```

And the following `hs-source-dirs` section:

```
hs-source-dirs:
  foo
  foo/bar
```

This will cause `foo/bar/baz.x` to occur twice. Once with the output `gen-srcs-pkg/bar/baz.hs` and once with the output `gen-srcs-pkg/baz.hs`. If the `genrule` name is based on the input, then this will cause a conflict. However, if the `genrule` name is bazed on the output it will not.

Since Hazel does not refer to the `genrule` name anywhere it is safe to change it.