### PR TITLE
Fix extra-source-files issue

### DIFF
--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -81,7 +81,7 @@ def _module_output(file, ending):
     "hs": "hs",
     "lhs": "lhs",
     "hsc": "hsc",
-    "chs": "chs",
+    "chs": "hs",
     "x": "hs",
     "y": "hs",
     "ly": "hs",
@@ -193,7 +193,11 @@ def _get_build_attrs(
   # module_map will contain a dictionary from module names ("Foo.Bar")
   # to the preprocessed source file ("src/Foo/Bar.hs").
   module_map = {}
+  # boot_module_map will contain a dictionary from module names ("Foo.Bar")
+  # to hs-boot files, if applicable.
   boot_module_map = {}
+  # build_files will contain a list of all files in the build directory.
+  build_files = []
 
   srcs_dir = "gen-srcs-" + name + "/"
   clib_name = name + "-cbits"
@@ -215,10 +219,10 @@ def _get_build_attrs(
 
     # Create module files in build directory.
     symlink_name = name + "-" + module + "-symlink"
-    chs_name = name + "-" + module + "-chs"
-    module_out = srcs_dir + info.out
-    module_map[module] = module_out
     if info.type in ["hs", "lhs", "hsc"]:
+      module_out = srcs_dir + info.out
+      module_map[module] = module_out
+      build_files.append(module_out)
       hazel_symlink(
         name = symlink_name,
         src = info.src,
@@ -227,16 +231,20 @@ def _get_build_attrs(
       if info.boot != None:
         boot_out = srcs_dir + info.out + "-boot"
         boot_module_map[module] = boot_out
+        build_files.append(boot_out)
         hazel_symlink(
           name = name + "-boot-" + module + "-symlink",
           src = info.boot,
           out = boot_out,
         )
     elif info.type in ["chs"]:
+      chs_name = name + "-" + module + "-chs"
+      module_map[module] = chs_name
+      build_files.append(srcs_dir + info.src)
       hazel_symlink(
         name = symlink_name,
         src = info.src,
-        out = module_out,
+        out = srcs_dir + info.src,
       )
       c2hs_library(
         name = chs_name,
@@ -248,11 +256,17 @@ def _get_build_attrs(
       )
       chs_targets.append(chs_name)
     elif info.type in ["x"]:
+      module_out = srcs_dir + info.out
+      module_map[module] = module_out
+      build_files.append(module_out)
       genalex(
         src = info.src,
         out = module_out,
       )
     elif info.type in ["y", "ly"]:
+      module_out = srcs_dir + info.out
+      module_map[module] = module_out
+      build_files.append(module_out)
       genhappy(
         src = info.src,
         out = module_out,
@@ -260,11 +274,10 @@ def _get_build_attrs(
 
   # Create extra source files in build directory.
   extra_srcs = []
-  all_module_files = module_map.values() + boot_module_map.values()
   for f in native.glob([paths.normalize(f) for f in desc.extraSrcFiles]):
     fout = srcs_dir + f
     # Skip files that were created in the previous steps.
-    if fout in all_module_files:
+    if fout in build_files:
       continue
     hazel_symlink(
       name = fout + "-symlink",

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -68,6 +68,15 @@ def _fix_source_dirs(dirs):
   return [""]
 
 def _module_output(file, ending):
+  """Replace the input's ending by the ending for the generated output file.
+
+  Args:
+    file: Input file name.
+    ending: Input file ending.
+
+  Returns:
+    The output file with appropriate ending. E.g. `file.y --> file.hs`.
+  """
   out_extension = {
     "hs": "hs",
     "lhs": "lhs",
@@ -80,6 +89,20 @@ def _module_output(file, ending):
   return file[:-len(ending)] + out_extension
 
 def _find_module_by_ending(modulePath, ending, sourceDirs):
+  """Try to find a source file for the given modulePath with the given ending.
+
+  Checks for module source files in all given source directories.
+
+  Args:
+    modulePath: The module path converted to a relative file path. E.g.
+      `Some/Module/Name`
+    ending: Look for module source files with this file ending.
+    sourceDirs: Look for module source files in these directories.
+
+  Returns:
+    Either `None` if no source file was found, or a `struct` describing the
+    module source file. See `_find_module` for details.
+  """
   # Find module source file in source directories.
   files = native.glob([
     paths.join(d if d != "." else "", modulePath + "." + ending)
@@ -102,6 +125,23 @@ def _find_module_by_ending(modulePath, ending, sourceDirs):
   )
 
 def _find_module(module, sourceDirs):
+  """Find the source file for the given module.
+
+  Args:
+    module: Find the source file for this module. E.g. `Some.Module.Name`.
+    sourceDirs: List of source directories under which to search for sources.
+
+  Returns:
+    Either `None` if no module source file was found,
+    or a `struct` with the following fields:
+
+    `type`: The ending.
+    `src`: The source file that was found.
+      E.g. `Some/Module/Name.y`
+    `out`: The expected generated output module file.
+      E.g. `Some/Module/Name.hs`.
+    `bootFile`: Haskell boot file path or `None` if no boot file was found.
+  """
   modulePath = module.replace(".", "/")
   mod = None
   # Looking for raw source files first. To override duplicates (e.g. if a

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -59,24 +59,6 @@ hazel_symlink = rule(
     },
     outputs={"out": "%{out}"})
 
-def _glob_modules(src_dir, extension, out_extension):
-  """List Haskell files under the given directory with this extension.
-
-  Args:
-    src_dir: A subdirectory relative to this package.
-    extension: A file extension; for example, ".hs" or ".hsc".
-  Returns:
-    A list of 3-tuples containing:
-      1. The original file, e.g., "srcs/Foo/Bar.hsc"
-      2. The Haskell module name, e.g., "Foo.Bar"
-      3. The preprocessed Haskell file name, e.g., "Foo/Bar.hs"
-  """
-  outputs = []
-  for f in native.glob([paths.normalize(paths.join(src_dir, "**", "*" + extension))]):
-    m,_ = paths.split_extension(paths.relativize(f, src_dir))
-    outputs += [(f, m.replace("/", "."), m + out_extension)]
-  return outputs
-
 def _conditions_dict(d):
   return d.select if hasattr(d, "select") else {_conditions_default: d}
 
@@ -84,6 +66,52 @@ def _fix_source_dirs(dirs):
   if dirs:
     return dirs
   return [""]
+
+def _module_output(file, ending):
+  out_extension = {
+    "hs": "hs",
+    "lhs": "lhs",
+    "hsc": "hsc",
+    "chs": "chs",
+    "x": "hs",
+    "y": "hs",
+    "ly": "hs",
+  }[ending]
+  return file[:-len(ending)] + out_extension
+
+def _find_module_by_ending(modulePath, ending, sourceDirs):
+  # Find module source file in source directories.
+  files = native.glob([
+    paths.join(d if d != "." else "", modulePath + "." + ending)
+    for d in sourceDirs
+  ])
+  if len(files) == 0:
+    return None
+  file = files[0]
+  # Look for hs/lhs boot file.
+  bootFile = None
+  if ending in ["hs", "lhs"]:
+    bootFiles = native.glob([file + "-boot"])
+    if len(bootFiles) != 0:
+      bootFile = bootFiles[0]
+  return struct(
+    type = ending,
+    src = file,
+    out = _module_output(file, ending),
+    boot = bootFile,
+  )
+
+def _find_module(module, sourceDirs):
+  modulePath = module.replace(".", "/")
+  mod = None
+  # Looking for raw source files first. To override duplicates (e.g. if a
+  # package contains both a Happy Foo.y file and the corresponding generated
+  # Foo.hs).
+  for ending in ["hs", "lhs", "hsc", "chs", "x", "y", "ly"]:
+    mod = _find_module_by_ending(modulePath, ending, sourceDirs)
+    if mod != None:
+      break
+  return mod
 
 def _get_build_attrs(
     name,
@@ -129,73 +157,89 @@ def _get_build_attrs(
 
   srcs_dir = "gen-srcs-" + name + "/"
   clib_name = name + "-cbits"
+  generated_modules = [_paths_module(desc)]
 
+  # Keep track of chs modules, as later chs modules may depend on earlier ones.
+  chs_targets = []
 
-  for d in _fix_source_dirs(build_info.hsSourceDirs) + [generated_srcs_dir]:
-    for f,m,out in _glob_modules(d, ".x", ".hs"):
-      module_map[m] = srcs_dir + out
-      genalex(
-          src = f,
-          out = module_map[m],
-      )
-    for f,m,out in _glob_modules(d, ".y", ".hs") + _glob_modules(d, ".ly", ".hs"):
-      module_map[m] = srcs_dir + out
-      genhappy(
-          src = f,
-          out = module_map[m],
-      )
+  for module in build_info.otherModules + extra_modules:
+    if module in generated_modules:
+      continue
 
-    for f,m,out in _glob_modules(d, ".chs", ".chs"):
-      chs_rule = name + "-" + m
-      symlink_rule = name + "-" + m + "-symlink"
+    # Look for module files in source directories.
+    info = _find_module(module,
+      _fix_source_dirs(build_info.hsSourceDirs) + [generated_srcs_dir]
+    )
+    if info == None:
+      fail("Missing module %s for %s" % (module, name) + str(module_map))
+
+    # Create module files in build directory.
+    symlink_name = name + "-" + module + "-symlink"
+    chs_name = name + "-" + module + "-chs"
+    module_out = srcs_dir + info.out
+    module_map[module] = module_out
+    if info.type in ["hs", "lhs", "hsc"]:
       hazel_symlink(
-          name = symlink_rule,
-          src = f,
-          out = srcs_dir + out,
+        name = symlink_name,
+        src = info.src,
+        out = module_out,
       )
-      # TODO: this will not work if one .chs file imports another.
-      # To mimic Cabal's behavior we should assume the module names are
-      # topologically ordered; i.e., make each one depend on all previous
-      # modules.  However, that's not easy the way the code is currently
-      # structured.
-      c2hs_library(
-          name = chs_rule,
-          srcs = [symlink_rule],
-          deps = [_haskell_cc_import_name(elib) for elib in build_info.extraLibs]
-              + [clib_name],
-      )
-
-      module_map[m] = chs_rule
-    # Raw source files.  Include them last, to override duplicates (e.g. if a
-    # package contains both a Happy Foo.y file and the corresponding generated
-    # Foo.hs).
-    for f,m,out in (_glob_modules(d, ".hs", ".hs")
-                     + _glob_modules(d, ".lhs", ".lhs")
-                     + _glob_modules(d, ".hsc", ".hsc")):
-      if m not in module_map:
-        module_map[m] = srcs_dir + out
+      if info.boot != None:
+        boot_out = srcs_dir + info.out + "-boot"
+        boot_module_map[module] = boot_out
         hazel_symlink(
-            name = name + "-" + m,
-            src = f,
-            out = module_map[m],
+          name = name + "-boot-" + module + "-symlink",
+          src = info.boot,
+          out = boot_out,
         )
-    for f,m,out in (_glob_modules(d, ".hs-boot", ".hs-boot")
-                     + _glob_modules(d, ".lhs-boot", ".lhs-boot")):
-      boot_module_map[m] = srcs_dir + out
+    elif info.type in ["chs"]:
       hazel_symlink(
-          name = name + "-boot-" + m,
-          src = f,
-          out = boot_module_map[m],
+        name = symlink_name,
+        src = info.src,
+        out = module_out,
       )
+      c2hs_library(
+        name = chs_name,
+        srcs = [symlink_name],
+        deps = [
+          _haskell_cc_import_name(elib)
+          for elib in build_info.extraLibs
+        ] + [clib_name] + chs_targets,
+      )
+      chs_targets.append(chs_name)
+    elif info.type in ["x"]:
+      genalex(
+        src = info.src,
+        out = module_out,
+      )
+    elif info.type in ["y", "ly"]:
+      genhappy(
+        src = info.src,
+        out = module_out,
+      )
+
+  # Create extra source files in build directory.
+  extra_srcs = []
+  all_module_files = module_map.values() + boot_module_map.values()
+  for f in native.glob([paths.normalize(f) for f in desc.extraSrcFiles]):
+    fout = srcs_dir + f
+    # Skip files that were created in the previous steps.
+    if fout in all_module_files:
+      continue
+    hazel_symlink(
+      name = fout + "-symlink",
+      src = f,
+      out = srcs_dir + f,
+    )
+    extra_srcs.append(fout)
 
   # Collect the source files for each module in this Cabal component.
   # srcs is a mapping from "select()" conditions (e.g. //third_party/haskell/ghc:ghc-8.0.2) to a list of source files.
-  # Turn "boot_srcs" and others to dicts if there is a use case.
+  # Turn others to dicts if there is a use case.
   srcs = {}
   # Keep track of .hs-boot files specially.  GHC doesn't want us to pass
   # them as command-line arguments; instead, it looks for them next to the
   # corresponding .hs files.
-  boot_srcs = []
   deps = {}
   cdeps = []
   paths_module = _paths_module(desc)
@@ -301,6 +345,7 @@ def _get_build_attrs(
 
   return {
       "srcs": srcs,
+      "extra_srcs": extra_srcs,
       "deps": deps,
       "compiler_flags": ghcopts + extra_ghcopts,
       "src_strip_prefix": srcs_dir,


### PR DESCRIPTION
Closes #57 

* Keep the original source tree structure intact in the build tree.
    Previously, Hazel would link source files into the build tree under a path determined by their module path. This broke CPP include directives. Now source files are linked into the build tree under their original path.
* Add extra-source-files to the build tree
    Previously, files declared as `extra-source-files` would not be copied into the build tree, but only added in `-I` flags. This broke CPP include directives.
    Now, extra-source-files are also linked into the build tree. Unless they would collide with previously linked or generated module files.
* Make chs targets depend on previous chs target, same as Cabal.
    Previously, chs modules were built in arbitrary order without dependency to any other chs targets. However, cabal builds chs modules in their order of appearance in the cabal file and later chs modules can depend on earlier ones.
    With this change Hazel defines module targets in their order of appearance in the Cabal file and keeps track of previously defined chs targets. Later chs targets automatically depend on earlier chs targets. This sequentializes chs targets. 
    (Since I had to refactor that part of the code anyway, I also added a fix for this issue)

For a concrete example, this fixes the build of `uniplate`. I.e. `bazel build @haskell_uniplate//:all` succeeds.