### PR TITLE
Remove language-c from test-packages for now

### DIFF
--- a/test-packages.txt
+++ b/test-packages.txt
@@ -6,7 +6,6 @@ fuzzyset_1745887768
 hsndfile__1202908931
 htaglib_1224840979
 http_client__884921168
-language_c__176479442
 lens_3318014
 network_1843485230
 postgresql_libpq_275795853


### PR DESCRIPTION
This built successfully in CI for #68 and promptly broke on master and subsequent runs.

Disabling it temporarily to keep unrelated work moving