### PR TITLE
Fix getDataDir in generated Paths_* module

### DIFF
--- a/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -28,8 +28,10 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 def _impl_path_module_gen(ctx):
   paths_file = ctx.new_file(ctx.label.name)
 
-  base_dir = ctx.label.package + (
-      ("/" + ctx.attr.data_dir) if ctx.attr.data_dir else "")
+  base_dir = paths.join(
+      ctx.label.package,
+      ctx.attr.data_dir if ctx.attr.data_dir else ""
+  )
 
   ctx.template_action(
       template=ctx.file._template,


### PR DESCRIPTION
`alex` failed trying to access its data files under absolute paths such as `/data/AlexTemplate-ghc`.

Looking at the result of `getDataDir` in the generated `Paths_*` module showed that it pointed to the absolute path `/data/`. The reason was that `/data/` was substituted for `%{base_dir}` in `paths-template.hs`, which when combined with `</>` would override the left-hand side and just return `/data/`.

In the case of `alex`, the value of `ctx.label.package` was empty which caused `base_dir` to become `/data`. Replacing string concatenation by `paths.join` resolves the issue.