### PR TITLE
Forward C header dependencies

### DIFF
--- a/hazel.bzl
+++ b/hazel.bzl
@@ -57,6 +57,13 @@ haskell_import(
     package = "{pkg}",
     visibility = ["//visibility:public"],
 )
+# Cabal packages can depend on other Cabal package's cbits, for example for
+# CPP includes. To enable uniform handling we define a `-cbits` target for
+# every Hazel Haskell target. In case of core_libraries this is just a dummy.
+cc_import(
+    name = "{pkg}-cbits",
+    visibility = ["//visibility:public"],
+)
 """.format(pkg=ctx.attr.package))
 
 _core_library_repository = repository_rule(

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -465,6 +465,10 @@ def cabal_haskell_package(
           name = name,
           visibility = ["//visibility:public"],
       )
+      native.cc_library(
+          name = name + "-cbits",
+          visibility = ["//visibility:public"],
+      )
     else:
       lib_attrs = _get_build_attrs(
         name,

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -297,13 +297,14 @@ def _get_build_attrs(
   # them as command-line arguments; instead, it looks for them next to the
   # corresponding .hs files.
   deps = {}
-  cdeps = []
+  cdeps = {}
   paths_module = _paths_module(desc)
   extra_modules_dict = _conditions_dict(extra_modules)
   other_modules_dict = _conditions_dict(build_info.otherModules)
   for condition in depset(extra_modules_dict.keys() + other_modules_dict.keys()):
     srcs[condition] = []
     deps[condition] = []
+    cdeps[condition] = []
     for m in (extra_modules_dict.get(condition, []) +
               other_modules_dict.get(condition, [])):
       if m == paths_module:
@@ -337,10 +338,13 @@ def _get_build_attrs(
       [p.name for p in build_info.targetBuildDepends]).to_list()).items():
     if condition not in deps:
       deps[condition] = []
+    if condition not in cdeps:
+      cdeps[condition] = []
     for p in ps:
       deps[condition] += [hazel_library(p)]
+      cdeps[condition] += ["{}-cbits".format(hazel_library(p))]
       if p in _CORE_DEPENDENCY_INCLUDES:
-        cdeps += [_CORE_DEPENDENCY_INCLUDES[p]]
+        cdeps[condition] += [_CORE_DEPENDENCY_INCLUDES[p]]
         deps[condition] += [_CORE_DEPENDENCY_INCLUDES[p]]
 
   ghcopts += ["-optP" + o for o in build_info.cppOptions]
@@ -396,7 +400,8 @@ def _get_build_attrs(
                + ["-I" + i for i in elibs_includes]),
       defines = [o[2:] for o in build_info.ccOptions if o.startswith("-D")],
       textual_hdrs = list(headers),
-      deps = ["@ghc//:threaded-rts"] + cdeps + cc_deps + elibs_targets,
+      deps = ["@ghc//:threaded-rts"] + select(cdeps) + cc_deps + elibs_targets,
+      visibility = ["//visibility:public"],
   )
 
   return {

--- a/third_party/haskell/BUILD.conduit
+++ b/third_party/haskell/BUILD.conduit
@@ -33,3 +33,8 @@ haskell_library(
   ],
   version = "1.2.13.1",
 )
+
+cc_import(
+    name = "conduit-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.ghc-paths
+++ b/third_party/haskell/BUILD.ghc-paths
@@ -17,3 +17,8 @@ haskell_library(
         hazel_library("base"),
     ],
 )
+
+cc_import(
+    name = "ghc-paths-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.text-metrics
+++ b/third_party/haskell/BUILD.text-metrics
@@ -16,3 +16,8 @@ haskell_library(
   ],
   version = "0.3.0",
 )
+
+cc_import(
+    name = "text-metrics-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.vault
+++ b/third_party/haskell/BUILD.vault
@@ -30,3 +30,8 @@ haskell_library(
     hazel_library("unordered-containers"),
   ],
 )
+
+cc_import(
+    name = "vault-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.wai-app-static
+++ b/third_party/haskell/BUILD.wai-app-static
@@ -42,3 +42,8 @@ haskell_library(
   ],
   version = "3.1.6.2",
 )
+
+cc_import(
+    name = "wai-app-static-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.zlib
+++ b/third_party/haskell/BUILD.zlib
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 cc_library(
-  name = "cbits",
+  name = "zlib-cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
   strip_include_prefix = "cbits",
@@ -21,7 +21,7 @@ haskell_library(
     "Codec/Compression/Zlib/*.hsc",
   ]),
   deps = [
-      ":cbits",
+      ":zlib-cbits",
       hazel_library("base"),
       hazel_library("bytestring"),
       hazel_library("ghc-prim"),


### PR DESCRIPTION
(Depends on #60)

Cabal allows packages to use CPP `#include` on files from dependencies. E.g. if the Cabal package `proj-a` includes a file `header.h` (specified in `extra-source-files` and with appropriate `include-dirs`). Then another package `proj-b`, which depends on `proj-a`, can `#include "header.h"`. This is true between Cabal packages, as well as, between library and executable targets within a Cabal package.

Hazel, currently fails to build packages that exploit this feature. The reason is that header files and include dirs are captured in a `cbits` target, but only the current `haskell_library|binary` target depends on it. The `cbits` target is not forwarded to other Hazel targets.

This PR changes that. If a Hazel target `A` depends on a Hazel target `B`, then `A-cbits` will depend on `B-cbits`. Since `A` depends on `A-cbits`, `A` can now also depend on headers defined in `B-cbits`. Refer to https://github.com/tweag/rules_haskell/issues/531 for more details.

---

The issue was discovered on an internal package. However, to allow others to test this change, I've created a [small demo](https://github.com/aherrmann/demo-cabal-header-forwarding) that exhibits the issue. To test it, follow these steps

- Checkout https://github.com/DACH-NY/hazel/tree/forward-cbits-demo (https://github.com/DACH-NY/hazel/commit/98bfd5a1e48e8a5a10503fd9122d7c74cd24e61a at time of writing).

- Build the demo projects in the Hazel `forward-cbits-demo` directory:

    ```
    $ bazel build @haskell_proj_a//:all
    $ bazel build @haskell_proj_b//:all
    ```

- Revert the `-cbits` dependency forwarding and see the build fail.

    ```
    $ git checkout HEAD^
    $ bazel build @haskell_proj_a//:all
    bazel-out/k8-fastbuild/bin/external/haskell_proj_a/gen-srcs-proj-a_bin/exe/Main.hs:6:2: error:
         fatal error: header.h: No such file or directory
    
          ^
      |
    6 |
      |  ^
    compilation terminated.
    `cc' failed in phase `C pre-processor'. (Exit code: 1)
    $ bazel build @haskell_proj_b//:all
    ...
    bazel-out/k8-fastbuild/bin/external/haskell_proj_b/gen-srcs-proj-b_bin/exe/Main.hs:6:2: error:
         fatal error: header.h: No such file or directory
    
          ^
      |
    6 |
      |  ^
    compilation terminated.
    `cc' failed in phase `C pre-processor'. (Exit code: 1)
    ```
