### PR TITLE
Upgrade rules_haskell

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,8 +36,7 @@ cc_configure_custom(
     ld = "@binutils//:bin/ld",
 )
 
-
-RULES_HASKELL_SHA = "edcd7c107d49ba69c96fe625161c42d4e5610d30"
+RULES_HASKELL_SHA = "8bc2b2c847c54f3d9f6bd5000f8deefa1cf4c995"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/test/BUILD
+++ b/test/BUILD
@@ -12,6 +12,7 @@ haskell_test(
         hazel_library("base"),
         hazel_library("vector"),
     ],
+    linkstatic = False,
 )
 
 haskell_test(

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -443,6 +443,7 @@ def cabal_haskell_package(
         name = exe_name,
         srcs = select(srcs),
         deps = select(deps),
+        linkstatic = False,
         visibility = ["//visibility:public"],
         **attrs
     )

--- a/third_party/haskell/BUILD.conduit
+++ b/third_party/haskell/BUILD.conduit
@@ -29,4 +29,5 @@ haskell_library(
     "@haskell_transformers_compat//:transformers-compat",
     "@haskell_vector//:vector",
   ],
+  version = "1.2.13.1",
 )

--- a/third_party/haskell/BUILD.text_metrics
+++ b/third_party/haskell/BUILD.text_metrics
@@ -14,4 +14,5 @@ haskell_library(
     hazel_library("text"),
     hazel_library("vector"),
   ],
+  version = "0.3.0",
 )


### PR DESCRIPTION
- Bump rules_haskell to something more recent
- Set `linkstatic = False` for library targets (default changed upstream)
- Set `linkstatic = False` on vector test to fix build (questionable)
- Include versions for Hazel dependencies so that Cabal macros are generated