### PR TITLE
Re-enable conduit build

### DIFF
--- a/test-packages.txt
+++ b/test-packages.txt
@@ -1,6 +1,7 @@
 aeson_92704494
 aeson_extra_2122370161
 cassava_555306702
+conduit_951069182
 entropy__1591567247
 fuzzyset_1745887768
 hsndfile__1202908931

--- a/third_party/haskell/BUILD.conduit
+++ b/third_party/haskell/BUILD.conduit
@@ -4,6 +4,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_library",
 )
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
+load("@ai_formation_hazel//:tools/mangling.bzl", "hazel_workspace")
 
 haskell_library(
   name = "conduit",
@@ -12,22 +13,22 @@ haskell_library(
     "Data/**/*.hs",
     "fusion-macros.h",
   ]),
-  compiler_flags = ["-Iexternal/haskell_conduit"],
+  compiler_flags = ["-Iexternal/" + hazel_workspace("conduit")],
   deps = [
     hazel_library("base"),
     hazel_library("bytestring"),
     hazel_library("exceptions"),
-    hazel_library("lifted_base"),
+    hazel_library("lifted-base"),
     hazel_library("mmorph"),
-    hazel_library("monad_control"),
-    hazel_library("mono_traversable"),
+    hazel_library("monad-control"),
+    hazel_library("mono-traversable"),
     hazel_library("mtl"),
     hazel_library("primitive"),
     hazel_library("resourcet"),
     hazel_library("text"),
     hazel_library("transformers"),
-    hazel_library("transformers_base"),
-    hazel_library("transformers_compat"),
+    hazel_library("transformers-base"),
+    hazel_library("transformers-compat"),
     hazel_library("vector"),
   ],
   version = "1.2.13.1",


### PR DESCRIPTION
Hopefully fixes #70 

I suspect the packages I changed to use hyphens instead of underscores were originally built with hyphenated names. Since the package names are hashed before swapping hyphens and underscores, passing the underscored version to Hazel resulted in the wrong hash being appended to Conduit's dependent package names.

On a somewhat similar note, when passing the `-I` option to direct GHC to C-like header files, one must now append the correct hash to guess the directory Bazel makes for your code.
